### PR TITLE
use: prefer no-bill auto selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -122,7 +122,7 @@ struct SelectionCandidate {
 /// Pick the most-available alias from scored candidates.
 ///
 /// Default (`reset_aware == false`): lowest `selection_score` (most headroom),
-/// after no-bill accounts. Reset-aware: among accounts with usable headroom
+/// exactly as before. Reset-aware: among accounts with usable headroom
 /// (`score < RATE_LIMIT_EXHAUSTED`) pick no-bill accounts first, then the
 /// soonest 7d reset, breaking ties by most headroom; if none have headroom, fall
 /// back to the default pick so the behavior degrades identically to today.
@@ -148,11 +148,9 @@ fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Op
     scored
         .iter()
         .min_by(|a, b| {
-            a.bills_credits.cmp(&b.bills_credits).then(
-                a.score
-                    .partial_cmp(&b.score)
-                    .unwrap_or(std::cmp::Ordering::Equal),
-            )
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
         })
         .filter(|candidate| candidate.score < f64::MAX)
         .map(|candidate| candidate.alias.as_str())
@@ -462,6 +460,17 @@ mod tests {
             selection_candidate("b", false, 60.0, 1000),
         ];
         assert_eq!(select_most_available(&scored, false), Some("a"));
+    }
+
+    #[test]
+    fn legacy_selection_picks_most_headroom_even_when_it_bills() {
+        // `CODEXCTL_SELECT=most-available` is the explicit legacy opt-out from
+        // reset-aware selection; it must preserve pure most-headroom ordering.
+        let scored = vec![
+            selection_candidate("billing", true, 20.0, 1000),
+            selection_candidate("no-bill", false, 60.0, 2000),
+        ];
+        assert_eq!(select_most_available(&scored, false), Some("billing"));
     }
 
     #[test]

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -55,12 +55,18 @@ fn find_most_available_excluding(excluded_alias: Option<&str>) -> Result<String>
     }
 
     let usages = fetch_usages(&profiles)?;
-    let scored: Vec<(String, f64, i64)> = usages
+    let scored: Vec<SelectionCandidate> = usages
         .iter()
         .map(|(alias, usage)| {
             let score = usage.as_ref().map_or(f64::MAX, selection_score);
+            let bills_credits = usage.as_ref().is_none_or(selection_bills_credits);
             let reset = usage.as_ref().map_or(i64::MAX, secondary_reset_ts);
-            (alias.clone(), score, reset)
+            SelectionCandidate {
+                alias: alias.clone(),
+                bills_credits,
+                score,
+                secondary_reset_ts: reset,
+            }
         })
         .collect();
 
@@ -103,31 +109,53 @@ fn secondary_reset_ts(usage: &api::RateLimitResponse) -> i64 {
         .unwrap_or(i64::MAX)
 }
 
-/// Pick the most-available alias from `(alias, score, reset_ts)` tuples.
+#[derive(Debug, Clone)]
+struct SelectionCandidate {
+    alias: String,
+    /// True when overage is open (spend cap NOT reached), so this account can
+    /// draw credits once it crosses the hard rate-limit windows.
+    bills_credits: bool,
+    score: f64,
+    secondary_reset_ts: i64,
+}
+
+/// Pick the most-available alias from scored candidates.
 ///
 /// Default (`reset_aware == false`): lowest `selection_score` (most headroom),
