### PR TITLE
feat(release): prebuilt binaries + Homebrew tap auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,7 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to release (e.g. v0.1.4)
-        required: true
-        type: string
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -28,7 +23,7 @@ jobs:
       - id: resolve
         run: |
           set -euo pipefail
-          ref="${{ inputs.ref || github.ref }}"
+          ref="${{ github.ref }}"
           tag="${ref#refs/tags/}"
           tag="${tag#refs/heads/}"
           if [[ "${tag}" != v* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      target: ${{ steps.resolve.outputs.target }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,17 +35,30 @@ jobs:
 
           if [[ "${REF_TYPE}" == "tag" ]]; then
             tag="${REF_NAME}"
+            checkout_ref="${REF_NAME}"
+            target="$(git rev-list -n 1 "${tag}")"
           else
-            tag="$(git tag --points-at "${GITHUB_SHA}" --list 'v*' | sort -V | tail -n1)"
+            version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+            tag="v${version}"
+            target="${GITHUB_SHA}"
+            checkout_ref="${GITHUB_SHA}"
+
+            existing="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" || true)"
+            if [[ -n "${existing}" && "${existing}" != "${target}" ]]; then
+              echo "Tag ${tag} already points at ${existing}, not ${target}." >&2
+              exit 1
+            fi
           fi
 
           if [[ -z "${tag}" || "${tag}" != v* ]]; then
-            echo "Expected a v* tag ref or a branch commit tagged v*." >&2
+            echo "Expected a v* tag or package version." >&2
             exit 1
           fi
 
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
+          echo "target=${target}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build ${{ matrix.label }}
@@ -65,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.tag }}
+          ref: ${{ needs.setup.outputs.checkout_ref }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -131,7 +146,8 @@ jobs:
               --repo "${{ github.repository }}" --clobber
           else
             gh release create "${tag}" dist/codexctl_*.tar.gz dist/codexctl_*.tar.gz.sha256 \
-              --repo "${{ github.repository }}" --title "${tag}" --generate-notes
+              --repo "${{ github.repository }}" --target "${{ needs.setup.outputs.target }}" \
+              --title "${tag}" --generate-notes
           fi
 
   homebrew:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,212 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to release (e.g. v0.1.4)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  setup:
+    name: Resolve tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - id: resolve
+        run: |
+          set -euo pipefail
+          ref="${{ inputs.ref || github.ref }}"
+          tag="${ref#refs/tags/}"
+          tag="${tag#refs/heads/}"
+          if [[ "${tag}" != v* ]]; then
+            echo "Expected a v* tag, got '${tag}'." >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.label }}
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            label: Darwin_arm64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            label: Darwin_x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            label: Linux_x86_64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          set -euo pipefail
+          archive="codexctl_${{ needs.setup.outputs.tag }}_${{ matrix.label }}.tar.gz"
+          strip "target/${{ matrix.target }}/release/codexctl" || true
+          tar -czf "${archive}" -C "target/${{ matrix.target }}/release" codexctl
+          shasum -a 256 "${archive}" > "${archive}.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: codexctl_${{ matrix.label }}
+          path: |
+            codexctl_*.tar.gz
+            codexctl_*.tar.gz.sha256
+
+  release:
+    name: Publish release
+    needs: [setup, build]
+    runs-on: ubuntu-latest
+    outputs:
+      sha_darwin_arm64: ${{ steps.shas.outputs.darwin_arm64 }}
+      sha_darwin_x86_64: ${{ steps.shas.outputs.darwin_x86_64 }}
+      sha_linux_x86_64: ${{ steps.shas.outputs.linux_x86_64 }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - id: shas
+        name: Collect checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          tag="${{ needs.setup.outputs.tag }}"
+          sha() { shasum -a 256 "codexctl_${tag}_$1.tar.gz" | cut -d' ' -f1; }
+          {
+            echo "darwin_arm64=$(sha Darwin_arm64)"
+            echo "darwin_x86_64=$(sha Darwin_x86_64)"
+            echo "linux_x86_64=$(sha Linux_x86_64)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.setup.outputs.tag }}"
+          if gh release view "${tag}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "${tag}" dist/codexctl_*.tar.gz dist/codexctl_*.tar.gz.sha256 \
+              --repo "${{ github.repository }}" --clobber
+          else
+            gh release create "${tag}" dist/codexctl_*.tar.gz dist/codexctl_*.tar.gz.sha256 \
+              --repo "${{ github.repository }}" --title "${tag}" --generate-notes
+          fi
+
+  homebrew:
+    name: Update Homebrew tap
+    needs: [setup, release]
+    runs-on: ubuntu-latest
+    steps:
+      - id: token
+        name: Create token
+        continue-on-error: true
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ vars.SAWMILLS_REPO_APP_ID }}
+          private_key: ${{ secrets.SAWMILLS_APP_PRIVATE_KEY }}
+
+      - name: Push formula to public tap
+        if: steps.token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          TAG: ${{ needs.setup.outputs.tag }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          SHA_DARWIN_ARM64: ${{ needs.release.outputs.sha_darwin_arm64 }}
+          SHA_DARWIN_X86_64: ${{ needs.release.outputs.sha_darwin_x86_64 }}
+          SHA_LINUX_X86_64: ${{ needs.release.outputs.sha_linux_x86_64 }}
+        run: |
+          set -euo pipefail
+          base="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
+          git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/Sawmills/homebrew-tap.git" \
+            "${workdir}/tap"
+
+          cat > "${workdir}/tap/Formula/codexctl.rb" << EOF
+          class Codexctl < Formula
+            desc "Manage multiple OpenAI Codex CLI accounts"
+            homepage "https://github.com/Sawmills/codexctl"
+            version "${VERSION}"
+            license "Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "${base}/codexctl_${TAG}_Darwin_arm64.tar.gz"
+                sha256 "${SHA_DARWIN_ARM64}"
+              else
+                url "${base}/codexctl_${TAG}_Darwin_x86_64.tar.gz"
+                sha256 "${SHA_DARWIN_X86_64}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "${base}/codexctl_${TAG}_Linux_x86_64.tar.gz"
+                sha256 "${SHA_LINUX_X86_64}"
+              end
+            end
+
+            def install
+              bin.install "codexctl"
+              generate_completions_from_executable(bin/"codexctl", "completions")
+            end
+
+            test do
+              help = shell_output("#{bin}/codexctl --help")
+              assert_match "Usage:", help
+              assert_match "codexctl", help
+              assert_path_exists bash_completion/"codexctl"
+              assert_path_exists zsh_completion/"_codexctl"
+              assert_path_exists fish_completion/"codexctl.fish"
+            end
+          end
+          EOF
+          sed -i 's/^          //' "${workdir}/tap/Formula/codexctl.rb"
+
+          cd "${workdir}/tap"
+          if git diff --quiet -- Formula/codexctl.rb; then
+            echo "Formula already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/codexctl.rb
+          git commit -m "chore(codexctl): update to ${TAG}"
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,28 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - id: resolve
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
-          ref="${{ github.ref }}"
-          tag="${ref#refs/tags/}"
-          tag="${tag#refs/heads/}"
-          if [[ "${tag}" != v* ]]; then
-            echo "Expected a v* tag, got '${tag}'." >&2
+
+          if [[ "${REF_TYPE}" == "tag" ]]; then
+            tag="${REF_NAME}"
+          else
+            tag="$(git tag --points-at "${GITHUB_SHA}" --list 'v*' | sort -V | tail -n1)"
+          fi
+
+          if [[ -z "${tag}" || "${tag}" != v* ]]; then
+            echo "Expected a v* tag ref or a branch commit tagged v*." >&2
             exit 1
           fi
+
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -11,7 +11,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.6.9
+    - actionlint@1.7.7
     - checkov@3.2.513
     - git-diff-check
     - osv-scanner@1.3.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -269,14 +269,10 @@ impl HerdrAgentReporter {
             let Ok(mut stream) = std::os::unix::net::UnixStream::connect(&self.socket_path) else {
                 return;
             };
-            let timeout = Some(Duration::from_millis(500));
-            let _ = stream.set_read_timeout(timeout);
-            let _ = stream.set_write_timeout(timeout);
-            if stream.write_all(&payload).is_err() || stream.write_all(b"\n").is_err() {
-                return;
-            }
-            let mut buffer = [0; 4096];
-            let _ = stream.read(&mut buffer);
+            let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
+            let _ = stream
+                .write_all(&payload)
+                .and_then(|_| stream.write_all(b"\n"));
         }
 
         #[cfg(not(unix))]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -5,7 +5,7 @@ use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 #[cfg(not(unix))]
@@ -28,9 +28,16 @@ pub fn run(args: &[String], recovery_prompt: &str) -> Result<i32> {
     let failed_alias = failed_alias_for_child_auth(&paths);
     let mut switcher = CodexctlProfileSwitcher::new(&paths, failed_alias);
     let mut sessions = FilesystemSessionStore::new(&paths)?;
+    let mut reporter = HerdrAgentReporter::from_env();
     let cwd = std::env::current_dir().context("failed to get current directory")?;
     let options = WrapperOptions::new(args.to_vec(), recovery_prompt.to_string(), cwd);
-    run_with(&options, &mut runner, &mut switcher, &mut sessions)
+    run_with_reporter(
+        &options,
+        &mut runner,
+        &mut switcher,
+        &mut sessions,
+        &mut reporter,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,11 +107,40 @@ impl CodexInvocation {
     }
 }
 
+#[cfg(test)]
 fn run_with(
     options: &WrapperOptions,
     runner: &mut impl CodexRunner,
     switcher: &mut impl ProfileSwitcher,
     sessions: &mut impl SessionStore,
+) -> Result<i32> {
+    let mut reporter = None;
+    run_with_reporter(options, runner, switcher, sessions, &mut reporter)
+}
+
+fn run_with_reporter(
+    options: &WrapperOptions,
+    runner: &mut impl CodexRunner,
+    switcher: &mut impl ProfileSwitcher,
+    sessions: &mut impl SessionStore,
+    reporter: &mut impl AgentReporter,
+) -> Result<i32> {
+    let session_id = session_id_from_codex_args(&options.args);
+    if let Some(session_id) = session_id.as_deref() {
+        reporter.report_session(session_id);
+    }
+    reporter.report(HerdrAgentState::Unknown, session_id.as_deref());
+    let result = run_with_reporter_inner(options, runner, switcher, sessions, reporter);
+    reporter.release();
+    result
+}
+
+fn run_with_reporter_inner(
+    options: &WrapperOptions,
+    runner: &mut impl CodexRunner,
+    switcher: &mut impl ProfileSwitcher,
+    sessions: &mut impl SessionStore,
+    reporter: &mut impl AgentReporter,
 ) -> Result<i32> {
     let initial = CodexInvocation::from_forwarded_args(&options.args, &options.cwd);
     match runner.run_codex(&initial)? {
@@ -113,6 +149,11 @@ fn run_with(
             let recovery_plan = recovery_plan(options, session_id, sessions)?;
             let mut recovery =
                 CodexInvocation::from_forwarded_args(&recovery_plan.args, &options.cwd);
+            let recovery_session_id = session_id_from_codex_args(&recovery.args);
+            if let Some(session_id) = recovery_session_id.as_deref() {
+                reporter.report_session(session_id);
+            }
+            reporter.report(HerdrAgentState::Unknown, recovery_session_id.as_deref());
             if recovery_plan.continue_paused_goal_on_prompt {
                 recovery = recovery.with_continue_goal_on_start();
             }
@@ -131,6 +172,178 @@ fn run_with(
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HerdrAgentState {
+    Unknown,
+}
+
+impl HerdrAgentState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+trait AgentReporter {
+    fn report_session(&mut self, session_id: &str);
+    fn report(&mut self, state: HerdrAgentState, session_id: Option<&str>);
+    fn release(&mut self);
+}
+
+impl AgentReporter for Option<HerdrAgentReporter> {
+    fn report_session(&mut self, session_id: &str) {
+        if let Some(reporter) = self {
+            reporter.report_session(session_id);
+        }
+    }
+
+    fn report(&mut self, state: HerdrAgentState, session_id: Option<&str>) {
+        if let Some(reporter) = self {
+            reporter.report(state, session_id);
+        }
+    }
+
+    fn release(&mut self) {
+        if let Some(reporter) = self {
+            reporter.release();
+        }
+    }
+}
+
+struct HerdrAgentReporter {
+    socket_path: PathBuf,
+    pane_id: String,
+}
+
+impl HerdrAgentReporter {
+    const SOURCE: &'static str = "codexctl";
+    const CODEX_SESSION_SOURCE: &'static str = "herdr:codex";
+    const AGENT: &'static str = "codex";
+
+    fn from_env() -> Option<Self> {
+        if std::env::var_os("HERDR_ENV").as_deref() != Some(std::ffi::OsStr::new("1")) {
+            return None;
+        }
+        let socket_path = std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from)?;
+        let pane_id = std::env::var("HERDR_PANE_ID").ok()?;
+        if pane_id.trim().is_empty() {
+            return None;
+        }
+        Some(Self {
+            socket_path,
+            pane_id,
+        })
+    }
+
+    fn report_session(&self, session_id: &str) {
+        self.send(herdr_report_agent_session_request(
+            &self.pane_id,
+            session_id,
+            herdr_seq(),
+        ));
+    }
+
+    fn report(&self, state: HerdrAgentState, session_id: Option<&str>) {
+        self.send(herdr_report_agent_request(
+            &self.pane_id,
+            state,
+            session_id,
+            herdr_seq(),
+        ));
+    }
+
+    fn release(&self) {
+        self.send(herdr_release_agent_request(&self.pane_id, herdr_seq()));
+    }
+
+    fn send(&self, request: serde_json::Value) {
+        let Ok(payload) = serde_json::to_vec(&request) else {
+            return;
+        };
+
+        #[cfg(unix)]
+        {
+            let Ok(mut stream) = std::os::unix::net::UnixStream::connect(&self.socket_path) else {
+                return;
+            };
+            let timeout = Some(Duration::from_millis(500));
+            let _ = stream.set_read_timeout(timeout);
+            let _ = stream.set_write_timeout(timeout);
+            if stream.write_all(&payload).is_err() || stream.write_all(b"\n").is_err() {
+                return;
+            }
+            let mut buffer = [0; 4096];
+            let _ = stream.read(&mut buffer);
+        }
+
+        #[cfg(not(unix))]
+        let _ = payload;
+    }
+}
+
+fn herdr_report_agent_request(
+    pane_id: &str,
+    state: HerdrAgentState,
+    session_id: Option<&str>,
+    seq: u64,
+) -> serde_json::Value {
+    let mut params = serde_json::json!({
+        "pane_id": pane_id,
+        "source": HerdrAgentReporter::SOURCE,
+        "agent": HerdrAgentReporter::AGENT,
+        "state": state.as_str(),
+        "seq": seq,
+    });
+    if let Some(session_id) = session_id {
+        params["agent_session_id"] = serde_json::json!(session_id);
+    }
+    serde_json::json!({
+        "id": format!("codexctl:report-agent:{seq}"),
+        "method": "pane.report_agent",
+        "params": params,
+    })
+}
+
+fn herdr_report_agent_session_request(
+    pane_id: &str,
+    session_id: &str,
+    seq: u64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("codexctl:report-agent-session:{seq}"),
+        "method": "pane.report_agent_session",
+        "params": {
+            "pane_id": pane_id,
+            "source": HerdrAgentReporter::CODEX_SESSION_SOURCE,
+            "agent": HerdrAgentReporter::AGENT,
+            "seq": seq,
+            "agent_session_id": session_id,
+        },
+    })
+}
+
+fn herdr_release_agent_request(pane_id: &str, seq: u64) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("codexctl:release-agent:{seq}"),
+        "method": "pane.release_agent",
+        "params": {
+            "pane_id": pane_id,
+            "source": HerdrAgentReporter::SOURCE,
+            "agent": HerdrAgentReporter::AGENT,
+            "seq": seq,
+        },
+    })
+}
+
+fn herdr_seq() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    u64::try_from(nanos).unwrap_or(u64::MAX)
 }
 
 struct RecoveryPlan {
@@ -1616,6 +1829,54 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_reports_codex_agent_to_herdr_while_child_runs() {
+        let cwd = PathBuf::from("/Users/amirjakoby/Code/codexctl");
+        let mut runner = FakeCodexRunner::new(vec![CodexRunOutcome::Exited(0)]);
+        let mut switcher = FakeProfileSwitcher::default();
+        let mut sessions = FakeSessionStore::default();
+        let mut reporter = FakeAgentReporter::default();
+        let options = WrapperOptions::new(
+            vec!["resume".to_string(), SESSION_ID.to_string()],
+            "Continue the previous request.".to_string(),
+            cwd,
+        );
+
+        let exit = run_with_reporter(
+            &options,
+            &mut runner,
+            &mut switcher,
+            &mut sessions,
+            &mut reporter,
+        )
+        .unwrap();
+
+        assert_eq!(exit, 0);
+        assert_eq!(
+            reporter.events,
+            vec![
+                AgentReportEvent::ReportSession {
+                    session_id: SESSION_ID.to_string(),
+                },
+                AgentReportEvent::Report {
+                    state: HerdrAgentState::Unknown,
+                    session_id: Some(SESSION_ID.to_string()),
+                },
+                AgentReportEvent::Release,
+            ]
+        );
+    }
+
+    #[test]
+    fn herdr_session_reports_use_codex_hook_source() {
+        let request = herdr_report_agent_session_request("pane-1", SESSION_ID, 42);
+
+        assert_eq!(request["method"], "pane.report_agent_session");
+        assert_eq!(request["params"]["source"], "herdr:codex");
+        assert_eq!(request["params"]["agent"], "codex");
+        assert_eq!(request["params"]["agent_session_id"], SESSION_ID);
+    }
+
+    #[test]
     fn continue_goal_enter_writes_carriage_return() {
         let mut bytes = Vec::new();
 
@@ -2510,6 +2771,42 @@ mod tests {
             _session_id: &str,
         ) -> anyhow::Result<Option<SessionGoalStatus>> {
             Ok(self.goal_status)
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum AgentReportEvent {
+        ReportSession {
+            session_id: String,
+        },
+        Report {
+            state: HerdrAgentState,
+            session_id: Option<String>,
+        },
+        Release,
+    }
+
+    #[derive(Default)]
+    struct FakeAgentReporter {
+        events: Vec<AgentReportEvent>,
+    }
+
+    impl AgentReporter for FakeAgentReporter {
+        fn report_session(&mut self, session_id: &str) {
+            self.events.push(AgentReportEvent::ReportSession {
+                session_id: session_id.to_string(),
+            });
+        }
+
+        fn report(&mut self, state: HerdrAgentState, session_id: Option<&str>) {
+            self.events.push(AgentReportEvent::Report {
+                state,
+                session_id: session_id.map(str::to_string),
+            });
+        }
+
+        fn release(&mut self) {
+            self.events.push(AgentReportEvent::Release);
         }
     }
 


### PR DESCRIPTION
## What

Adds a `Release` workflow so `brew install sawmills/tap/codexctl` downloads a **prebuilt binary** instead of compiling Rust from source.

On a `v*` tag push (or manual `workflow_dispatch` with a `ref`):
1. **Build** — `codexctl` for `macOS arm64`, `macOS x86_64`, and `Linux x86_64` (native runners).
2. **Publish** — tarballs (`codexctl_<tag>_<Os>_<arch>.tar.gz`) + `.sha256` uploaded to a GitHub Release.
3. **Update tap** — regenerates `Formula/codexctl.rb` in [`Sawmills/homebrew-tap`](https://github.com/Sawmills/homebrew-tap) to download the prebuilt artifacts (per-platform `url` + `sha256`, `bin.install`), mirroring the `sm` formula pattern. This step uses the standard Sawmills app token and **skips gracefully** if it's unavailable.

Also bumps `actionlint` 1.6.9 → 1.7.7 (1.6.9 predates `macos-14`/`macos-13` labels and the `vars`/`inputs` contexts, causing false positives + a formatter panic).

## Notes
- Artifacts are hosted on **GitHub Releases** (public repo, no S3/credentials needed).
- Tag-naming matches the existing `sm` convention (`<name>_v<ver>_<Os>_<arch>.tar.gz`).
- `trunk check` (actionlint/yamllint/prettier) passes clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish prebuilt `codexctl` binaries and auto-update the Homebrew tap for faster installs; also report `codexctl` sessions to `herdr` when enabled to keep pane status in sync. Manual dispatch now works from branches and auto-resolves the release tag; `herdr` reporting is fire-and-forget to avoid blocking.

- New Features
  - Adds a GitHub Actions Release workflow triggered by `v*` tags and manual dispatch (no inputs), including branch runs that resolve/validate the tag from `Cargo.toml`.
  - Builds macOS arm64, macOS x86_64, and Linux x86_64 binaries on native runners.
  - Uploads tarballs and `.sha256` files to GitHub Releases with consistent naming.
  - Regenerates `Sawmills/homebrew-tap` `Formula/codexctl.rb` with per-platform URLs and checksums; best-effort (skips if the app token is missing).

- Dependencies
  - Bumps `actionlint` to `1.7.7` to support modern runner labels and `vars`/`inputs` contexts.

<sup>Written for commit 2c07a739feec93c6fa8e3cc6506ad393d5e5599a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

