### PR TITLE
chore(release): v0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump to **v0.1.12**. Ships reset-aware account selection (default-on) from #8.

Tagging `v0.1.12` after merge triggers the Release workflow: builds Darwin arm64/x86_64 + Linux x86_64, cuts the GitHub release, and opens the formula PR on `Sawmills/homebrew-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.1.12 to ship reset-aware account selection (default-on) from #8. Tagging v0.1.12 triggers the Release workflow to build macOS (arm64, x86_64) and Linux (x86_64), publish the GitHub release, and open the Homebrew formula PR in `Sawmills/homebrew-tap`.

<sup>Written for commit f9c08b6b927ff6fd87af61a78b02fce6a7e958ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

