### PR TITLE
ci(SAW-7155): move trunk check to Namespace cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: trunk-io/trunk-action@v1
         with:
           cache: false
-          check-mode: all
+          check-mode: ${{ github.event_name == 'pull_request' && 'pull_request' || 'all' }}
 
   build-macos:
     name: Build (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache Trunk and Rust artifacts
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         # yamllint disable-line rule:line-length
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,24 @@ jobs:
 
   trunk:
     name: Trunk Check
-    runs-on: ubuntu-latest
+    # trunk-ignore(actionlint/runner-label): Namespace profile
+    runs-on: namespace-profile-sawmills-runner-large
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Trunk and Rust artifacts
+        # yamllint disable-line rule:line-length
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0
+        with:
+          cache: rust
+          path: |
+            /home/runner/.cache/trunk
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
         with:
+          cache: false
           check-mode: all
 
   build-macos:


### PR DESCRIPTION
## Summary

- Move the Trunk code-quality job to `namespace-profile-sawmills-runner-large`.
- Add Namespace cache volume for Trunk artifacts and Go/Rust caches where applicable.
- Disable `trunk-action` GitHub cache so warm runs avoid the large actions/cache restore.

## Validation

- `git diff --check`
- `yq e '.' <workflow>`
- Local Trunk hooks/checks on the touched workflow where enabled

Linear: SAW-7155

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI (Linear SAW-7155) by moving the Trunk check to `namespace-profile-sawmills-runner-large`, caching Trunk/Rust artifacts with `namespacelabs/nscloud-cache-action` (skipped on fork PRs), and limiting PR checks to changed files. Disables `trunk-io/trunk-action`’s GitHub cache to avoid heavy restores on warm runs.

<sup>Written for commit b7293bc280f73becb501ec3687d9c5db771277c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

