### PR TITLE
fix(release): use current macOS Intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             label: Darwin_arm64
-          - os: macos-13
+          # trunk-ignore(actionlint/runner-label): Current GitHub Intel macOS runner label.
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             label: Darwin_x86_64
           - os: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"


### PR DESCRIPTION
release: Use current macOS Intel runner

Fix the release workflow after `macos-13` queued indefinitely on the v0.1.5 tag run.

- switch the x86_64 macOS release build to `macos-15-intel`
- keep a narrow actionlint ignore for the current GitHub runner label
- bump codexctl to 0.1.6 for a clean follow-up release tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by switching the macOS Intel build to `macos-15-intel`, avoiding indefinite queues on `macos-13`. Adds a narrow `actionlint` ignore for the runner label and bumps `codexctl` to 0.1.6 for the next release.

<sup>Written for commit 08900826a1bb127eea4ad05c3fac35032f0b107f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

