### PR TITLE
fix(release): open tap PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           app_id: ${{ vars.SAWMILLS_REPO_APP_ID }}
           private_key: ${{ secrets.SAWMILLS_APP_PRIVATE_KEY }}
 
-      - name: Push formula to public tap
+      - name: Open formula PR on public tap
         if: steps.token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -229,8 +229,25 @@ jobs:
             echo "Formula already up to date."
             exit 0
           fi
+
+          # The public tap's main is protected (PR + required checks), so land
+          # the update through a PR instead of pushing to main directly.
+          branch="codexctl-${TAG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
           git add Formula/codexctl.rb
           git commit -m "chore(codexctl): update to ${TAG}"
-          git push origin HEAD:main
+          git push -f origin "HEAD:${branch}"
+
+          if ! gh pr view "${branch}" --repo Sawmills/homebrew-tap >/dev/null 2>&1; then
+            gh pr create --repo Sawmills/homebrew-tap \
+              --base main --head "${branch}" \
+              --title "chore(codexctl): update to ${TAG}" \
+              --body "Automated formula update for codexctl ${TAG}, built from https://github.com/${{ github.repository }}/releases/tag/${TAG}."
+          fi
+
+          # Best effort: queue auto-merge if the tap enables it; otherwise the
+          # PR stays open for a maintainer to merge once formula-ci is green.
+          gh pr merge "${branch}" --repo Sawmills/homebrew-tap --squash --auto --delete-branch \
+            || echo "Auto-merge unavailable; PR left open for manual merge."


### PR DESCRIPTION
## Problem

The `Release` workflow's **Update Homebrew tap** job did `git push origin HEAD:main` against `Sawmills/homebrew-tap`, whose `main` is protected. Every release failed that step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "formula-ci" is expected.
```

(Builds + GitHub Release were fine — only the tap push failed. v0.1.6 was landed manually via tap PR #70.)

## Fix

The tap step now pushes the regenerated formula to a per-release branch (`codexctl-<tag>`), opens a PR against the tap, and queues auto-merge when the tap allows it — otherwise the PR waits for a maintainer to merge after `formula-ci` passes. No direct push to a protected branch.

`trunk check` (actionlint/yamllint/prettier) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by opening a PR to the public Homebrew tap instead of pushing to protected `main`, so releases no longer fail the tap update step. Auto-merge is queued when available; otherwise a maintainer merges after CI.

- **Bug Fixes**
  - Push formula updates to a per-release branch `codexctl-<tag>` and open a PR against `main` on `Sawmills/homebrew-tap`.
  - Queue squash auto-merge when allowed; otherwise wait for `formula-ci` and manual merge.
  - Remove direct push to protected `main` (fixes GH006 failures). Build and GitHub Release steps unchanged.

<sup>Written for commit 94c20f31aa778a89a6c59fba49777010a66d8a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

