### PR TITLE
codex: Add spend-cap recovery wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -144,6 +150,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -216,7 +228,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,9 +237,12 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "crossterm",
  "dialoguer",
  "dirs",
  "futures",
+ "libc",
+ "portable-pty",
  "reqwest",
  "serde",
  "serde_json",
@@ -266,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,11 +301,15 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
  "rustix",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -292,6 +320,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -356,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +438,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -836,6 +903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,8 +981,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
 ]
 
 [[package]]
@@ -973,6 +1059,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1045,7 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -1085,7 +1192,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1149,7 +1256,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1230,12 +1337,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1357,6 +1473,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1504,37 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1589,7 +1757,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -1817,7 +1985,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2099,6 +2267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,7 +2339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"
@@ -11,9 +11,12 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 comfy-table = "7"
+crossterm = "0.29"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 dirs = "6"
 futures = "0.3"
+libc = "0.2"
+portable-pty = "0.9"
 reqwest = { version = "0.12", default-features = false, features = [
   "blocking",
   "json",

--- a/README.md
+++ b/README.md
@@ -85,12 +85,37 @@ Interactive fuzzy picker:
 codexctl switch
 ```
 
+### Run Codex with spend-cap recovery
+
+Use `codexctl codex` as the Codex launcher when you want account failover:
+
+```bash
+codexctl codex
+codexctl codex -- "start prompt"
+codexctl codex -- -C ~/Code/codexctl -m gpt-5
+codexctl codex resume 019e8489-aa28-7071-ab90-16b81c7cfd1d
+```
+
+The wrapper runs `codex` in a PTY and watches for this spend-cap message:
+
+```text
+You hit your spend cap set by the owner of your workspace. Ask an owner to increase your spend cap to continue.
+```
+
+Codex is launched from the current directory where `codexctl codex` was run. When detected, it
+terminates that Codex process, runs the same account selection as
+`codexctl use`, then resumes with `codex resume <session-id> "Continue the previous request."`.
+For a new session, it discovers the session id from the new Codex session file created under
+`~/.codex/sessions/`. For an existing session, pass `resume <session-id>` so the wrapper can
+recover without discovery.
+
 ### Other commands
 
 ```bash
 codexctl list          # list saved profiles
 codexctl login <alias> # isolated Codex login and save
 codexctl whoami        # show active account
+codexctl codex -- ...  # run Codex with spend-cap recovery
 codexctl remove <alias>
 ```
 

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -136,12 +136,27 @@ fn recovery_args(
     }
 
     if resume_command_index(&options.args).is_some() {
-        let mut args = options.args.clone();
-        append_recovery_prompt(&mut args, &options.recovery_prompt);
-        return Ok(args);
+        return Ok(resume_args_with_recovery_prompt(
+            &options.args,
+            &options.recovery_prompt,
+        ));
     }
 
     bail!("spend cap detected, but no Codex session id was available to resume")
+}
+
+fn resume_args_with_recovery_prompt(args: &[String], recovery_prompt: &str) -> Vec<String> {
+    let mut args = args.to_vec();
+    if recovery_prompt.trim().is_empty() {
+        return args;
+    }
+
+    if let Some(prompt_index) = resume_prompt_index(&args) {
+        args[prompt_index] = recovery_prompt.to_string();
+    } else {
+        args.push(recovery_prompt.to_string());
+    }
+    args
 }
 
 fn resume_args_for_session(
@@ -305,6 +320,67 @@ fn resume_command_index(args: &[String]) -> Option<usize> {
     None
 }
 
+fn resume_prompt_index(args: &[String]) -> Option<usize> {
+    let shape = resume_args_shape(args)?;
+    if shape.has_last {
+        shape.positionals.first().copied()
+    } else {
+        shape.positionals.get(1).copied()
+    }
+}
+
+struct ResumeArgsShape {
+    has_last: bool,
+    positionals: Vec<usize>,
+}
+
+fn resume_args_shape(args: &[String]) -> Option<ResumeArgsShape> {
+    let mut index = resume_command_index(args)? + 1;
+    let mut has_last = false;
+    let mut positionals = Vec::new();
+    let mut after_terminator = false;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if !after_terminator {
+            if arg == "--" {
+                after_terminator = true;
+                index += 1;
+                continue;
+            }
+            if arg == "--last" {
+                has_last = true;
+                index += 1;
+                continue;
+            }
+            if arg.starts_with("--") {
+                if !arg.contains('=') && long_option_takes_value(arg) {
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+                continue;
+            }
+            if arg.starts_with('-') {
+                if short_option_takes_value(arg) {
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+                continue;
+            }
+        }
+
+        positionals.push(index);
+        index += 1;
+    }
+
+    Some(ResumeArgsShape {
+        has_last,
+        positionals,
+    })
+}
+
 fn long_option_takes_value(arg: &str) -> bool {
     matches!(
         arg,
@@ -361,20 +437,14 @@ impl ProfileSwitcher for CodexctlProfileSwitcher {
 struct FilesystemSessionStore {
     sessions_dir: PathBuf,
     seen: HashSet<PathBuf>,
-    started_at: SystemTime,
 }
 
 impl FilesystemSessionStore {
     fn new(paths: &Paths) -> Result<Self> {
-        let started_at = SystemTime::now();
         let codex_home = codex_home_for_child(paths);
         let sessions_dir = codex_home.join("sessions");
         let seen = session_files(&sessions_dir)?;
-        Ok(Self {
-            sessions_dir,
-            seen,
-            started_at,
-        })
+        Ok(Self { sessions_dir, seen })
     }
 }
 
@@ -391,10 +461,7 @@ impl SessionStore for FilesystemSessionStore {
             }
             let modified = std::fs::metadata(&path)
                 .and_then(|metadata| metadata.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
-            if modified < self.started_at {
-                continue;
-            }
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
             let Some(meta) = session_meta_from_file(&path)? else {
                 continue;
             };
@@ -1262,6 +1329,101 @@ mod tests {
 
         assert!(runner.calls[1].args.contains(&SESSION_ID.to_string()));
         assert!(!runner.calls[1].args.contains(&unrelated.to_string()));
+    }
+
+    #[test]
+    fn spend_cap_recovery_replaces_resume_last_prompt() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap { session_id: None },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec![
+                "resume".to_string(),
+                "--last".to_string(),
+                "fix tests".to_string(),
+            ],
+            "Continue the previous request.".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1].args,
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "resume".to_string(),
+                "--last".to_string(),
+                "Continue the previous request.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn spend_cap_recovery_appends_resume_last_prompt_when_missing() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap { session_id: None },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec!["resume".to_string(), "--last".to_string()],
+            "Continue the previous request.".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1].args,
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "resume".to_string(),
+                "--last".to_string(),
+                "Continue the previous request.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn spend_cap_recovery_replaces_named_resume_prompt() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap { session_id: None },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec![
+                "resume".to_string(),
+                "release-lane".to_string(),
+                "fix tests".to_string(),
+            ],
+            "Continue the previous request.".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1].args,
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "resume".to_string(),
+                "release-lane".to_string(),
+                "Continue the previous request.".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -1,0 +1,1526 @@
+use std::collections::HashSet;
+use std::io::{BufRead, IsTerminal, Read, Write};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+#[cfg(not(unix))]
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::terminal;
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+use crate::commands::use_profile;
+use crate::config::{self, Paths};
+use crate::profile;
+
+const SPEND_CAP_MESSAGE: &str = "You hit your spend cap set by the owner of your workspace. Ask an owner to increase your spend cap to continue.";
+const SELF_MANAGED_SPEND_CAP_MESSAGE: &str =
+    "You hit your spend cap set in your workspace. Increase your spend cap to continue.";
+pub const DEFAULT_RECOVERY_PROMPT: &str = "Continue the previous request.";
+
+pub fn run(args: &[String], recovery_prompt: &str) -> Result<i32> {
+    let paths = config::default_paths()?;
+    let mut runner = PtyCodexRunner;
+    let failed_alias = failed_alias_for_child_auth(&paths);
+    let mut switcher = CodexctlProfileSwitcher::new(&paths, failed_alias);
+    let mut sessions = FilesystemSessionStore::new(&paths)?;
+    let cwd = std::env::current_dir().context("failed to get current directory")?;
+    let options = WrapperOptions::new(args.to_vec(), recovery_prompt.to_string(), cwd);
+    run_with(&options, &mut runner, &mut switcher, &mut sessions)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CodexRunOutcome {
+    Exited(i32),
+    SpendCap { session_id: Option<String> },
+}
+
+trait CodexRunner {
+    fn run_codex(&mut self, invocation: &CodexInvocation) -> Result<CodexRunOutcome>;
+}
+
+trait ProfileSwitcher {
+    fn use_profile(&mut self) -> Result<()>;
+}
+
+trait SessionStore {
+    fn discover_latest_session_id(
+        &mut self,
+        invocation: &CodexInvocation,
+    ) -> Result<Option<String>>;
+}
+
+#[derive(Debug, Clone)]
+struct WrapperOptions {
+    args: Vec<String>,
+    recovery_prompt: String,
+    cwd: PathBuf,
+}
+
+impl WrapperOptions {
+    fn new(args: Vec<String>, recovery_prompt: String, cwd: PathBuf) -> Self {
+        Self {
+            args,
+            recovery_prompt,
+            cwd,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexInvocation {
+    args: Vec<String>,
+    cwd: PathBuf,
+}
+
+impl CodexInvocation {
+    fn new(args: Vec<String>, cwd: PathBuf) -> Self {
+        Self { args, cwd }
+    }
+
+    fn from_forwarded_args(args: &[String], cwd: &std::path::Path) -> Self {
+        Self::new(invocation_args_for_cwd(args, cwd), cwd.to_path_buf())
+    }
+}
+
+fn run_with(
+    options: &WrapperOptions,
+    runner: &mut impl CodexRunner,
+    switcher: &mut impl ProfileSwitcher,
+    sessions: &mut impl SessionStore,
+) -> Result<i32> {
+    let initial = CodexInvocation::from_forwarded_args(&options.args, &options.cwd);
+    match runner.run_codex(&initial)? {
+        CodexRunOutcome::Exited(code) => Ok(code),
+        CodexRunOutcome::SpendCap { session_id } => {
+            let recovery_args = recovery_args(options, session_id, sessions)?;
+            let recovery = CodexInvocation::from_forwarded_args(&recovery_args, &options.cwd);
+
+            eprintln!();
+            eprintln!("codexctl: spend cap detected; running `codexctl use`");
+            switcher.use_profile()?;
+
+            eprintln!();
+            eprintln!("codexctl: running `codex {}`", recovery.args.join(" "));
+            match runner.run_codex(&recovery)? {
+                CodexRunOutcome::Exited(code) => Ok(code),
+                CodexRunOutcome::SpendCap { .. } => {
+                    bail!("spend cap detected again after switching profiles")
+                }
+            }
+        }
+    }
+}
+
+fn recovery_args(
+    options: &WrapperOptions,
+    detected_session_id: Option<String>,
+    sessions: &mut impl SessionStore,
+) -> Result<Vec<String>> {
+    let mut session_id = session_id_from_codex_args(&options.args).or(detected_session_id);
+    if session_id.is_none() {
+        let invocation = CodexInvocation::from_forwarded_args(&options.args, &options.cwd);
+        session_id = sessions.discover_latest_session_id(&invocation)?;
+    }
+
+    if let Some(session_id) = session_id {
+        return Ok(resume_args_for_session(
+            preserved_codex_options(&options.args),
+            &session_id,
+            &options.recovery_prompt,
+        ));
+    }
+
+    if resume_command_index(&options.args).is_some() {
+        let mut args = options.args.clone();
+        append_recovery_prompt(&mut args, &options.recovery_prompt);
+        return Ok(args);
+    }
+
+    bail!("spend cap detected, but no Codex session id was available to resume")
+}
+
+fn resume_args_for_session(
+    mut preserved_options: Vec<String>,
+    session_id: &str,
+    recovery_prompt: &str,
+) -> Vec<String> {
+    let mut args = Vec::with_capacity(preserved_options.len() + 3);
+    args.append(&mut preserved_options);
+    args.push("resume".to_string());
+    args.push(session_id.to_string());
+    append_recovery_prompt(&mut args, recovery_prompt);
+    args
+}
+
+fn append_recovery_prompt(args: &mut Vec<String>, recovery_prompt: &str) {
+    if !recovery_prompt.trim().is_empty() {
+        args.push(recovery_prompt.to_string());
+    }
+}
+
+fn invocation_args_for_cwd(args: &[String], cwd: &std::path::Path) -> Vec<String> {
+    if codex_args_set_cwd(args) {
+        return args.to_vec();
+    }
+
+    let mut invocation_args = Vec::with_capacity(args.len() + 2);
+    invocation_args.push("--cd".to_string());
+    invocation_args.push(cwd.display().to_string());
+    invocation_args.extend(args.iter().cloned());
+    invocation_args
+}
+
+fn codex_args_set_cwd(args: &[String]) -> bool {
+    cwd_from_codex_args(args).is_some()
+}
+
+fn preserved_codex_options(args: &[String]) -> Vec<String> {
+    let mut preserved = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            break;
+        }
+        if let Some(name) = arg.strip_prefix("--") {
+            let option_name = name.split_once('=').map_or(name, |(name, _)| name);
+            let long_name = format!("--{option_name}");
+
+            if long_option_takes_value(&long_name) {
+                preserved.push(arg.clone());
+                if !arg.contains('=')
+                    && let Some(value) = args.get(index + 1)
+                {
+                    preserved.push(value.clone());
+                    index += 2;
+                    continue;
+                }
+            } else if long_option_is_preserved_flag(&long_name) {
+                preserved.push(arg.clone());
+            }
+
+            index += 1;
+            continue;
+        }
+
+        if short_option_takes_value(arg) {
+            preserved.push(arg.clone());
+            if let Some(value) = args.get(index + 1) {
+                preserved.push(value.clone());
+                index += 2;
+                continue;
+            }
+        } else if short_option_is_preserved_flag(arg) {
+            preserved.push(arg.clone());
+        }
+
+        index += 1;
+    }
+
+    preserved
+}
+
+fn long_option_is_preserved_flag(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--strict-config"
+            | "--oss"
+            | "--dangerously-bypass-approvals-and-sandbox"
+            | "--dangerously-bypass-hook-trust"
+            | "--search"
+            | "--no-alt-screen"
+            | "--full-auto"
+            | "--skip-git-repo-check"
+    )
+}
+
+fn short_option_is_preserved_flag(_arg: &str) -> bool {
+    false
+}
+
+fn session_id_from_codex_args(args: &[String]) -> Option<String> {
+    let mut index = resume_command_index(args)? + 1;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            index += 1;
+            continue;
+        }
+        if arg.starts_with("--") {
+            if !arg.contains('=') && long_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if arg.starts_with('-') {
+            if short_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        return is_session_id(arg).then(|| arg.clone());
+    }
+
+    None
+}
+
+fn resume_command_index(args: &[String]) -> Option<usize> {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            return None;
+        }
+        if arg.starts_with("--") {
+            if !arg.contains('=') && long_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if arg.starts_with('-') {
+            if short_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        return (arg == "resume").then_some(index);
+    }
+
+    None
+}
+
+fn long_option_takes_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--config"
+            | "--remote"
+            | "--remote-auth-token-env"
+            | "--image"
+            | "--model"
+            | "--local-provider"
+            | "--profile"
+            | "--sandbox"
+            | "--cd"
+            | "--add-dir"
+            | "--ask-for-approval"
+            | "--enable"
+            | "--disable"
+    )
+}
+
+fn short_option_takes_value(arg: &str) -> bool {
+    matches!(arg, "-c" | "-i" | "-m" | "-p" | "-s" | "-C" | "-a")
+}
+
+fn is_session_id(candidate: &str) -> bool {
+    let bytes = candidate.as_bytes();
+    bytes.len() == 36
+        && [8, 13, 18, 23].iter().all(|i| bytes[*i] == b'-')
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(i, b)| [8, 13, 18, 23].contains(&i) || b.is_ascii_hexdigit())
+}
+
+struct CodexctlProfileSwitcher {
+    auth_json: PathBuf,
+    excluded_alias: Option<String>,
+}
+
+impl CodexctlProfileSwitcher {
+    fn new(paths: &Paths, excluded_alias: Option<String>) -> Self {
+        Self {
+            auth_json: codex_auth_json_for_child(paths),
+            excluded_alias,
+        }
+    }
+}
+
+impl ProfileSwitcher for CodexctlProfileSwitcher {
+    fn use_profile(&mut self) -> Result<()> {
+        use_profile::run_recovery_to_auth_json(&self.auth_json, self.excluded_alias.as_deref())
+    }
+}
+
+struct FilesystemSessionStore {
+    sessions_dir: PathBuf,
+    seen: HashSet<PathBuf>,
+    started_at: SystemTime,
+}
+
+impl FilesystemSessionStore {
+    fn new(paths: &Paths) -> Result<Self> {
+        let started_at = SystemTime::now();
+        let codex_home = codex_home_for_child(paths);
+        let sessions_dir = codex_home.join("sessions");
+        let seen = session_files(&sessions_dir)?;
+        Ok(Self {
+            sessions_dir,
+            seen,
+            started_at,
+        })
+    }
+}
+
+impl SessionStore for FilesystemSessionStore {
+    fn discover_latest_session_id(
+        &mut self,
+        invocation: &CodexInvocation,
+    ) -> Result<Option<String>> {
+        let expected_cwd = invocation_session_cwd(invocation);
+        let mut newest: Option<(SystemTime, String)> = None;
+        for path in session_files(&self.sessions_dir)? {
+            if self.seen.contains(&path) {
+                continue;
+            }
+            let modified = std::fs::metadata(&path)
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            if modified < self.started_at {
+                continue;
+            }
+            let Some(meta) = session_meta_from_file(&path)? else {
+                continue;
+            };
+            if meta.is_subagent {
+                continue;
+            }
+            if !session_cwd_matches(meta.cwd.as_deref(), &expected_cwd) {
+                continue;
+            };
+            if newest
+                .as_ref()
+                .is_none_or(|(newest_modified, _)| modified > *newest_modified)
+            {
+                newest = Some((modified, meta.id));
+            }
+        }
+
+        Ok(newest.map(|(_, session_id)| session_id))
+    }
+}
+
+fn codex_auth_json_for_child(paths: &Paths) -> PathBuf {
+    codex_home_for_child(paths).join("auth.json")
+}
+
+fn codex_home_for_child(paths: &Paths) -> PathBuf {
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| paths.home.join(".codex"))
+}
+
+fn failed_alias_for_child_auth(paths: &Paths) -> Option<String> {
+    let auth_json = codex_auth_json_for_child(paths);
+    profile::alias_for_auth_json_from(paths, &auth_json)
+        .ok()
+        .flatten()
+        .or_else(|| {
+            if auth_json == paths.codex_auth_json() {
+                profile::get_active_from(paths).ok().flatten()
+            } else {
+                None
+            }
+        })
+}
+
+fn invocation_session_cwd(invocation: &CodexInvocation) -> PathBuf {
+    let cwd = cwd_from_codex_args(&invocation.args).unwrap_or_else(|| invocation.cwd.clone());
+    let cwd = if cwd.is_absolute() {
+        cwd
+    } else {
+        invocation.cwd.join(cwd)
+    };
+    normalize_cwd(cwd)
+}
+
+fn cwd_from_codex_args(args: &[String]) -> Option<PathBuf> {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            break;
+        }
+        if let Some(value) = arg.strip_prefix("--cd=") {
+            return Some(PathBuf::from(value));
+        }
+        if arg == "--cd" || arg == "-C" {
+            return args.get(index + 1).map(PathBuf::from);
+        }
+        if arg.starts_with("--") {
+            if !arg.contains('=') && long_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if arg.starts_with('-') {
+            if short_option_takes_value(arg) {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn normalize_cwd(cwd: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&cwd).unwrap_or(cwd)
+}
+
+fn session_cwd_matches(session_cwd: Option<&Path>, expected_cwd: &Path) -> bool {
+    session_cwd
+        .map(|cwd| normalize_cwd(cwd.to_path_buf()) == expected_cwd)
+        .unwrap_or(false)
+}
+
+struct SessionMeta {
+    id: String,
+    cwd: Option<PathBuf>,
+    is_subagent: bool,
+}
+
+fn session_files(root: &std::path::Path) -> Result<HashSet<PathBuf>> {
+    let mut files = HashSet::new();
+    if !root.exists() {
+        return Ok(files);
+    }
+
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in
+            std::fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+            {
+                files.insert(path);
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn session_meta_from_file(path: &std::path::Path) -> Result<Option<SessionMeta>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open session file {}", path.display()))?;
+    let mut lines = std::io::BufReader::new(file).lines();
+    let Some(line) = lines.next().transpose()? else {
+        return Ok(None);
+    };
+    let value: serde_json::Value = serde_json::from_str(&line)
+        .with_context(|| format!("failed to parse session file {}", path.display()))?;
+    let Some(id) = value
+        .get("payload")
+        .and_then(|payload| payload.get("id"))
+        .and_then(|id| id.as_str())
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+    let cwd = value
+        .get("payload")
+        .and_then(|payload| payload.get("cwd"))
+        .and_then(|cwd| cwd.as_str())
+        .map(PathBuf::from);
+    let is_subagent = value.get("payload").is_some_and(|payload| {
+        payload
+            .get("thread_source")
+            .and_then(|thread_source| thread_source.as_str())
+            .is_some_and(|thread_source| thread_source == "subagent")
+            || payload
+                .get("source")
+                .and_then(|source| source.get("subagent"))
+                .is_some()
+    });
+
+    Ok(Some(SessionMeta {
+        id,
+        cwd,
+        is_subagent,
+    }))
+}
+
+struct PtyCodexRunner;
+
+impl CodexRunner for PtyCodexRunner {
+    fn run_codex(&mut self, invocation: &CodexInvocation) -> Result<CodexRunOutcome> {
+        run_codex_in_pty(invocation)
+    }
+}
+
+fn run_codex_in_pty(invocation: &CodexInvocation) -> Result<CodexRunOutcome> {
+    let interactive = std::io::stdin().is_terminal();
+    let _raw_mode = RawModeGuard::enable(interactive)?;
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(current_pty_size())
+        .context("failed to open pty")?;
+    let mut command = CommandBuilder::new("codex");
+    for arg in &invocation.args {
+        command.arg(arg);
+    }
+    command.cwd(invocation.cwd.as_os_str());
+    if std::env::var_os("TERM").is_none() {
+        command.env("TERM", "xterm-256color");
+    }
+
+    let mut child = pair
+        .slave
+        .spawn_command(command)
+        .context("failed to run `codex`")?;
+    drop(pair.slave);
+
+    let stop_input = Arc::new(AtomicBool::new(false));
+    let spend_cap = Arc::new(AtomicBool::new(false));
+    let session_id = Arc::new(Mutex::new(None));
+
+    let mut master = Some(pair.master);
+    let reader = master.as_ref().unwrap().try_clone_reader()?;
+    let writer = master.as_ref().unwrap().take_writer()?;
+    let mut killer = child.clone_killer();
+
+    let reader_thread = spawn_output_thread(
+        reader,
+        Arc::clone(&spend_cap),
+        Arc::clone(&session_id),
+        Arc::clone(&stop_input),
+        move || {
+            let _ = killer.kill();
+        },
+    );
+    let input_thread = if interactive {
+        Some(InputThread {
+            handle: spawn_input_thread(writer, Arc::clone(&stop_input), master.take().unwrap()),
+            join_on_stop: true,
+        })
+    } else {
+        Some(InputThread {
+            handle: spawn_pipe_input_thread(writer),
+            join_on_stop: false,
+        })
+    };
+
+    let status = child.wait().context("failed to wait for codex")?;
+    stop_input.store(true, Ordering::SeqCst);
+    if let Some(input_thread) = input_thread
+        && input_thread.join_on_stop
+    {
+        let _ = input_thread.handle.join();
+    }
+    let _ = reader_thread.join();
+
+    if spend_cap.load(Ordering::SeqCst) {
+        let session_id = session_id.lock().ok().and_then(|guard| guard.clone());
+        Ok(CodexRunOutcome::SpendCap { session_id })
+    } else {
+        Ok(CodexRunOutcome::Exited(status.exit_code() as i32))
+    }
+}
+
+struct InputThread {
+    handle: std::thread::JoinHandle<()>,
+    join_on_stop: bool,
+}
+
+fn current_pty_size() -> PtySize {
+    let (cols, rows) = terminal::size().unwrap_or((80, 24));
+    PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    }
+}
+
+struct RawModeGuard {
+    enabled: bool,
+}
+
+impl RawModeGuard {
+    fn enable(interactive: bool) -> Result<Self> {
+        if interactive {
+            terminal::enable_raw_mode().context("failed to enable terminal raw mode")?;
+        }
+        Ok(Self {
+            enabled: interactive,
+        })
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if self.enabled {
+            let _ = terminal::disable_raw_mode();
+        }
+    }
+}
+
+fn spawn_output_thread(
+    mut reader: Box<dyn Read + Send>,
+    spend_cap: Arc<AtomicBool>,
+    session_id: Arc<Mutex<Option<String>>>,
+    stop_input: Arc<AtomicBool>,
+    mut kill_child: impl FnMut() + Send + 'static,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut stdout = std::io::stdout();
+        let mut buffer = [0; 8192];
+        let mut recent = String::new();
+
+        loop {
+            let bytes_read = match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            let chunk = &buffer[..bytes_read];
+            let _ = stdout.write_all(chunk);
+            let _ = stdout.flush();
+
+            recent.push_str(&String::from_utf8_lossy(chunk));
+            if recent.len() > 16_384 {
+                let keep_from = recent.len().saturating_sub(8_192);
+                let drain_to = recent
+                    .char_indices()
+                    .map(|(index, _)| index)
+                    .find(|index| *index >= keep_from)
+                    .unwrap_or(0);
+                recent.drain(..drain_to);
+            }
+
+            if spend_cap_seen(&recent) {
+                spend_cap.store(true, Ordering::SeqCst);
+                if let Some(id) = find_resume_hint_session_id(&recent)
+                    && let Ok(mut guard) = session_id.lock()
+                {
+                    *guard = Some(id);
+                }
+                stop_input.store(true, Ordering::SeqCst);
+                kill_child();
+                break;
+            }
+        }
+    })
+}
+
+fn spawn_pipe_input_thread(mut writer: Box<dyn Write + Send>) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        let mut buffer = [0; 8192];
+        loop {
+            match stdin.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if writer.write_all(&buffer[..n]).is_err() {
+                        break;
+                    }
+                    let _ = writer.flush();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+#[cfg(unix)]
+fn spawn_input_thread(
+    mut writer: Box<dyn Write + Send>,
+    stop_input: Arc<AtomicBool>,
+    master: Box<dyn portable_pty::MasterPty + Send>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let stdin_fd = stdin.as_raw_fd();
+        let mut stdin = stdin.lock();
+        let mut buffer = [0; 8192];
+        let mut last_size = terminal::size().ok();
+
+        while !stop_input.load(Ordering::SeqCst) {
+            resize_child_if_needed(master.as_ref(), &mut last_size);
+
+            let mut pollfd = libc::pollfd {
+                fd: stdin_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let result = unsafe { libc::poll(&mut pollfd, 1, 50) };
+            if result < 0 {
+                if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break;
+            }
+            if result == 0 {
+                continue;
+            }
+            if pollfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+                break;
+            }
+            if pollfd.revents & libc::POLLIN == 0 {
+                continue;
+            }
+
+            match stdin.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if writer.write_all(&buffer[..n]).is_err() {
+                        break;
+                    }
+                    let _ = writer.flush();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn spawn_input_thread(
+    mut writer: Box<dyn Write + Send>,
+    stop_input: Arc<AtomicBool>,
+    master: Box<dyn portable_pty::MasterPty + Send>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        while !stop_input.load(Ordering::SeqCst) {
+            match event::poll(std::time::Duration::from_millis(50)) {
+                Ok(true) => match event::read() {
+                    Ok(Event::Key(key)) => {
+                        if let Some(bytes) = key_event_bytes(key) {
+                            if writer.write_all(&bytes).is_err() {
+                                break;
+                            }
+                            let _ = writer.flush();
+                        }
+                    }
+                    Ok(Event::Paste(text)) => {
+                        if writer.write_all(&paste_event_bytes(&text)).is_err() {
+                            break;
+                        }
+                        let _ = writer.flush();
+                    }
+                    Ok(Event::Resize(cols, rows)) => {
+                        let _ = master.resize(PtySize {
+                            rows,
+                            cols,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(_) => break,
+                },
+                Ok(false) => {}
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn paste_event_bytes(text: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(text.len() + 12);
+    bytes.extend_from_slice(b"\x1b[200~");
+    bytes.extend_from_slice(text.as_bytes());
+    bytes.extend_from_slice(b"\x1b[201~");
+    bytes
+}
+
+#[cfg(not(unix))]
+fn key_event_bytes(key: KeyEvent) -> Option<Vec<u8>> {
+    if key.kind == KeyEventKind::Release {
+        return None;
+    }
+
+    let mut bytes = Vec::new();
+    if key.modifiers.contains(KeyModifiers::ALT) {
+        bytes.push(0x1b);
+    }
+
+    match key.code {
+        KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            bytes.push(control_byte(c)?);
+        }
+        KeyCode::Char(c) => {
+            let mut encoded = [0; 4];
+            bytes.extend_from_slice(c.encode_utf8(&mut encoded).as_bytes());
+        }
+        KeyCode::Enter => bytes.push(b'\r'),
+        KeyCode::Backspace => bytes.push(0x7f),
+        KeyCode::Esc => bytes.push(0x1b),
+        KeyCode::Tab => bytes.push(b'\t'),
+        KeyCode::BackTab => bytes.extend_from_slice(b"\x1b[Z"),
+        KeyCode::Left => bytes.extend_from_slice(b"\x1b[D"),
+        KeyCode::Right => bytes.extend_from_slice(b"\x1b[C"),
+        KeyCode::Up => bytes.extend_from_slice(b"\x1b[A"),
+        KeyCode::Down => bytes.extend_from_slice(b"\x1b[B"),
+        KeyCode::Home => bytes.extend_from_slice(b"\x1b[H"),
+        KeyCode::End => bytes.extend_from_slice(b"\x1b[F"),
+        KeyCode::PageUp => bytes.extend_from_slice(b"\x1b[5~"),
+        KeyCode::PageDown => bytes.extend_from_slice(b"\x1b[6~"),
+        KeyCode::Delete => bytes.extend_from_slice(b"\x1b[3~"),
+        KeyCode::Insert => bytes.extend_from_slice(b"\x1b[2~"),
+        KeyCode::F(n) => bytes.extend_from_slice(function_key_bytes(n)?),
+        _ => return None,
+    }
+
+    Some(bytes)
+}
+
+#[cfg(not(unix))]
+fn control_byte(c: char) -> Option<u8> {
+    let lower = c.to_ascii_lowercase();
+    if lower.is_ascii_alphabetic() {
+        Some((lower as u8) - b'a' + 1)
+    } else {
+        match c {
+            '[' => Some(0x1b),
+            '\\' => Some(0x1c),
+            ']' => Some(0x1d),
+            '^' => Some(0x1e),
+            '_' => Some(0x1f),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn function_key_bytes(n: u8) -> Option<&'static [u8]> {
+    match n {
+        1 => Some(b"\x1bOP"),
+        2 => Some(b"\x1bOQ"),
+        3 => Some(b"\x1bOR"),
+        4 => Some(b"\x1bOS"),
+        5 => Some(b"\x1b[15~"),
+        6 => Some(b"\x1b[17~"),
+        7 => Some(b"\x1b[18~"),
+        8 => Some(b"\x1b[19~"),
+        9 => Some(b"\x1b[20~"),
+        10 => Some(b"\x1b[21~"),
+        11 => Some(b"\x1b[23~"),
+        12 => Some(b"\x1b[24~"),
+        _ => None,
+    }
+}
+
+fn resize_child_if_needed(
+    master: &(dyn portable_pty::MasterPty + Send),
+    last_size: &mut Option<(u16, u16)>,
+) {
+    let Ok((cols, rows)) = terminal::size() else {
+        return;
+    };
+    if last_size.is_some_and(|size| size == (cols, rows)) {
+        return;
+    }
+    *last_size = Some((cols, rows));
+    let _ = master.resize(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    });
+}
+
+fn spend_cap_seen(output: &str) -> bool {
+    output.lines().any(|line| {
+        line.contains("\u{25a0} ")
+            && (line.contains(SPEND_CAP_MESSAGE) || line.contains(SELF_MANAGED_SPEND_CAP_MESSAGE))
+    })
+}
+
+fn find_resume_hint_session_id(output: &str) -> Option<String> {
+    output
+        .lines()
+        .rev()
+        .filter_map(|line| {
+            line.find("codex resume")
+                .map(|index| &line[index + "codex resume".len()..])
+        })
+        .flat_map(|line| line.split(|c: char| !(c.is_ascii_hexdigit() || c == '-')))
+        .find(|token| is_session_id(token))
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION_ID: &str = "019e8489-aa28-7071-ab90-16b81c7cfd1d";
+    const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+
+    #[test]
+    fn session_id_from_resume_args_reads_explicit_session() {
+        let args = vec!["resume".to_string(), SESSION_ID.to_string()];
+
+        assert_eq!(
+            session_id_from_codex_args(&args).as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn session_id_from_resume_args_skips_resume_flags() {
+        let args = vec![
+            "resume".to_string(),
+            "--all".to_string(),
+            SESSION_ID.to_string(),
+        ];
+
+        assert_eq!(
+            session_id_from_codex_args(&args).as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn session_id_from_resume_args_allows_global_codex_flags() {
+        let args = vec![
+            "-C".to_string(),
+            "/Users/amirjakoby/Code/codexctl".to_string(),
+            "resume".to_string(),
+            SESSION_ID.to_string(),
+        ];
+
+        assert_eq!(
+            session_id_from_codex_args(&args).as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn invocation_args_add_current_cwd_when_not_supplied() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+
+        assert_eq!(
+            invocation_args_for_cwd(&["resume".to_string(), SESSION_ID.to_string()], &cwd),
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "resume".to_string(),
+                SESSION_ID.to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn invocation_args_preserve_explicit_cwd() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+
+        assert_eq!(
+            invocation_args_for_cwd(
+                &[
+                    "--cd".to_string(),
+                    "/tmp/other".to_string(),
+                    "resume".to_string(),
+                    SESSION_ID.to_string(),
+                ],
+                &cwd,
+            ),
+            vec![
+                "--cd".to_string(),
+                "/tmp/other".to_string(),
+                "resume".to_string(),
+                SESSION_ID.to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn invocation_args_ignore_cwd_after_codex_terminator() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+
+        assert_eq!(
+            invocation_args_for_cwd(
+                &[
+                    "--".to_string(),
+                    "--cd".to_string(),
+                    "/tmp/prompt-text".to_string(),
+                    "explain".to_string(),
+                ],
+                &cwd,
+            ),
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "--".to_string(),
+                "--cd".to_string(),
+                "/tmp/prompt-text".to_string(),
+                "explain".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserved_codex_options_stop_at_codex_terminator() {
+        assert_eq!(
+            preserved_codex_options(&[
+                "--".to_string(),
+                "--cd".to_string(),
+                "/tmp/prompt-text".to_string(),
+            ]),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn resume_command_index_ignores_prompt_after_codex_terminator() {
+        assert_eq!(
+            resume_command_index(&[
+                "--".to_string(),
+                "resume".to_string(),
+                SESSION_ID.to_string()
+            ]),
+            None
+        );
+    }
+
+    #[test]
+    fn alias_for_auth_json_matches_custom_child_auth_by_subject() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        paths.ensure_dirs().unwrap();
+        let seat_a_old = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old");
+        let seat_a_live = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.live");
+        let seat_b = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.sig");
+        write_profile_auth(&paths, "failed@test", &seat_a_old);
+        write_profile_auth(&paths, "next@test", &seat_b);
+        let custom_auth = tmp.path().join("custom-codex-home").join("auth.json");
+        std::fs::create_dir_all(custom_auth.parent().unwrap()).unwrap();
+        std::fs::write(
+            &custom_auth,
+            format!(r#"{{"access_token":"{seat_a_live}"}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(
+            profile::alias_for_auth_json_from(&paths, &custom_auth)
+                .unwrap()
+                .as_deref(),
+            Some("failed@test")
+        );
+    }
+
+    #[test]
+    fn resume_hint_session_id_ignores_unrelated_screen_uuid() {
+        let output = format!("run id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n{SPEND_CAP_MESSAGE}");
+
+        assert_eq!(find_resume_hint_session_id(&output), None);
+    }
+
+    #[test]
+    fn resume_hint_session_id_reads_codex_resume_hint() {
+        let output = format!("To continue, run codex resume {SESSION_ID}\n{SPEND_CAP_MESSAGE}");
+
+        assert_eq!(
+            find_resume_hint_session_id(&output).as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn spend_cap_seen_requires_codex_error_marker() {
+        let output = format!("assistant quoted: {SPEND_CAP_MESSAGE}");
+
+        assert!(!spend_cap_seen(&output));
+        assert!(spend_cap_seen(&format!("\u{25a0} {SPEND_CAP_MESSAGE}")));
+        assert!(spend_cap_seen(&format!(
+            "\u{25a0} {SELF_MANAGED_SPEND_CAP_MESSAGE}"
+        )));
+    }
+
+    #[test]
+    fn spend_cap_recovery_switches_profile_and_resumes_session() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(SESSION_ID.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec!["resume".to_string(), SESSION_ID.to_string()],
+            "resume".to_string(),
+            cwd.clone(),
+        );
+
+        let exit = run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(exit, 0);
+        assert_eq!(switcher.use_calls, 1);
+        assert_eq!(
+            runner.calls,
+            vec![
+                CodexInvocation::new(
+                    vec![
+                        "--cd".to_string(),
+                        cwd.display().to_string(),
+                        "resume".to_string(),
+                        SESSION_ID.to_string(),
+                    ],
+                    cwd.clone()
+                ),
+                CodexInvocation::new(
+                    vec![
+                        "--cd".to_string(),
+                        cwd.display().to_string(),
+                        "resume".to_string(),
+                        SESSION_ID.to_string(),
+                        "resume".to_string()
+                    ],
+                    cwd,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn spend_cap_recovery_discovers_session_for_new_run() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap { session_id: None },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore {
+            discovered: Some(SESSION_ID.to_string()),
+        };
+        let options = WrapperOptions::new(
+            vec!["finish this".to_string()],
+            "resume".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1],
+            CodexInvocation::new(
+                vec![
+                    "--cd".to_string(),
+                    cwd.display().to_string(),
+                    "resume".to_string(),
+                    SESSION_ID.to_string(),
+                    "resume".to_string()
+                ],
+                cwd,
+            )
+        );
+    }
+
+    #[test]
+    fn spend_cap_recovery_prefers_explicit_resume_id_over_detected_uuid() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let unrelated = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(unrelated.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec!["resume".to_string(), SESSION_ID.to_string()],
+            "Continue the previous request.".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert!(runner.calls[1].args.contains(&SESSION_ID.to_string()));
+        assert!(!runner.calls[1].args.contains(&unrelated.to_string()));
+    }
+
+    #[test]
+    fn session_discovery_ignores_new_files_for_other_cwds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        let mut store = FilesystemSessionStore::new(&paths).unwrap();
+        let sessions = paths
+            .home
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("06")
+            .join("04");
+        std::fs::create_dir_all(&sessions).unwrap();
+        write_session_file(
+            &sessions.join("rollout-other.jsonl"),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "/tmp/other",
+        );
+        write_session_file(
+            &sessions.join("rollout-current.jsonl"),
+            SESSION_ID,
+            "/Users/amirjakoby/Code/codexctl",
+        );
+        let invocation = CodexInvocation::new(
+            vec![
+                "--cd".to_string(),
+                "/Users/amirjakoby/Code/codexctl".to_string(),
+            ],
+            PathBuf::from("/Users/amirjakoby/Code/codexctl"),
+        );
+
+        assert_eq!(
+            store
+                .discover_latest_session_id(&invocation)
+                .unwrap()
+                .as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn session_discovery_ignores_new_subagent_files_for_same_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        let mut store = FilesystemSessionStore::new(&paths).unwrap();
+        let sessions = paths
+            .home
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("06")
+            .join("04");
+        std::fs::create_dir_all(&sessions).unwrap();
+        write_session_file(
+            &sessions.join("rollout-current.jsonl"),
+            SESSION_ID,
+            "/Users/amirjakoby/Code/codexctl",
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        write_subagent_session_file(
+            &sessions.join("rollout-subagent.jsonl"),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "/Users/amirjakoby/Code/codexctl",
+        );
+        let invocation = CodexInvocation::new(
+            vec![
+                "--cd".to_string(),
+                "/Users/amirjakoby/Code/codexctl".to_string(),
+            ],
+            PathBuf::from("/Users/amirjakoby/Code/codexctl"),
+        );
+
+        assert_eq!(
+            store
+                .discover_latest_session_id(&invocation)
+                .unwrap()
+                .as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    fn write_session_file(path: &std::path::Path, session_id: &str, cwd: &str) {
+        let line = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "cwd": cwd,
+            }
+        });
+        std::fs::write(path, format!("{line}\n")).unwrap();
+    }
+
+    fn write_subagent_session_file(path: &std::path::Path, session_id: &str, cwd: &str) {
+        let line = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "cwd": cwd,
+                "thread_source": "subagent",
+                "source": {
+                    "subagent": {
+                        "thread_spawn": {
+                            "parent_thread_id": SESSION_ID
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(path, format!("{line}\n")).unwrap();
+    }
+
+    fn write_profile_auth(paths: &Paths, alias: &str, access_token: &str) {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{access_token}"}}"#),
+        )
+        .unwrap();
+        let meta = profile::Meta {
+            alias: alias.to_string(),
+            email: None,
+            plan: None,
+            saved_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        std::fs::write(
+            dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn spend_cap_recovery_preserves_explicit_cwd_and_model() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let explicit_cwd = "/tmp/other-repo".to_string();
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(SESSION_ID.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec![
+                "--cd".to_string(),
+                explicit_cwd.clone(),
+                "-m".to_string(),
+                "gpt-5".to_string(),
+                "finish this".to_string(),
+            ],
+            "Continue the previous request.".to_string(),
+            cwd,
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1].args,
+            vec![
+                "--cd".to_string(),
+                explicit_cwd,
+                "-m".to_string(),
+                "gpt-5".to_string(),
+                "resume".to_string(),
+                SESSION_ID.to_string(),
+                "Continue the previous request.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn spend_cap_recovery_preserves_resume_relevant_codex_flags() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(SESSION_ID.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let options = WrapperOptions::new(
+            vec![
+                "--full-auto".to_string(),
+                "--skip-git-repo-check".to_string(),
+                "--local-provider".to_string(),
+                "ollama".to_string(),
+                "finish this".to_string(),
+            ],
+            "Continue the previous request.".to_string(),
+            cwd.clone(),
+        );
+
+        run_with(&options, &mut runner, &mut switcher, &mut sessions).unwrap();
+
+        assert_eq!(
+            runner.calls[1].args,
+            vec![
+                "--cd".to_string(),
+                cwd.display().to_string(),
+                "--full-auto".to_string(),
+                "--skip-git-repo-check".to_string(),
+                "--local-provider".to_string(),
+                "ollama".to_string(),
+                "resume".to_string(),
+                SESSION_ID.to_string(),
+                "Continue the previous request.".to_string(),
+            ]
+        );
+    }
+
+    #[derive(Default)]
+    struct FakeProfileSwitcher {
+        use_calls: usize,
+    }
+
+    impl ProfileSwitcher for FakeProfileSwitcher {
+        fn use_profile(&mut self) -> anyhow::Result<()> {
+            self.use_calls += 1;
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSessionStore {
+        discovered: Option<String>,
+    }
+
+    impl SessionStore for FakeSessionStore {
+        fn discover_latest_session_id(
+            &mut self,
+            _invocation: &CodexInvocation,
+        ) -> anyhow::Result<Option<String>> {
+            Ok(self.discovered.clone())
+        }
+    }
+
+    struct FakeCodexRunner {
+        calls: Vec<CodexInvocation>,
+        outcomes: Vec<CodexRunOutcome>,
+    }
+
+    impl FakeCodexRunner {
+        fn new(outcomes: Vec<CodexRunOutcome>) -> Self {
+            Self {
+                calls: Vec::new(),
+                outcomes,
+            }
+        }
+    }
+
+    impl CodexRunner for FakeCodexRunner {
+        fn run_codex(&mut self, invocation: &CodexInvocation) -> anyhow::Result<CodexRunOutcome> {
+            self.calls.push(invocation.clone());
+            Ok(self.outcomes.remove(0))
+        }
+    }
+}

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -462,8 +462,16 @@ impl SessionStore for FilesystemSessionStore {
             let modified = std::fs::metadata(&path)
                 .and_then(|metadata| metadata.modified())
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-            let Some(meta) = session_meta_from_file(&path)? else {
-                continue;
+            let meta = match session_meta_from_file(&path) {
+                Ok(Some(meta)) => meta,
+                Ok(None) => continue,
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to inspect codex session file {}: {e:#}",
+                        path.display()
+                    );
+                    continue;
+                }
             };
             if meta.is_subagent {
                 continue;
@@ -691,8 +699,8 @@ fn run_codex_in_pty(invocation: &CodexInvocation) -> Result<CodexRunOutcome> {
         })
     } else {
         Some(InputThread {
-            handle: spawn_pipe_input_thread(writer),
-            join_on_stop: false,
+            handle: spawn_pipe_input_thread(writer, Arc::clone(&stop_input)),
+            join_on_stop: pipe_input_thread_is_stop_aware(),
         })
     };
 
@@ -799,7 +807,68 @@ fn spawn_output_thread(
     })
 }
 
-fn spawn_pipe_input_thread(mut writer: Box<dyn Write + Send>) -> std::thread::JoinHandle<()> {
+#[cfg(unix)]
+fn pipe_input_thread_is_stop_aware() -> bool {
+    true
+}
+
+#[cfg(not(unix))]
+fn pipe_input_thread_is_stop_aware() -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn spawn_pipe_input_thread(
+    mut writer: Box<dyn Write + Send>,
+    stop_input: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        let stdin_fd = stdin.as_raw_fd();
+        let mut buffer = [0; 8192];
+        while !stop_input.load(Ordering::SeqCst) {
+            let mut pollfd = libc::pollfd {
+                fd: stdin_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let result = unsafe { libc::poll(&mut pollfd, 1, 50) };
+            if result < 0 {
+                if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break;
+            }
+            if result == 0 {
+                continue;
+            }
+            if pollfd.revents & libc::POLLIN == 0 {
+                if pollfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+                    break;
+                }
+                continue;
+            }
+
+            match stdin.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if writer.write_all(&buffer[..n]).is_err() {
+                        break;
+                    }
+                    let _ = writer.flush();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn spawn_pipe_input_thread(
+    mut writer: Box<dyn Write + Send>,
+    _stop_input: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut stdin = std::io::stdin();
         let mut buffer = [0; 8192];
@@ -1488,6 +1557,42 @@ mod tests {
         write_subagent_session_file(
             &sessions.join("rollout-subagent.jsonl"),
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "/Users/amirjakoby/Code/codexctl",
+        );
+        let invocation = CodexInvocation::new(
+            vec![
+                "--cd".to_string(),
+                "/Users/amirjakoby/Code/codexctl".to_string(),
+            ],
+            PathBuf::from("/Users/amirjakoby/Code/codexctl"),
+        );
+
+        assert_eq!(
+            store
+                .discover_latest_session_id(&invocation)
+                .unwrap()
+                .as_deref(),
+            Some(SESSION_ID)
+        );
+    }
+
+    #[test]
+    fn session_discovery_skips_invalid_new_session_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        let mut store = FilesystemSessionStore::new(&paths).unwrap();
+        let sessions = paths
+            .home
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("06")
+            .join("04");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::write(sessions.join("rollout-bad.jsonl"), "{not-json\n").unwrap();
+        write_session_file(
+            &sessions.join("rollout-current.jsonl"),
+            SESSION_ID,
             "/Users/amirjakoby/Code/codexctl",
         );
         let invocation = CodexInvocation::new(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod alias;
+pub mod codex;
 pub mod completions;
 pub mod list;
 pub mod login;

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -1,21 +1,54 @@
+use std::path::Path;
+
 use anyhow::{Result, bail};
 
 use crate::api;
 use crate::commands::alias;
 use crate::commands::status;
+use crate::config;
 use crate::profile;
 
 pub fn run(alias: Option<&str>) -> Result<()> {
+    run_to_auth_json(alias, &config::codex_auth_json()?)
+}
+
+pub fn run_to_auth_json(alias: Option<&str>, auth_json: &Path) -> Result<()> {
+    run_to_auth_json_excluding(alias, auth_json, None)
+}
+
+pub fn run_recovery_to_auth_json(auth_json: &Path, excluded_alias: Option<&str>) -> Result<()> {
+    run_to_auth_json_with_mode(
+        None,
+        auth_json,
+        excluded_alias,
+        AutoSelectMode::SpendCapRecovery,
+    )
+}
+
+pub fn run_to_auth_json_excluding(
+    alias: Option<&str>,
+    auth_json: &Path,
+    excluded_alias: Option<&str>,
+) -> Result<()> {
+    run_to_auth_json_with_mode(alias, auth_json, excluded_alias, AutoSelectMode::RateLimit)
+}
+
+fn run_to_auth_json_with_mode(
+    alias: Option<&str>,
+    auth_json: &Path,
+    excluded_alias: Option<&str>,
+    mode: AutoSelectMode,
+) -> Result<()> {
     match alias::optional(alias) {
         Some(a) => {
-            let email = profile::switch_to(a)?;
+            let email = profile::switch_to_auth_json(a, auth_json)?;
             println!("switched to {} ({})", a, email);
             println!();
             status::run_focused(a)?;
         }
         None => {
-            let best = find_most_available()?;
-            let email = profile::switch_to(&best)?;
+            let best = find_most_available_excluding(excluded_alias, mode)?;
+            let email = profile::switch_to_auth_json(&best, auth_json)?;
             println!("auto-selected most available: {} ({})", best, email);
             println!();
             status::run_focused(&best)?;
@@ -24,9 +57,23 @@ pub fn run(alias: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn find_most_available() -> Result<String> {
-    let profiles = profile::list_profiles()?;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AutoSelectMode {
+    RateLimit,
+    SpendCapRecovery,
+}
+
+fn find_most_available_excluding(
+    excluded_alias: Option<&str>,
+    mode: AutoSelectMode,
+) -> Result<String> {
+    let all_profiles = profile::list_profiles()?;
+    let had_profiles = !all_profiles.is_empty();
+    let profiles = profiles_after_excluding(all_profiles, excluded_alias);
     if profiles.is_empty() {
+        if had_profiles {
+            bail!("no alternate profiles saved. Use 'codexctl save' to save another account.");
+        }
         bail!("no profiles saved. Use 'codexctl save' to save the current account.");
     }
 
@@ -52,35 +99,7 @@ fn find_most_available() -> Result<String> {
                     )
                     .await
                     {
-                        Ok(usage) => {
-                            let plan = usage.plan_type.as_deref().unwrap_or("");
-                            if plan.contains("usage_based") {
-                                return (alias, f64::MAX);
-                            }
-
-                            let h5 = usage
-                                .rate_limit
-                                .as_ref()
-                                .and_then(|r| r.primary())
-                                .map(|w| w.used_percent)
-                                .unwrap_or(0.0);
-                            let d7 = usage
-                                .rate_limit
-                                .as_ref()
-                                .and_then(|r| r.secondary())
-                                .map(|w| w.used_percent)
-                                .unwrap_or(0.0);
-                            let score = if h5 >= 100.0 && d7 >= 100.0 {
-                                900.0
-                            } else if d7 >= 100.0 {
-                                700.0 + h5
-                            } else if h5 >= 100.0 {
-                                500.0 + d7
-                            } else {
-                                h5 * 2.0 + d7
-                            };
-                            (alias, score)
-                        }
+                        Ok(usage) => (alias, selection_score(&usage, mode)),
                         Err(_) => (alias, f64::MAX),
                     }
                 }
@@ -97,5 +116,178 @@ fn find_most_available() -> Result<String> {
     match best {
         Some((alias, _)) => Ok(alias.clone()),
         None => bail!("no usable accounts found (all expired or errored)"),
+    }
+}
+
+fn selection_score(usage: &api::RateLimitResponse, mode: AutoSelectMode) -> f64 {
+    if mode == AutoSelectMode::SpendCapRecovery
+        && usage.spend_control.as_ref().is_some_and(|s| s.reached)
+    {
+        return f64::MAX;
+    }
+
+    let plan = usage.plan_type.as_deref().unwrap_or("");
+    if plan.contains("usage_based") {
+        return match mode {
+            AutoSelectMode::RateLimit => f64::MAX,
+            AutoSelectMode::SpendCapRecovery => usage_based_recovery_score(usage),
+        };
+    }
+
+    rate_limit_score(usage)
+}
+
+fn usage_based_recovery_score(usage: &api::RateLimitResponse) -> f64 {
+    if usage.spend_control.as_ref().is_some_and(|s| s.reached) {
+        return f64::MAX;
+    }
+
+    match usage.credits.as_ref() {
+        Some(credits) if credits.overage_limit_reached => f64::MAX,
+        Some(credits) if credits.unlimited => -100.0,
+        Some(credits) if credits.has_credits => -50.0,
+        Some(_) => f64::MAX,
+        None => 0.0,
+    }
+}
+
+fn rate_limit_score(usage: &api::RateLimitResponse) -> f64 {
+    let h5 = usage
+        .rate_limit
+        .as_ref()
+        .and_then(|r| r.primary())
+        .map(|w| w.used_percent)
+        .unwrap_or(0.0);
+    let d7 = usage
+        .rate_limit
+        .as_ref()
+        .and_then(|r| r.secondary())
+        .map(|w| w.used_percent)
+        .unwrap_or(0.0);
+    if h5 >= 100.0 && d7 >= 100.0 {
+        900.0
+    } else if d7 >= 100.0 {
+        700.0 + h5
+    } else if h5 >= 100.0 {
+        500.0 + d7
+    } else {
+        h5 * 2.0 + d7
+    }
+}
+
+fn profiles_after_excluding(
+    mut profiles: Vec<profile::Profile>,
+    excluded_alias: Option<&str>,
+) -> Vec<profile::Profile> {
+    if let Some(excluded_alias) = excluded_alias {
+        profiles.retain(|p| p.meta.alias != excluded_alias);
+    }
+    profiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_profile(alias: &str) -> profile::Profile {
+        profile::Profile {
+            meta: profile::Meta {
+                alias: alias.to_string(),
+                email: None,
+                plan: None,
+                saved_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+            dir: Path::new("/tmp").join(alias),
+        }
+    }
+
+    fn usage_based_response(
+        credits: Option<api::Credits>,
+        spend_control: Option<api::SpendControl>,
+    ) -> api::RateLimitResponse {
+        api::RateLimitResponse {
+            plan_type: Some("usage_based".to_string()),
+            rate_limit: None,
+            credits,
+            spend_control,
+        }
+    }
+
+    #[test]
+    fn profiles_after_excluding_removes_failed_active_alias() {
+        let profiles = vec![test_profile("failed@test"), test_profile("next@test")];
+
+        let aliases: Vec<_> = profiles_after_excluding(profiles, Some("failed@test"))
+            .into_iter()
+            .map(|profile| profile.meta.alias)
+            .collect();
+
+        assert_eq!(aliases, vec!["next@test"]);
+    }
+
+    #[test]
+    fn rate_limit_mode_ignores_usage_based_profiles() {
+        let usage = usage_based_response(
+            Some(api::Credits {
+                has_credits: true,
+                unlimited: false,
+                overage_limit_reached: false,
+                balance: Some("10.00".to_string()),
+            }),
+            Some(api::SpendControl { reached: false }),
+        );
+
+        assert_eq!(selection_score(&usage, AutoSelectMode::RateLimit), f64::MAX);
+    }
+
+    #[test]
+    fn recovery_mode_accepts_healthy_usage_based_profiles() {
+        let usage = usage_based_response(
+            Some(api::Credits {
+                has_credits: true,
+                unlimited: false,
+                overage_limit_reached: false,
+                balance: Some("10.00".to_string()),
+            }),
+            Some(api::SpendControl { reached: false }),
+        );
+
+        assert!(
+            selection_score(&usage, AutoSelectMode::SpendCapRecovery) < f64::MAX,
+            "healthy usage-based profile should be selectable for spend-cap recovery"
+        );
+    }
+
+    #[test]
+    fn recovery_mode_rejects_spend_capped_usage_based_profiles() {
+        let usage = usage_based_response(
+            Some(api::Credits {
+                has_credits: true,
+                unlimited: false,
+                overage_limit_reached: false,
+                balance: Some("10.00".to_string()),
+            }),
+            Some(api::SpendControl { reached: true }),
+        );
+
+        assert_eq!(
+            selection_score(&usage, AutoSelectMode::SpendCapRecovery),
+            f64::MAX
+        );
+    }
+
+    #[test]
+    fn recovery_mode_rejects_spend_capped_profiles_without_usage_plan_label() {
+        let usage = api::RateLimitResponse {
+            plan_type: Some("team".to_string()),
+            rate_limit: None,
+            credits: None,
+            spend_control: Some(api::SpendControl { reached: true }),
+        };
+
+        assert_eq!(
+            selection_score(&usage, AutoSelectMode::SpendCapRecovery),
+            f64::MAX
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,15 @@ enum Commands {
     },
     /// Show current active account
     Whoami,
+    /// Run Codex with automatic spend-cap account recovery
+    Codex {
+        /// Prompt sent when the wrapper resumes after switching profiles
+        #[arg(long, default_value = commands::codex::DEFAULT_RECOVERY_PROMPT)]
+        recovery_prompt: String,
+        /// Arguments forwarded to codex
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -86,11 +95,72 @@ fn main() {
         Commands::List => commands::list::run(),
         Commands::Remove { ref alias } => commands::remove::run(alias),
         Commands::Whoami => commands::whoami::run(),
+        Commands::Codex {
+            ref args,
+            ref recovery_prompt,
+        } => codex_command_outcome(commands::codex::run(args, recovery_prompt)).into_result(),
         Commands::Completions { shell } => commands::completions::run(shell),
     };
 
     if let Err(e) = result {
         eprintln!("error: {e:#}");
         std::process::exit(1);
+    }
+}
+
+enum CommandOutcome {
+    Continue(anyhow::Result<()>),
+    Exit(i32),
+}
+
+impl CommandOutcome {
+    fn into_result(self) -> anyhow::Result<()> {
+        match self {
+            Self::Continue(result) => result,
+            Self::Exit(code) => std::process::exit(code),
+        }
+    }
+}
+
+fn codex_command_outcome(result: anyhow::Result<i32>) -> CommandOutcome {
+    match result {
+        Ok(code) => CommandOutcome::Exit(code),
+        Err(e) => CommandOutcome::Continue(Err(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_subcommand_accepts_resume_without_separator() {
+        let cli = Cli::parse_from([
+            "codexctl",
+            "codex",
+            "resume",
+            "019e9507-1bdc-7fd1-ac72-5705ee5cd793",
+        ]);
+
+        match cli.command {
+            Commands::Codex { args, .. } => {
+                assert_eq!(
+                    args,
+                    vec![
+                        "resume".to_string(),
+                        "019e9507-1bdc-7fd1-ac72-5705ee5cd793".to_string()
+                    ]
+                );
+            }
+            _ => panic!("expected codex command"),
+        }
+    }
+
+    #[test]
+    fn codex_command_outcome_preserves_child_exit_status() {
+        match codex_command_outcome(Ok(130)) {
+            CommandOutcome::Exit(code) => assert_eq!(code, 130),
+            CommandOutcome::Continue(_) => panic!("expected process exit"),
+        }
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -121,46 +121,79 @@ pub fn set_active_from(paths: &Paths, alias: &str) -> Result<()> {
 }
 
 pub fn switch_to_from(paths: &Paths, alias: &str) -> Result<String> {
+    switch_to_auth_json_from(paths, alias, &paths.codex_auth_json())
+}
+
+pub fn switch_to_auth_json_from(
+    paths: &Paths,
+    alias: &str,
+    codex_auth: &std::path::Path,
+) -> Result<String> {
     let profile = get_profile_from(paths, alias)?;
-    let codex_auth = paths.codex_auth_json();
 
     // Capture the outgoing active profile's live tokens before we overwrite
     // ~/.codex/auth.json. OpenAI uses single-use rotating refresh tokens, so the
     // Codex CLI may have rotated this profile's tokens since it was saved; if we
     // don't fold them back into the store they're lost and the profile later
     // looks "expired". See capture_active_profile_tokens for the safety guard.
-    capture_active_profile_tokens(paths, &codex_auth);
+    capture_auth_file_profile_tokens(paths, codex_auth);
 
-    std::fs::copy(profile.auth_json_path(), &codex_auth)
-        .with_context(|| "failed to copy auth.json to ~/.codex/")?;
-    set_active_from(paths, alias)?;
+    if let Some(parent) = codex_auth.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::copy(profile.auth_json_path(), codex_auth)
+        .with_context(|| format!("failed to copy auth.json to {}", codex_auth.display()))?;
+    if codex_auth == paths.codex_auth_json() {
+        set_active_from(paths, alias)?;
+    }
     Ok(profile.meta.email.unwrap_or_else(|| "unknown".to_string()))
 }
 
-/// Best-effort: copy the live ~/.codex/auth.json back into the currently-active
-/// profile's store, but only when both files decode to the same seat (`sub`).
-/// The guard prevents clobbering the store when ~/.codex was changed out-of-band
-/// (e.g. a direct `codex login`). Failures only warn — they must not block a switch.
-fn capture_active_profile_tokens(paths: &Paths, codex_auth: &std::path::Path) {
-    let Ok(Some(active)) = get_active_from(paths) else {
-        return;
+pub fn alias_for_auth_json_from(
+    paths: &Paths,
+    auth_json: &std::path::Path,
+) -> Result<Option<String>> {
+    let Ok(target_auth) = api::read_auth_json(auth_json) else {
+        return Ok(None);
     };
+    let target_sub = api::token_subject(&target_auth.access_token);
+    let mut profile_auths = Vec::new();
+    for profile in list_profiles_from(paths)? {
+        let Ok(profile_auth) = api::read_auth_json(&profile.auth_json_path()) else {
+            continue;
+        };
+        profile_auths.push((profile, profile_auth));
+    }
+
+    for (profile, profile_auth) in &profile_auths {
+        if profile_auth.access_token == target_auth.access_token {
+            return Ok(Some(profile.meta.alias.clone()));
+        }
+    }
+
+    for (profile, profile_auth) in profile_auths {
+        let profile_sub = api::token_subject(&profile_auth.access_token);
+        if target_sub.is_some() && target_sub == profile_sub {
+            return Ok(Some(profile.meta.alias));
+        }
+    }
+    Ok(None)
+}
+
+/// Best-effort: copy the live Codex auth file back into the saved profile that
+/// owns that auth, but only when the token matches by exact value or seat (`sub`).
+/// Failures only warn — they must not block a switch.
+fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &std::path::Path) {
     if !codex_auth.exists() {
         return;
     }
-    let dest = paths.profiles_dir().join(&active).join("auth.json");
-    let stored_sub = api::read_auth_json(&dest)
-        .ok()
-        .and_then(|a| api::token_subject(&a.access_token));
-    let live_sub = api::read_auth_json(codex_auth)
-        .ok()
-        .and_then(|a| api::token_subject(&a.access_token));
-
-    if stored_sub.is_some()
-        && stored_sub == live_sub
-        && let Err(e) = std::fs::copy(codex_auth, &dest)
-    {
-        eprintln!("warning: failed to capture tokens for active profile '{active}': {e}");
+    let Ok(Some(alias)) = alias_for_auth_json_from(paths, codex_auth) else {
+        return;
+    };
+    let dest = paths.profiles_dir().join(&alias).join("auth.json");
+    if let Err(e) = std::fs::copy(codex_auth, &dest) {
+        eprintln!("warning: failed to capture tokens for profile '{alias}': {e}");
     }
 }
 
@@ -204,4 +237,7 @@ pub fn set_active(alias: &str) -> Result<()> {
 }
 pub fn switch_to(alias: &str) -> Result<String> {
     switch_to_from(&config::default_paths()?, alias)
+}
+pub fn switch_to_auth_json(alias: &str, auth_json: &std::path::Path) -> Result<String> {
+    switch_to_auth_json_from(&config::default_paths()?, alias, auth_json)
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -172,11 +172,16 @@ pub fn alias_for_auth_json_from(
         }
     }
 
-    for (profile, profile_auth) in profile_auths {
-        let profile_sub = api::token_subject(&profile_auth.access_token);
-        if target_sub.is_some() && target_sub == profile_sub {
-            return Ok(Some(profile.meta.alias));
-        }
+    let mut sub_matches = profile_auths
+        .into_iter()
+        .filter_map(|(profile, profile_auth)| {
+            let profile_sub = api::token_subject(&profile_auth.access_token);
+            (target_sub.is_some() && target_sub == profile_sub).then_some(profile.meta.alias)
+        });
+    if let Some(alias) = sub_matches.next()
+        && sub_matches.next().is_none()
+    {
+        return Ok(Some(alias));
     }
     Ok(None)
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -13,6 +13,7 @@ fn help_shows_all_subcommands() {
     assert!(stdout.contains("list"));
     assert!(stdout.contains("remove"));
     assert!(stdout.contains("whoami"));
+    assert!(stdout.contains("codex"));
     assert!(stdout.contains("completions"));
 }
 
@@ -20,6 +21,15 @@ fn help_shows_all_subcommands() {
 fn unknown_subcommand_fails() {
     let mut cmd = Command::cargo_bin("codexctl").unwrap();
     cmd.arg("nonexistent").assert().failure();
+}
+
+#[test]
+fn codex_help_uses_safe_recovery_prompt_default() {
+    let mut cmd = Command::cargo_bin("codexctl").unwrap();
+    let output = cmd.args(["codex", "--help"]).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Continue the previous request."));
+    assert!(!stdout.contains("[default: resume]"));
 }
 
 #[test]

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -91,6 +91,66 @@ fn switch_copies_auth_json() {
 }
 
 #[test]
+fn switch_copies_auth_json_to_custom_codex_auth_path() {
+    let (tmp, paths) = setup_test_env();
+
+    write_profile(&paths, "acct@test.com", "custom_home_tok");
+    let custom_auth = tmp.path().join("custom-codex-home").join("auth.json");
+
+    profile::switch_to_auth_json_from(&paths, "acct@test.com", &custom_auth).unwrap();
+
+    let custom_contents = std::fs::read_to_string(&custom_auth).unwrap();
+    assert!(custom_contents.contains("custom_home_tok"));
+    let default_contents = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
+    assert!(default_contents.contains("test_tok"));
+    assert!(profile::get_active_from(&paths).unwrap().is_none());
+}
+
+#[test]
+fn switch_custom_auth_path_captures_matching_profile_tokens_before_overwrite() {
+    let (tmp, paths) = setup_test_env();
+    let failed_old = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old");
+    let failed_live = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.live");
+    let next_tok = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.next");
+    write_profile(&paths, "failed@test", &failed_old);
+    write_profile(&paths, "next@test", &next_tok);
+    let custom_auth = tmp.path().join("custom-codex-home").join("auth.json");
+    std::fs::create_dir_all(custom_auth.parent().unwrap()).unwrap();
+    std::fs::write(
+        &custom_auth,
+        format!(r#"{{"access_token":"{failed_live}"}}"#),
+    )
+    .unwrap();
+
+    profile::switch_to_auth_json_from(&paths, "next@test", &custom_auth).unwrap();
+
+    let failed_store =
+        std::fs::read_to_string(paths.profiles_dir().join("failed@test").join("auth.json"))
+            .unwrap();
+    assert!(failed_store.contains(".live"));
+    let custom_contents = std::fs::read_to_string(&custom_auth).unwrap();
+    assert!(custom_contents.contains(&next_tok));
+}
+
+#[test]
+fn alias_for_auth_json_prefers_exact_token_before_subject_fallback() {
+    let (tmp, paths) = setup_test_env();
+    let stale_same_seat = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old");
+    let exact_token = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.exact");
+    write_profile(&paths, "aaa-stale@test", &stale_same_seat);
+    write_profile(&paths, "zzz-exact@test", &exact_token);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{exact_token}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json)
+            .unwrap()
+            .as_deref(),
+        Some("zzz-exact@test")
+    );
+}
+
+#[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();
     let active = profile::get_active_from(&paths).unwrap();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -151,6 +151,27 @@ fn alias_for_auth_json_prefers_exact_token_before_subject_fallback() {
 }
 
 #[test]
+fn alias_for_auth_json_rejects_ambiguous_subject_fallback() {
+    let (tmp, paths) = setup_test_env();
+    let stale_a = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old-a");
+    let stale_b = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old-b");
+    let live_same_seat = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.live");
+    write_profile(&paths, "seat-a-primary@test", &stale_a);
+    write_profile(&paths, "seat-a-copy@test", &stale_b);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(
+        &auth_json,
+        format!(r#"{{"access_token":"{live_same_seat}"}}"#),
+    )
+    .unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
+#[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();
     let active = profile::get_active_from(&paths).unwrap();


### PR DESCRIPTION
Adds `codexctl codex` so Codex can recover from spend-cap prompts by switching profiles and resuming the same session.

- runs Codex through a PTY and detects workspace spend-cap prompts
- switches to the best alternate saved profile using spend-cap-aware selection
- resumes with cwd, model/config, approval/sandbox, and other resume-relevant flags preserved
- supports direct `codexctl codex resume <session-id>` from the caller cwd
- handles CODEX_HOME-backed auth, non-TTY stdin, and session discovery edge cases

Test Plan:
- cargo test --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- trunk check
- $autoreview --mode uncommitted: clean
- Herdr live: forced amir+11 cap, recovered to amir+8, produced HERDR_WRAPPER_LIVE_PASS
- Herdr live: `codexctl codex resume 019e9507-...` opened with `directory: ~/Code/codexctl`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `codexctl codex`, a PTY-backed launcher that detects Codex spend-cap errors, switches to the best alternate profile, and resumes the same session automatically. It preserves cwd and relevant flags, works with `resume <session-id>` (including `--last`), and exits with the child’s status.

- **New Features**
  - Runs `codex` in a PTY, detects spend-cap messages (workspace and self-managed), then kills/resumes seamlessly.
  - Auto-selects an alternate saved profile (excludes the failed one) with spend-cap-aware logic and usage-based credit preference.
  - Preserves cwd via `--cd`, model/config flags, approvals/sandbox flags, and other resume-relevant options.
  - Supports `codexctl codex resume <session-id>`; otherwise discovers the latest session from `~/.codex/sessions/**/rollout-*.jsonl` (ignores subagents; matches caller cwd).
  - Handles `CODEX_HOME` auth, non-TTY input, terminal resize and paste (bracketed paste on Windows), and returns the child exit code.
  - New CLI: `codexctl codex --recovery_prompt "<text>"` (default: "Continue the previous request.").

- **Bug Fixes**
  - Correctly handle the self-managed spend-cap copy and parse resume hints to extract session ids.
  - Replace or append the recovery prompt for `resume --last` and named lanes; prefer explicit resume ids over detected hints.
  - Canonicalize cwd for session matching; ignore invalid/new files and subagent sessions; stop input threads cleanly on recovery.
  - Profile switching can target a custom auth path; captures tokens by exact token or JWT `sub`; auto-selection rejects spend-capped accounts. Added `crossterm`, `portable-pty`, `libc`.

<sup>Written for commit eed931ba3033da0772a78197e6bcc5061ae4201d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codexctl codex` wrapper command that runs Codex with automatic spend-cap failover. When a spend-cap limit is detected, the tool automatically switches accounts and resumes the previous session.
  * Enhanced account selection logic with multiple selection modes for improved profile switching behavior.

* **Chores**
  * Bumped version to 0.1.3.
  * Added terminal and pseudo-terminal support dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->