-/// exactly as before. Reset-aware: among accounts with usable headroom
-/// (`score < RATE_LIMIT_EXHAUSTED`) pick the soonest 7d reset, breaking ties by
-/// most headroom; if none have headroom, fall back to the default pick so the
-/// behavior degrades identically to today.
-fn select_most_available(scored: &[(String, f64, i64)], reset_aware: bool) -> Option<&str> {
+/// after no-bill accounts. Reset-aware: among accounts with usable headroom
+/// (`score < RATE_LIMIT_EXHAUSTED`) pick no-bill accounts first, then the
+/// soonest 7d reset, breaking ties by most headroom; if none have headroom, fall
+/// back to the default pick so the behavior degrades identically to today.
+fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Option<&str> {
     if reset_aware {
         let staggered = scored
             .iter()
-            .filter(|(_, score, _)| *score < RATE_LIMIT_EXHAUSTED)
+            .filter(|candidate| candidate.score < RATE_LIMIT_EXHAUSTED)
             .min_by(|a, b| {
-                a.2.cmp(&b.2)
-                    .then(a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                a.bills_credits
+                    .cmp(&b.bills_credits)
+                    .then(a.secondary_reset_ts.cmp(&b.secondary_reset_ts))
+                    .then(
+                        a.score
+                            .partial_cmp(&b.score)
+                            .unwrap_or(std::cmp::Ordering::Equal),
+                    )
             });
-        if let Some((alias, _, _)) = staggered {
-            return Some(alias.as_str());
+        if let Some(candidate) = staggered {
+            return Some(candidate.alias.as_str());
         }
     }
     scored
         .iter()
-        .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .filter(|(_, score, _)| *score < f64::MAX)
-        .map(|(alias, _, _)| alias.as_str())
+        .min_by(|a, b| {
+            a.bills_credits.cmp(&b.bills_credits).then(
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+        })
+        .filter(|candidate| candidate.score < f64::MAX)
+        .map(|candidate| candidate.alias.as_str())
 }
 
 fn selection_score(usage: &api::RateLimitResponse) -> f64 {
@@ -245,6 +273,10 @@ fn rate_limit_score(usage: &api::RateLimitResponse) -> f64 {
     }
 }
 
+fn selection_bills_credits(usage: &api::RateLimitResponse) -> bool {
+    !usage.spend_control.as_ref().is_some_and(|s| s.reached)
+}
+
 fn fetch_usages(
     profiles: &[profile::Profile],
 ) -> Result<Vec<(String, Option<api::RateLimitResponse>)>> {
@@ -344,6 +376,20 @@ mod tests {
         }
     }
 
+    fn selection_candidate(
+        alias: &str,
+        bills_credits: bool,
+        score: f64,
+        secondary_reset_ts: i64,
+    ) -> SelectionCandidate {
+        SelectionCandidate {
+            alias: alias.to_string(),
+            bills_credits,
+            score,
+            secondary_reset_ts,
+        }
+    }
+
     #[test]
     fn profiles_after_excluding_removes_failed_active_alias() {
         let profiles = vec![test_profile("failed@test"), test_profile("next@test")];
@@ -411,7 +457,10 @@ mod tests {
     #[test]
     fn default_selection_picks_most_headroom_ignoring_reset() {
         // a has more headroom (lower score) but a later reset than b.
-        let scored = vec![("a".to_string(), 20.0, 2000), ("b".to_string(), 60.0, 1000)];
+        let scored = vec![
+            selection_candidate("a", false, 20.0, 2000),
+            selection_candidate("b", false, 60.0, 1000),
+        ];
         assert_eq!(select_most_available(&scored, false), Some("a"));
     }
 
@@ -419,8 +468,36 @@ mod tests {
     fn reset_aware_prefers_soonest_7d_reset_among_headroom() {
         // Same accounts; reset-aware drains the soonest-resetting one first even
         // though it has less headroom — this is what de-synchronizes the fleet.
-        let scored = vec![("a".to_string(), 20.0, 2000), ("b".to_string(), 60.0, 1000)];
+        let scored = vec![
+            selection_candidate("a", false, 20.0, 2000),
+            selection_candidate("b", false, 60.0, 1000),
+        ];
         assert_eq!(select_most_available(&scored, true), Some("b"));
+    }
+
+    #[test]
+    fn reset_aware_selection_prefers_no_bill_before_billing() {
+        // Plain `codexctl use` must keep the same billing guard as recovery:
+        // a credit-billing account with an earlier reset must not beat a
+        // no-bill account that still has usable headroom.
+        let billing = team_response(5.0, 10.0, false);
+        let no_bill = team_response(20.0, 30.0, true);
+        let scored = vec![
+            selection_candidate(
+                "billing",
+                selection_bills_credits(&billing),
+                selection_score(&billing),
+                secondary_reset_ts(&billing),
+            ),
+            selection_candidate(
+                "no-bill",
+                selection_bills_credits(&no_bill),
+                selection_score(&no_bill),
+                secondary_reset_ts(&no_bill),
+            ),
+        ];
+
+        assert_eq!(select_most_available(&scored, true), Some("no-bill"));
     }
 
     #[test]
@@ -428,8 +505,8 @@ mod tests {
         // Both windows exhausted (score >= RATE_LIMIT_EXHAUSTED): reset-aware must
         // NOT pick by reset, it falls back to the default lowest-score pick.
         let scored = vec![
-            ("a".to_string(), 700.0, 2000),
-            ("b".to_string(), 550.0, 1000),
+            selection_candidate("a", false, 700.0, 2000),
+            selection_candidate("b", false, 550.0, 1000),
         ];
         assert_eq!(select_most_available(&scored, true), Some("b"));
     }
@@ -437,7 +514,7 @@ mod tests {
     #[test]
     fn select_most_available_skips_usage_based_in_both_modes() {
         // Usage-based -> score f64::MAX -> never usable.
-        let scored = vec![("u".to_string(), f64::MAX, 100)];
+        let scored = vec![selection_candidate("u", false, f64::MAX, 100)];
         assert_eq!(select_most_available(&scored, true), None);
         assert_eq!(select_most_available(&scored, false), None);
     }


### PR DESCRIPTION
Fixes no-arg `codexctl use` selecting credit-billing accounts ahead of no-bill accounts during reset-aware selection.

Description
- Carry billing/no-bill classification through plain auto-selection.
- Sort no-bill accounts ahead of credit-billing accounts, then apply reset-aware ordering.
- Bump package version to `0.1.14` for release.

Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`
- `cargo test --all-targets`
- `trunk check --ci`
- `cargo build --release`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auto-selection in `codexctl use` to prefer no‑bill accounts in reset‑aware mode while preserving legacy headroom‑only selection. Released in `codexctl` `0.1.14`.

- **Bug Fixes**
  - Reset‑aware selection now orders: no‑bill first → earliest 7d reset → most headroom; falls back to headroom when none have usable headroom.
  - Legacy `most-available` mode remains pure most‑headroom, even if the pick bills credits.

- **Dependencies**
  - Bump package version to `0.1.14`.

<sup>Written for commit c29d08e238d25c62c0e18650f9efc0171a7cc010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

