### PR TITLE
feat(resets): manage banked rate-limit resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ codexctl resets                     # what every account holds, and when it expi
 codexctl reset                      # redeem one for the active account
 codexctl reset amir+5@sawmills.ai   # ...or for a specific one
 codexctl reset --yes                # skip the confirmation (unattended)
+codexctl resets --claim             # redeem everything about to lapse
+codexctl resets --claim --within-days 7 --yes
 ```
 
 ```text
@@ -167,11 +169,18 @@ A reset only clears an *already-exhausted* window — the backend reports zero r
 until an account actually hits 100%, and codexctl refuses to redeem before that rather than waste
 one. When several credits qualify, it always spends the one closest to expiring.
 
+`--claim` sweeps the whole fleet and redeems credits that are about to lapse (default: within three
+days) on accounts that are already at 100%. Those credits are the ones with nothing left to lose:
+the account cannot be used right now anyway, and the credit is about to evaporate. Note the flip
+side — a credit on an account that is *not* yet at 100% cannot be rescued at all, since the backend
+will not apply a reset to a window that has nothing to clear.
+
 ### Reset-aware recovery
 
-`codexctl codex` folds banked resets into its recovery ladder, cheapest option first:
+Both `codexctl use` (no alias) and `codexctl codex` recovery pick accounts from one cost-ranked
+ladder, cheapest option first:
 
-1. A no-bill account that still has rate-limit headroom — switched to silently, as before.
+1. A no-bill account that still has rate-limit headroom — used silently, as before.
 2. A banked reset whose credit would **expire before its window resets anyway** — redeemed without
    prompting, since holding it back cannot pay off.
 3. A banked reset worth keeping — asks for confirmation, or pass `--allow-resets`.
@@ -181,9 +190,14 @@ Resets rank ahead of credit-billing accounts because they cost no money. `--allo
 **not** imply permission to spend resets; each is approved separately.
 
 ```bash
-codexctl codex --allow-resets -- "start prompt"                   # unattended: may spend resets
+codexctl use --allow-resets                                       # unattended: may spend resets
+codexctl codex --allow-resets -- "start prompt"
 codexctl codex --allow-resets --allow-billing -- "start prompt"   # ...and may spend credits
 ```
+
+So when every account is exhausted, `codexctl use` redeems a reset and hands back an account that
+actually works, instead of a seat sitting at 100%. Passing an explicit alias never redeems — use
+`codexctl reset <alias>` to spend a credit on a named account.
 
 ### Other commands
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Usage-Based Accounts
 Sorted by availability — most available accounts first. All accounts are fetched live in parallel.
 The account column is the saved profile alias, with `*` marking the active account.
 
+The `Resets` column shows banked rate-limit resets (see [Banked resets](#banked-resets)):
+`3 (2 now)` means three are held and two can be redeemed this second; a bare count turns red when
+a credit lapses within three days.
+
 The `Token` column shows how long the stored access token is good for **without re-logging in**
 (green = days left, yellow = hours, red = under an hour). An `invalidated` value means OpenAI revoked
 the grant server-side even though the token has not yet timed out — this happens when another seat
@@ -137,6 +141,50 @@ CODEXCTL_SELECT=most-available codexctl codex -- "..."
 export CODEXCTL_SELECT=most-available   # alias: headroom / legacy
 ```
 
+### Banked resets
+
+OpenAI grants **banked rate-limit resets**: credits that clear an exhausted usage window on demand
+instead of waiting for it to lapse. They are per-account, expire ~30 days after they are granted,
+and are not refundable — so codexctl treats them as scarce.
+
+```bash
+codexctl resets                     # what every account holds, and when it expires
+codexctl reset                      # redeem one for the active account
+codexctl reset amir+5@sawmills.ai   # ...or for a specific one
+codexctl reset --yes                # skip the confirmation (unattended)
+```
+
+```text
+┌─────────────────────┬────────┬────────────┬────────────────────────┐
+│ Account             ┆ Banked ┆ Redeemable ┆ Expiries               │
+╞═════════════════════╪════════╪════════════╪════════════════════════╡
+│ amir+p3@sawmills.ai ┆ 2      ┆ 2          ┆ Jul 31, Aug 12         │
+│ * amir@sawmills.ai  ┆ 3      ┆ 0          ┆ Jul 26, Jul 31, Aug 12 │
+└─────────────────────┴────────┴────────────┴────────────────────────┘
+```
+
+A reset only clears an *already-exhausted* window — the backend reports zero redeemable credits
+until an account actually hits 100%, and codexctl refuses to redeem before that rather than waste
+one. When several credits qualify, it always spends the one closest to expiring.
+
+### Reset-aware recovery
+
+`codexctl codex` folds banked resets into its recovery ladder, cheapest option first:
+
+1. A no-bill account that still has rate-limit headroom — switched to silently, as before.
+2. A banked reset whose credit would **expire before its window resets anyway** — redeemed without
+   prompting, since holding it back cannot pay off.
+3. A banked reset worth keeping — asks for confirmation, or pass `--allow-resets`.
+4. A credit-billing account — asks for confirmation, or pass `--allow-billing`.
+
+Resets rank ahead of credit-billing accounts because they cost no money. `--allow-billing` does
+**not** imply permission to spend resets; each is approved separately.
+
+```bash
+codexctl codex --allow-resets -- "start prompt"                   # unattended: may spend resets
+codexctl codex --allow-resets --allow-billing -- "start prompt"   # ...and may spend credits
+```
+
 ### Other commands
 
 ```bash
@@ -144,6 +192,8 @@ codexctl list          # list saved profiles
 codexctl login <alias> # isolated Codex login and save
 codexctl whoami        # show active account
 codexctl codex -- ...  # run Codex with spend-cap recovery
+codexctl resets        # list banked rate-limit resets
+codexctl reset [alias] # redeem a banked reset
 codexctl remove <alias>
 ```
 
@@ -168,7 +218,13 @@ Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a cop
 
 Rate limits are fetched from `chatgpt.com/backend-api/wham/usage` using the stored access tokens.
 When an account ID is available, codexctl sends it as `chatgpt-account-id` so the usage response is
-scoped to the intended account/workspace.
+scoped to the intended account/workspace. Windows are matched by their declared duration rather
+than by position, since plans that publish only a weekly limit return it in the `primary_window`
+slot.
+
+Banked resets use `wham/rate-limit-reset-credits` to list credits and
+`wham/rate-limit-reset-credits/consume` to redeem one. Redemptions carry a client-generated
+idempotency key, so retrying a timed-out request never spends a second credit.
 
 Supports both Codex CLI auth formats:
 

--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ codexctl resets --claim --within-days 7 --yes
 └─────────────────────┴────────┴────────────┴────────────────────────┘
 ```
 
-A reset only clears an *already-exhausted* window — the backend reports zero redeemable credits
+A reset only clears an _already-exhausted_ window — the backend reports zero redeemable credits
 until an account actually hits 100%, and codexctl refuses to redeem before that rather than waste
 one. When several credits qualify, it always spends the one closest to expiring.
 
 `--claim` sweeps the whole fleet and redeems credits that are about to lapse (default: within three
 days) on accounts that are already at 100%. Those credits are the ones with nothing left to lose:
 the account cannot be used right now anyway, and the credit is about to evaporate. Note the flip
-side — a credit on an account that is *not* yet at 100% cannot be rescued at all, since the backend
+side — a credit on an account that is _not_ yet at 100% cannot be rescued at all, since the backend
 will not apply a reset to a window that has nothing to clear.
 
 ### Reset-aware recovery

--- a/src/api.rs
+++ b/src/api.rs
@@ -35,6 +35,26 @@ pub struct RateLimitResponse {
     pub rate_limit: Option<RateLimit>,
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
+    /// Banked rate-limit reset credits, when the plan has any.
+    pub rate_limit_reset_credits: Option<ResetCreditsSummary>,
+}
+
+impl RateLimitResponse {
+    /// How many banked resets are held, redeemable or not.
+    pub fn reset_credits_available(&self) -> i64 {
+        self.rate_limit_reset_credits
+            .as_ref()
+            .map_or(0, |c| c.available_count)
+    }
+
+    /// How many banked resets can be redeemed *right now*. The backend only
+    /// counts a credit as applicable once a window is actually exhausted, so
+    /// this is the authoritative "would a redeem do anything" signal.
+    pub fn reset_credits_applicable(&self) -> i64 {
+        self.rate_limit_reset_credits
+            .as_ref()
+            .map_or(0, |c| c.applicable_available_count)
+    }
 }
 
 #[derive(Deserialize)]
@@ -46,12 +66,50 @@ pub struct RateLimit {
     pub secondary_window: Option<RateLimitWindow>,
 }
 
+/// Windows at or under this duration are the short (5h) window; longer ones are
+/// the long (7d) window.
+const SHORT_WINDOW_MAX_SECONDS: u64 = 24 * 60 * 60;
+
 impl RateLimit {
-    pub fn primary(&self) -> Option<&RateLimitWindow> {
+    fn first(&self) -> Option<&RateLimitWindow> {
         self.primary.as_ref().or(self.primary_window.as_ref())
     }
-    pub fn secondary(&self) -> Option<&RateLimitWindow> {
+
+    fn second(&self) -> Option<&RateLimitWindow> {
         self.secondary.as_ref().or(self.secondary_window.as_ref())
+    }
+
+    /// The short (5h) window.
+    ///
+    /// Windows are matched by their declared duration rather than by position:
+    /// plans that no longer publish a 5h window return their weekly window in
+    /// the `primary_window` slot, and reading that positionally would report a
+    /// weekly limit as a 5h one. Windows with no declared duration fall back to
+    /// the historical positional reading.
+    pub fn short_window(&self) -> Option<&RateLimitWindow> {
+        self.window_matching(|seconds| seconds <= SHORT_WINDOW_MAX_SECONDS, Self::first)
+    }
+
+    /// The long (7d) window. See [`RateLimit::short_window`] for how windows are
+    /// matched.
+    pub fn long_window(&self) -> Option<&RateLimitWindow> {
+        self.window_matching(|seconds| seconds > SHORT_WINDOW_MAX_SECONDS, Self::second)
+    }
+
+    fn window_matching(
+        &self,
+        matches: impl Fn(u64) -> bool,
+        positional: impl Fn(&Self) -> Option<&RateLimitWindow>,
+    ) -> Option<&RateLimitWindow> {
+        for window in [self.first(), self.second()].into_iter().flatten() {
+            if window.duration_seconds().is_some_and(&matches) {
+                return Some(window);
+            }
+        }
+        // Nothing declares a duration in this class. Fall back to the historical
+        // positional reading only when that window's duration is unknown, so a
+        // response that does publish durations is never misread.
+        positional(self).filter(|w| w.duration_seconds().is_none())
     }
 }
 
@@ -76,6 +134,168 @@ impl RateLimitWindow {
                 .map(|s| chrono::Utc::now().timestamp() + s)
         })
     }
+
+    /// How long this window spans, from whichever field the API published.
+    pub fn duration_seconds(&self) -> Option<u64> {
+        self.limit_window_seconds
+            .or_else(|| self.window_minutes.map(|m| m * 60))
+    }
+}
+
+/// Banked rate-limit reset credits, as summarized on the usage response.
+#[derive(Deserialize)]
+pub struct ResetCreditsSummary {
+    pub available_count: i64,
+    /// Credits redeemable right now. The backend reports this as zero until a
+    /// rate-limit window is actually exhausted — there is nothing to reset
+    /// before that, and redeeming would waste the credit.
+    #[serde(default)]
+    pub applicable_available_count: i64,
+}
+
+#[derive(Deserialize)]
+pub struct ResetCreditsDetails {
+    #[serde(default)]
+    pub credits: Vec<ResetCredit>,
+    #[serde(default)]
+    pub available_count: i64,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ResetCredit {
+    pub id: String,
+    pub status: String,
+    #[allow(dead_code)]
+    pub reset_type: Option<String>,
+    #[allow(dead_code)]
+    pub granted_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub title: Option<String>,
+    #[allow(dead_code)]
+    pub description: Option<String>,
+}
+
+impl ResetCredit {
+    /// Only `available` credits can be redeemed; the rest are already spent,
+    /// in flight, or cooling down.
+    pub fn is_available(&self) -> bool {
+        self.status == "available"
+    }
+
+    pub fn expires_at_timestamp(&self) -> Option<i64> {
+        parse_rfc3339(self.expires_at.as_deref()?)
+    }
+}
+
+fn parse_rfc3339(value: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+/// Outcome of redeeming a banked reset.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumeResetCode {
+    /// The credit was spent and the window(s) cleared.
+    Reset,
+    /// No exhausted window to clear, so no credit was spent.
+    NothingToReset,
+    /// The account holds no redeemable credit.
+    NoCredit,
+    /// This redemption request was already applied.
+    AlreadyRedeemed,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+pub struct ConsumeResetResponse {
+    pub code: ConsumeResetCode,
+    #[serde(default)]
+    pub windows_reset: i64,
+}
+
+const RESET_CREDITS_URL: &str = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+
+pub async fn fetch_reset_credits_async(
+    client: &reqwest::Client,
+    access_token: &str,
+    account_id: Option<&str>,
+) -> Result<ResetCreditsDetails> {
+    let mut request = client.get(RESET_CREDITS_URL).bearer_auth(access_token);
+    if let Some(account_id) = account_id {
+        request = request.header("chatgpt-account-id", account_id);
+    }
+
+    let resp = request
+        .send()
+        .await
+        .context("failed to reach reset credits API")?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("expired");
+    }
+    if !status.is_success() {
+        anyhow::bail!("reset credits API returned {status}");
+    }
+
+    resp.json::<ResetCreditsDetails>()
+        .await
+        .context("failed to parse reset credits response")
+}
+
+/// Redeem one banked reset, clearing the account's exhausted rate-limit window.
+///
+/// `redeem_request_id` is the idempotency key: retrying a timed-out redemption
+/// with the same key returns `AlreadyRedeemed` instead of spending a second
+/// credit, so callers must reuse it across retries of the *same* redemption.
+pub async fn consume_reset_credit_async(
+    client: &reqwest::Client,
+    access_token: &str,
+    account_id: Option<&str>,
+    redeem_request_id: &str,
+    credit_id: Option<&str>,
+) -> Result<ConsumeResetResponse> {
+    let mut body = serde_json::json!({ "redeem_request_id": redeem_request_id });
+    if let Some(credit_id) = credit_id {
+        body["credit_id"] = serde_json::Value::String(credit_id.to_string());
+    }
+
+    let mut request = client
+        .post(format!("{RESET_CREDITS_URL}/consume"))
+        .bearer_auth(access_token)
+        .json(&body);
+    if let Some(account_id) = account_id {
+        request = request.header("chatgpt-account-id", account_id);
+    }
+
+    let resp = request
+        .send()
+        .await
+        .context("failed to reach reset credits API")?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("expired");
+    }
+    if !status.is_success() {
+        anyhow::bail!("reset credits API returned {status}");
+    }
+
+    resp.json::<ConsumeResetResponse>()
+        .await
+        .context("failed to parse reset redemption response")
+}
+
+/// A unique idempotency key for one redemption attempt.
+pub fn new_redeem_request_id(alias: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("codexctl-{alias}-{nanos}")
 }
 
 #[derive(Deserialize)]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -13,6 +13,8 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifier
 use crossterm::terminal;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
+use crate::api;
+use crate::commands::resets;
 use crate::commands::use_profile;
 use crate::config::{self, Paths};
 use crate::profile;
@@ -22,14 +24,22 @@ const SELF_MANAGED_SPEND_CAP_MESSAGE: &str =
     "You hit your spend cap set in your workspace. Increase your spend cap to continue.";
 pub const DEFAULT_RECOVERY_PROMPT: &str = "Continue the previous request.";
 
-pub fn run(args: &[String], recovery_prompt: &str, allow_billing: bool) -> Result<i32> {
+pub fn run(
+    args: &[String],
+    recovery_prompt: &str,
+    allow_billing: bool,
+    allow_resets: bool,
+) -> Result<i32> {
     let paths = config::default_paths()?;
     let mut reporter = HerdrAgentReporter::from_env();
     let mut runner = PtyCodexRunner::new(reporter.clone());
     let failed_alias = failed_alias_for_child_auth(&paths);
     let mut switcher = CodexctlProfileSwitcher::new(&paths);
     let mut sessions = FilesystemSessionStore::new(&paths)?;
-    let mut consent = InteractiveConsent { allow_billing };
+    let mut consent = InteractiveConsent {
+        allow_billing,
+        allow_resets,
+    };
     let cwd = std::env::current_dir().context("failed to get current directory")?;
     let options = WrapperOptions::new(args.to_vec(), recovery_prompt.to_string(), cwd);
     // The account that hit the cap is already active; never switch back to it.
@@ -64,12 +74,17 @@ trait ProfileSwitcher {
 
     /// Switch the child Codex auth to `alias`.
     fn switch_to(&mut self, alias: &str) -> Result<()>;
+
+    /// Redeem `alias`'s banked reset so its exhausted window clears.
+    fn redeem_reset(&mut self, alias: &str, plan: &use_profile::ResetPlan) -> Result<()>;
 }
 
-/// Decides whether spend-cap recovery may switch to a credit-billing account
-/// (one whose overage is open, so it draws credits past 100%).
+/// Decides whether recovery may spend something the user cares about: credits
+/// ($) on an overage-open account, or one of a scarce pool of banked resets.
 trait RecoveryConsent {
     fn allow_billing_account(&mut self, alias: &str) -> bool;
+
+    fn allow_reset_credit(&mut self, alias: &str, plan: &use_profile::ResetPlan) -> bool;
 }
 
 trait SessionStore {
@@ -219,8 +234,24 @@ fn run_with_reporter_inner(
                             candidate.alias
                         );
                     }
-                } else {
+                } else if candidate.reset_plan().is_none() {
                     eprintln!("codexctl: spend cap detected; switching to a no-overage account");
+                }
+
+                // Every account with headroom is spoken for, so the cheapest way
+                // forward is to spend a banked reset on an exhausted one.
+                if let Some(plan) = candidate.reset_plan() {
+                    eprintln!(
+                        "codexctl: no account has rate-limit headroom left; {} can redeem a banked reset.",
+                        candidate.alias
+                    );
+                    if !consent.allow_reset_credit(&candidate.alias, plan) {
+                        bail!(
+                            "spend cap reached; redeeming a banked reset for {} was not approved",
+                            candidate.alias
+                        );
+                    }
+                    switcher.redeem_reset(&candidate.alias, plan)?;
                 }
 
                 switcher.switch_to(&candidate.alias)?;
@@ -792,15 +823,40 @@ impl ProfileSwitcher for CodexctlProfileSwitcher {
         eprintln!("codexctl: switched to {alias} ({email})");
         Ok(())
     }
+
+    fn redeem_reset(&mut self, alias: &str, plan: &use_profile::ResetPlan) -> Result<()> {
+        let response = resets::redeem(alias, plan.credit_id.as_deref())?;
+        resets::report_outcome(alias, &response);
+        if response.code != api::ConsumeResetCode::Reset {
+            bail!("redeeming a banked reset for {alias} did not clear its rate limit");
+        }
+        // Let the cleared window land before Codex restarts against it.
+        resets::settle_after_redeem(alias);
+        Ok(())
+    }
 }
 
 struct InteractiveConsent {
     /// Set by `--allow-billing`: approve credit-billing accounts without asking,
     /// for unattended runs.
     allow_billing: bool,
+    /// Set by `--allow-resets`: approve spending banked resets without asking.
+    allow_resets: bool,
 }
 
 impl RecoveryConsent for InteractiveConsent {
+    fn allow_reset_credit(&mut self, alias: &str, plan: &use_profile::ResetPlan) -> bool {
+        // The same policy `codexctl use` applies, reported on stderr so it does
+        // not land in the wrapped Codex output.
+        resets::approve_redemption(
+            alias,
+            plan.expires_at,
+            plan.expires_unused,
+            self.allow_resets,
+            &mut std::io::stderr(),
+        )
+    }
+
     fn allow_billing_account(&mut self, alias: &str) -> bool {
         if self.allow_billing {
             eprintln!("codexctl: --allow-billing set; switching to {alias} (may use credits)");
@@ -2989,6 +3045,7 @@ mod tests {
         use_profile::RecoveryCandidate {
             alias: alias.to_string(),
             bills_credits: false,
+            cost: use_profile::RecoveryCost::Headroom,
         }
     }
 
@@ -2996,6 +3053,20 @@ mod tests {
         use_profile::RecoveryCandidate {
             alias: alias.to_string(),
             bills_credits: true,
+            cost: use_profile::RecoveryCost::Headroom,
+        }
+    }
+
+    /// An exhausted account that only a banked reset can bring back.
+    fn needs_reset(alias: &str, expires_unused: bool) -> use_profile::RecoveryCandidate {
+        use_profile::RecoveryCandidate {
+            alias: alias.to_string(),
+            bills_credits: false,
+            cost: use_profile::RecoveryCost::ResetCredit(use_profile::ResetPlan {
+                credit_id: Some(format!("credit-{alias}")),
+                expires_at: None,
+                expires_unused,
+            }),
         }
     }
 
@@ -3066,7 +3137,7 @@ mod tests {
         let mut sessions = FakeSessionStore::default();
         let mut consent = RecordingConsent {
             allow: false,
-            asked: Vec::new(),
+            ..Default::default()
         };
 
         let result = run_with_consent(
@@ -3100,7 +3171,7 @@ mod tests {
         let mut sessions = FakeSessionStore::default();
         let mut consent = RecordingConsent {
             allow: true,
-            asked: Vec::new(),
+            ..Default::default()
         };
 
         let exit = run_with_consent(
@@ -3134,7 +3205,7 @@ mod tests {
         let mut sessions = FakeSessionStore::default();
         let mut consent = RecordingConsent {
             allow: true,
-            asked: Vec::new(),
+            ..Default::default()
         };
 
         let exit = run_with_consent(
@@ -3152,6 +3223,101 @@ mod tests {
         assert_eq!(
             switcher.switched,
             vec!["amir+2".to_string(), "amir@sawmills.ai".to_string()]
+        );
+    }
+
+    #[test]
+    fn recovery_redeems_a_banked_reset_when_no_account_has_headroom() {
+        // Every account is exhausted; the only way forward is to spend a reset.
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(SESSION_ID.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher = FakeProfileSwitcher::new(vec![needs_reset("amir+3", false)]);
+        let mut sessions = FakeSessionStore::default();
+        let mut consent = RecordingConsent {
+            allow: true,
+            ..Default::default()
+        };
+
+        let exit = run_with_consent(
+            &resume_options(),
+            &mut runner,
+            &mut switcher,
+            &mut sessions,
+            &mut consent,
+        )
+        .unwrap();
+
+        assert_eq!(exit, 0);
+        assert_eq!(consent.asked_resets, vec!["amir+3".to_string()]);
+        assert_eq!(switcher.redeemed, vec!["amir+3".to_string()]);
+        assert_eq!(switcher.switched, vec!["amir+3".to_string()]);
+        assert!(
+            consent.asked.is_empty(),
+            "redeeming a reset must not be confused with billing consent"
+        );
+    }
+
+    #[test]
+    fn recovery_does_not_redeem_a_reset_without_approval() {
+        let mut runner = FakeCodexRunner::new(vec![CodexRunOutcome::SpendCap {
+            session_id: Some(SESSION_ID.to_string()),
+        }]);
+        let mut switcher = FakeProfileSwitcher::new(vec![needs_reset("amir+3", false)]);
+        let mut sessions = FakeSessionStore::default();
+        let mut consent = DenyBillingConsent;
+
+        let result = run_with_consent(
+            &resume_options(),
+            &mut runner,
+            &mut switcher,
+            &mut sessions,
+            &mut consent,
+        );
+
+        assert!(
+            result.is_err(),
+            "an unapproved redemption must stop recovery"
+        );
+        assert!(switcher.redeemed.is_empty(), "no credit may be spent");
+        assert!(switcher.switched.is_empty());
+    }
+
+    #[test]
+    fn recovery_switches_before_it_redeems_when_headroom_exists() {
+        // A reset costs a scarce credit, so an account that just works wins —
+        // the exhausted seat is only reached on the next spend cap.
+        let mut runner = FakeCodexRunner::new(vec![
+            CodexRunOutcome::SpendCap {
+                session_id: Some(SESSION_ID.to_string()),
+            },
+            CodexRunOutcome::Exited(0),
+        ]);
+        let mut switcher =
+            FakeProfileSwitcher::new(vec![no_bill("amir+2"), needs_reset("amir+3", false)]);
+        let mut sessions = FakeSessionStore::default();
+        let mut consent = RecordingConsent {
+            allow: true,
+            ..Default::default()
+        };
+
+        let exit = run_with_consent(
+            &resume_options(),
+            &mut runner,
+            &mut switcher,
+            &mut sessions,
+            &mut consent,
+        )
+        .unwrap();
+
+        assert_eq!(exit, 0);
+        assert_eq!(switcher.switched, vec!["amir+2".to_string()]);
+        assert!(
+            switcher.redeemed.is_empty(),
+            "no credit spent while headroom remains"
         );
     }
 
@@ -3182,8 +3348,56 @@ mod tests {
         // with no terminal to prompt on (unattended runs).
         let mut consent = InteractiveConsent {
             allow_billing: true,
+            allow_resets: false,
         };
         assert!(consent.allow_billing_account("amir@sawmills.ai"));
+    }
+
+    #[test]
+    fn allow_resets_flag_approves_without_prompting() {
+        let mut consent = InteractiveConsent {
+            allow_billing: false,
+            allow_resets: true,
+        };
+        assert!(consent.allow_reset_credit("amir@sawmills.ai", &bankable_plan()));
+    }
+
+    #[test]
+    fn banked_reset_needs_approval_without_the_flag() {
+        // No flag and no terminal to prompt on: a scarce credit must not be
+        // spent behind the user's back.
+        let mut consent = InteractiveConsent {
+            allow_billing: true,
+            allow_resets: false,
+        };
+        assert!(
+            !consent.allow_reset_credit("amir@sawmills.ai", &bankable_plan()),
+            "--allow-billing must not imply permission to spend banked resets"
+        );
+    }
+
+    #[test]
+    fn lapsing_reset_is_redeemed_without_approval() {
+        // The credit expires before its window resets, so holding it back
+        // cannot pay off — there is nothing for the user to weigh.
+        let mut consent = InteractiveConsent {
+            allow_billing: false,
+            allow_resets: false,
+        };
+        let plan = use_profile::ResetPlan {
+            credit_id: Some("credit-1".to_string()),
+            expires_at: None,
+            expires_unused: true,
+        };
+        assert!(consent.allow_reset_credit("amir@sawmills.ai", &plan));
+    }
+
+    fn bankable_plan() -> use_profile::ResetPlan {
+        use_profile::ResetPlan {
+            credit_id: Some("credit-1".to_string()),
+            expires_at: None,
+            expires_unused: false,
+        }
     }
 
     fn write_session_file(path: &std::path::Path, session_id: &str, cwd: &str) {
@@ -3372,6 +3586,7 @@ mod tests {
     struct FakeProfileSwitcher {
         candidates: Vec<use_profile::RecoveryCandidate>,
         switched: Vec<String>,
+        redeemed: Vec<String>,
     }
 
     impl FakeProfileSwitcher {
@@ -3379,16 +3594,14 @@ mod tests {
             Self {
                 candidates,
                 switched: Vec::new(),
+                redeemed: Vec::new(),
             }
         }
     }
 
     impl Default for FakeProfileSwitcher {
         fn default() -> Self {
-            Self::new(vec![use_profile::RecoveryCandidate {
-                alias: "next@test".to_string(),
-                bills_credits: false,
-            }])
+            Self::new(vec![no_bill("next@test")])
         }
     }
 
@@ -3408,6 +3621,15 @@ mod tests {
             self.switched.push(alias.to_string());
             Ok(())
         }
+
+        fn redeem_reset(
+            &mut self,
+            alias: &str,
+            _plan: &use_profile::ResetPlan,
+        ) -> anyhow::Result<()> {
+            self.redeemed.push(alias.to_string());
+            Ok(())
+        }
     }
 
     pub(super) struct DenyBillingConsent;
@@ -3416,17 +3638,27 @@ mod tests {
         fn allow_billing_account(&mut self, _alias: &str) -> bool {
             false
         }
+
+        fn allow_reset_credit(&mut self, _alias: &str, _plan: &use_profile::ResetPlan) -> bool {
+            false
+        }
     }
 
     #[derive(Default)]
     struct RecordingConsent {
         allow: bool,
         asked: Vec<String>,
+        asked_resets: Vec<String>,
     }
 
     impl RecoveryConsent for RecordingConsent {
         fn allow_billing_account(&mut self, alias: &str) -> bool {
             self.asked.push(alias.to_string());
+            self.allow
+        }
+
+        fn allow_reset_credit(&mut self, alias: &str, _plan: &use_profile::ResetPlan) -> bool {
+            self.asked_resets.push(alias.to_string());
             self.allow
         }
     }

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -37,6 +37,10 @@ _codexctl_profiles() {
             "':alias -- Profile alias to remove:_default'",
             "':alias -- Profile alias to remove:_codexctl_profiles'",
         );
+        script = script.replace(
+            "'::alias -- Profile alias to redeem for (defaults to the active account):_default'",
+            "'::alias -- Profile alias to redeem for (defaults to the active account):_codexctl_profiles'",
+        );
 
         // Insert profile function before the main _codexctl function
         print!("{profile_fn}{script}");
@@ -54,11 +58,12 @@ _codexctl_profiles() {
         println!(r#"}}"#);
         println!(r#"complete -F _codexctl_profiles codexctl use"#);
         println!(r#"complete -F _codexctl_profiles codexctl remove"#);
+        println!(r#"complete -F _codexctl_profiles codexctl reset"#);
     } else if shell == Shell::Fish {
         generate(shell, &mut cmd, name, &mut std::io::stdout());
         println!();
         println!(
-            r#"complete -c codexctl -n '__fish_seen_subcommand_from use remove' -xa '(ls ~/.codexctl/profiles/ 2>/dev/null)'"#
+            r#"complete -c codexctl -n '__fish_seen_subcommand_from use remove reset' -xa '(ls ~/.codexctl/profiles/ 2>/dev/null)'"#
         );
     } else {
         generate(shell, &mut cmd, name, &mut std::io::stdout());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod completions;
 pub mod list;
 pub mod login;
 pub mod remove;
+pub mod resets;
 pub mod save;
 pub mod status;
 pub mod switch;

--- a/src/commands/resets.rs
+++ b/src/commands/resets.rs
@@ -1,0 +1,603 @@
+//! Banked rate-limit resets: grants that clear an exhausted usage window on
+//! demand instead of waiting for it to lapse.
+//!
+//! Credits are scarce, per-account, and expire ~30 days after they are granted
+//! with no refund, so every redemption here is deliberate: codexctl only spends
+//! one when the backend reports it as applicable, and it always spends the
+//! credit closest to lapsing first.
+
+use anyhow::{Context, Result, bail};
+use comfy_table::{Cell, Color, Table, presets::UTF8_FULL_CONDENSED};
+
+use crate::api;
+use crate::commands::status;
+use crate::config;
+use crate::profile;
+
+/// `codexctl resets` — list banked resets across every saved profile.
+pub fn run_list() -> Result<()> {
+    let profiles = profile::list_profiles()?;
+    if profiles.is_empty() {
+        println!("no profiles saved. Use 'codexctl save' to save the current account.");
+        return Ok(());
+    }
+
+    let active = profile::get_active()?;
+    let rows = fetch_all(&profiles, &active)?;
+
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL_CONDENSED);
+    table.set_header(vec!["Account", "Banked", "Redeemable", "Expiries"]);
+    let mut total = 0;
+    let mut redeemable = 0;
+    for row in &rows {
+        total += row.available;
+        redeemable += row.applicable;
+        table.add_row(render_row(row));
+    }
+    println!("{table}");
+
+    println!();
+    println!("{total} banked, {redeemable} redeemable now.");
+    if redeemable > 0 {
+        println!("Redeem with `codexctl reset <alias>`.");
+    } else if total > 0 {
+        println!(
+            "A reset only applies to an exhausted window, so none can be redeemed until an\naccount hits 100%."
+        );
+    }
+
+    Ok(())
+}
+
+/// `codexctl resets --claim` — redeem every credit that is about to lapse.
+///
+/// A credit is only worth claiming when it is *applicable*: the account is
+/// already at 100%, so the reset buys back capacity that is unavailable right
+/// now. Combined with a near expiry, holding it back has almost no option value
+/// left — the alternative is watching it evaporate.
+pub fn run_claim(within_days: i64, assume_yes: bool) -> Result<()> {
+    let profiles = profile::list_profiles()?;
+    if profiles.is_empty() {
+        println!("no profiles saved. Use 'codexctl save' to save the current account.");
+        return Ok(());
+    }
+
+    let active = profile::get_active()?;
+    let rows = fetch_all(&profiles, &active)?;
+    let deadline = chrono::Utc::now().timestamp() + within_days * 24 * 60 * 60;
+
+    let mut claimable: Vec<(&ResetsRow, &api::ResetCredit)> = Vec::new();
+    for row in &rows {
+        if row.applicable <= 0 {
+            continue;
+        }
+        if let Some(credit) = row
+            .credits
+            .iter()
+            .filter(|c| c.is_available())
+            .filter(|c| c.expires_at_timestamp().is_some_and(|e| e <= deadline))
+            .min_by_key(|c| c.expires_at_timestamp().unwrap_or(i64::MAX))
+        {
+            claimable.push((row, credit));
+        }
+    }
+
+    if claimable.is_empty() {
+        println!("no banked resets lapse within {within_days} day(s) on an exhausted account.");
+        return Ok(());
+    }
+
+    println!(
+        "{} banked reset(s) lapse within {within_days} day(s) on accounts that are already at 100%:",
+        claimable.len()
+    );
+    for (row, credit) in &claimable {
+        println!(
+            "  {} — expires {}",
+            row.alias,
+            credit
+                .expires_at
+                .as_deref()
+                .map(format_date)
+                .unwrap_or_else(|| "-".to_string())
+        );
+    }
+    println!("Redeeming them is not refundable.");
+
+    if !assume_yes && !confirm("Redeem all of them?")? {
+        bail!("claim cancelled");
+    }
+
+    let mut redeemed = 0;
+    for (row, credit) in &claimable {
+        match redeem(&row.alias, Some(&credit.id)) {
+            Ok(response) => {
+                report_outcome(&row.alias, &response);
+                if response.code == api::ConsumeResetCode::Reset {
+                    redeemed += 1;
+                }
+            }
+            // One bad seat must not strand the rest of the sweep.
+            Err(e) => eprintln!("{}: redemption failed: {e:#}", row.alias),
+        }
+    }
+
+    println!();
+    println!("{redeemed} of {} redeemed.", claimable.len());
+    Ok(())
+}
+
+/// `codexctl reset [alias]` — redeem one banked reset.
+pub fn run_redeem(alias: Option<&str>, assume_yes: bool, credit_id: Option<&str>) -> Result<()> {
+    let alias = match alias {
+        Some(alias) => alias.to_string(),
+        None => profile::get_active()?
+            .context("no active profile; pass an alias: codexctl reset <alias>")?,
+    };
+    // Fail early on an unknown alias rather than after a round trip.
+    profile::get_profile(&alias)?;
+
+    let account = fetch_one(&alias, is_active(&alias)?)?;
+    if account.applicable <= 0 {
+        if account.available <= 0 {
+            bail!("{alias} has no banked resets to redeem");
+        }
+        bail!(
+            "{alias} has {} banked reset(s) but none apply right now — a reset only clears an \
+             already-exhausted window, so redeeming would waste one. Check `codexctl status`.",
+            account.available
+        );
+    }
+
+    let chosen = match credit_id {
+        Some(id) => {
+            let credit = account
+                .credits
+                .iter()
+                .find(|c| c.id == id)
+                .with_context(|| format!("{alias} has no reset credit {id}"))?;
+            if !credit.is_available() {
+                bail!(
+                    "reset credit {id} is not available (status: {})",
+                    credit.status
+                );
+            }
+            Some(credit.clone())
+        }
+        // Spend the credit closest to lapsing first.
+        None => account
+            .credits
+            .iter()
+            .filter(|c| c.is_available())
+            .min_by_key(|c| c.expires_at_timestamp().unwrap_or(i64::MAX))
+            .cloned(),
+    };
+
+    println!(
+        "{alias}: {} banked reset(s), {} redeemable now.",
+        account.available, account.applicable
+    );
+    if let Some(credit) = &chosen {
+        println!(
+            "Redeeming {}{}.",
+            credit.title.as_deref().unwrap_or("reset credit"),
+            match credit.expires_at.as_deref() {
+                Some(expiry) => format!(" (expires {})", format_date(expiry)),
+                None => String::new(),
+            }
+        );
+    }
+    println!("This is not refundable.");
+
+    if !assume_yes && !confirm(&format!("Redeem a banked reset for {alias}?"))? {
+        bail!("redemption cancelled");
+    }
+
+    let response = redeem(&alias, chosen.as_ref().map(|c| c.id.as_str()))?;
+    report_outcome(&alias, &response);
+
+    if response.code == api::ConsumeResetCode::Reset {
+        settle_after_redeem(&alias);
+        println!();
+        status::run_focused(&alias)?;
+    }
+
+    Ok(())
+}
+
+/// Redeem one banked reset for `alias`, spending `credit_id` when given.
+pub fn redeem(alias: &str, credit_id: Option<&str>) -> Result<api::ConsumeResetResponse> {
+    let auth = auth_for(alias, is_active(alias)?)?;
+    let request_id = api::new_redeem_request_id(alias);
+    let rt = tokio::runtime::Runtime::new()?;
+    let client = reqwest::Client::new();
+    rt.block_on(api::consume_reset_credit_async(
+        &client,
+        &auth.access_token,
+        auth.account_id.as_deref(),
+        &request_id,
+        credit_id,
+    ))
+}
+
+/// Decide whether to spend a banked reset for `alias`, reporting the reasoning
+/// to `out` (stdout for interactive commands, stderr for the Codex wrapper).
+///
+/// A credit that would lapse before its window resets anyway is approved with
+/// no prompt: holding it back cannot pay off, so there is nothing to weigh.
+/// Anything else needs `assume_yes` or a human on a terminal — a credit is
+/// scarce and non-refundable, so it is never spent unattended by default.
+pub fn approve_redemption(
+    alias: &str,
+    expires_at: Option<i64>,
+    expires_unused: bool,
+    assume_yes: bool,
+    out: &mut impl std::io::Write,
+) -> bool {
+    use std::io::IsTerminal;
+
+    if expires_unused {
+        let _ = writeln!(
+            out,
+            "codexctl: {alias}'s banked reset expires before its window resets; redeeming it now (it would otherwise lapse unused)"
+        );
+        return true;
+    }
+    if assume_yes {
+        let _ = writeln!(out, "codexctl: redeeming a banked reset for {alias}");
+        return true;
+    }
+    if !std::io::stdin().is_terminal() {
+        let _ = writeln!(
+            out,
+            "codexctl: not redeeming a banked reset for {alias} (no terminal to approve; pass --allow-resets to allow)"
+        );
+        return false;
+    }
+
+    let expiry = expires_at
+        .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+        .map(|dt| {
+            format!(
+                " (expires {})",
+                dt.with_timezone(&chrono::Local).format("%b %d")
+            )
+        })
+        .unwrap_or_default();
+    let _ = write!(
+        out,
+        "codexctl: redeem a banked reset for {alias}{expiry}? It is not refundable. [y/N] "
+    );
+    let _ = out.flush();
+
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+/// Wait, briefly, for a redemption to show up on the usage endpoint.
+///
+/// The consume call returns before `wham/usage` reflects the cleared window, so
+/// reading status immediately after a redeem reports the old 100% and makes a
+/// successful redemption look like it did nothing. Poll until the account stops
+/// reporting a redeemable credit — that flips only once the window is clear —
+/// and give up quietly, since this is cosmetic.
+pub fn settle_after_redeem(alias: &str) {
+    const ATTEMPTS: u32 = 6;
+    const DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+
+    let Ok(is_active) = is_active(alias) else {
+        return;
+    };
+    let Ok(auth) = auth_for(alias, is_active) else {
+        return;
+    };
+    let Ok(rt) = tokio::runtime::Runtime::new() else {
+        return;
+    };
+    let client = reqwest::Client::new();
+
+    for _ in 0..ATTEMPTS {
+        std::thread::sleep(DELAY);
+        let usage = rt.block_on(api::fetch_usage_async(
+            &client,
+            &auth.access_token,
+            auth.account_id.as_deref(),
+        ));
+        if let Ok(usage) = usage
+            && usage.reset_credits_applicable() == 0
+        {
+            return;
+        }
+    }
+}
+
+/// Print what the backend did with the redemption.
+pub fn report_outcome(alias: &str, response: &api::ConsumeResetResponse) {
+    match response.code {
+        api::ConsumeResetCode::Reset => {
+            let windows = response.windows_reset;
+            if windows > 0 {
+                println!("{alias}: reset redeemed — {windows} window(s) cleared.");
+            } else {
+                println!("{alias}: reset redeemed.");
+            }
+        }
+        api::ConsumeResetCode::NothingToReset => {
+            println!("{alias}: nothing to reset — no credit was spent.");
+        }
+        api::ConsumeResetCode::NoCredit => {
+            println!("{alias}: no banked reset available.");
+        }
+        api::ConsumeResetCode::AlreadyRedeemed => {
+            println!("{alias}: this redemption was already applied.");
+        }
+        api::ConsumeResetCode::Unknown => {
+            println!("{alias}: unrecognized redemption outcome.");
+        }
+    }
+}
+
+struct ResetsRow {
+    alias: String,
+    is_active: bool,
+    available: i64,
+    applicable: i64,
+    credits: Vec<api::ResetCredit>,
+    error: Option<String>,
+}
+
+fn fetch_all(profiles: &[profile::Profile], active: &Option<String>) -> Result<Vec<ResetsRow>> {
+    let codex_auth = config::codex_auth_json()?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let client = reqwest::Client::new();
+
+    Ok(rt.block_on(async {
+        let futs: Vec<_> = profiles
+            .iter()
+            .map(|p| {
+                let client = client.clone();
+                let alias = p.meta.alias.clone();
+                let is_active = active.as_deref() == Some(&p.meta.alias);
+                let auth_path = if is_active {
+                    codex_auth.clone()
+                } else {
+                    p.auth_json_path()
+                };
+                async move {
+                    match api::read_auth_json(&auth_path) {
+                        Ok(auth) => fetch_row(&client, alias, is_active, &auth).await,
+                        Err(_) => ResetsRow {
+                            alias,
+                            is_active,
+                            available: 0,
+                            applicable: 0,
+                            credits: Vec::new(),
+                            error: Some("bad auth.json".to_string()),
+                        },
+                    }
+                }
+            })
+            .collect();
+        futures::future::join_all(futs).await
+    }))
+}
+
+async fn fetch_row(
+    client: &reqwest::Client,
+    alias: String,
+    is_active: bool,
+    auth: &api::AuthJson,
+) -> ResetsRow {
+    let account_id = auth.account_id.as_deref();
+    // The usage response carries the applicable count — whether a credit can be
+    // spent right now — which the credit listing alone does not report.
+    let usage = api::fetch_usage_async(client, &auth.access_token, account_id).await;
+    let details = api::fetch_reset_credits_async(client, &auth.access_token, account_id).await;
+
+    match (usage, details) {
+        (Ok(usage), Ok(details)) => ResetsRow {
+            alias,
+            is_active,
+            available: usage.reset_credits_available().max(details.available_count),
+            applicable: usage.reset_credits_applicable(),
+            credits: details.credits,
+            error: None,
+        },
+        (usage, details) => {
+            let err = usage
+                .err()
+                .or_else(|| details.err())
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "error".to_string());
+            ResetsRow {
+                alias,
+                is_active,
+                available: 0,
+                applicable: 0,
+                credits: Vec::new(),
+                error: Some(if err.contains("expired") {
+                    "expired".to_string()
+                } else {
+                    "error".to_string()
+                }),
+            }
+        }
+    }
+}
+
+fn fetch_one(alias: &str, is_active: bool) -> Result<ResetsRow> {
+    let auth = auth_for(alias, is_active)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let client = reqwest::Client::new();
+    let row = rt.block_on(fetch_row(&client, alias.to_string(), is_active, &auth));
+    if let Some(error) = &row.error {
+        bail!("could not read reset credits for {alias}: {error}");
+    }
+    Ok(row)
+}
+
+/// The active profile's live tokens are Codex-maintained and authoritative; the
+/// stored snapshot can be stale until the next switch or save.
+fn auth_for(alias: &str, is_active: bool) -> Result<api::AuthJson> {
+    let path = if is_active {
+        config::codex_auth_json()?
+    } else {
+        profile::get_profile(alias)?.auth_json_path()
+    };
+    api::read_auth_json(&path)
+}
+
+fn is_active(alias: &str) -> Result<bool> {
+    Ok(profile::get_active()?.as_deref() == Some(alias))
+}
+
+fn render_row(row: &ResetsRow) -> Vec<Cell> {
+    let alias = if row.is_active {
+        format!("* {}", row.alias)
+    } else {
+        row.alias.clone()
+    };
+
+    if let Some(error) = &row.error {
+        return vec![
+            Cell::new(alias),
+            Cell::new("-"),
+            Cell::new("-"),
+            Cell::new(error).fg(Color::Red),
+        ];
+    }
+
+    let redeemable = if row.applicable > 0 {
+        Cell::new(row.applicable.to_string()).fg(Color::Green)
+    } else {
+        Cell::new("0")
+    };
+
+    vec![
+        Cell::new(alias),
+        Cell::new(row.available.to_string()),
+        redeemable,
+        expiries_cell(&row.credits),
+    ]
+}
+
+/// Expiry dates of the redeemable credits, soonest first. A credit lapsing
+/// within [`EXPIRY_WARN_SECONDS`] is called out — an unspent credit is simply
+/// lost, which is the whole reason to surface this column.
+fn expiries_cell(credits: &[api::ResetCredit]) -> Cell {
+    let mut expiries: Vec<(Option<i64>, String)> = credits
+        .iter()
+        .filter(|c| c.is_available())
+        .map(|c| {
+            (
+                c.expires_at_timestamp(),
+                c.expires_at
+                    .as_deref()
+                    .map(format_date)
+                    .unwrap_or_else(|| "-".to_string()),
+            )
+        })
+        .collect();
+    if expiries.is_empty() {
+        return Cell::new("-");
+    }
+    expiries.sort_by_key(|(ts, _)| ts.unwrap_or(i64::MAX));
+
+    let soonest = expiries.first().and_then(|(ts, _)| *ts);
+    let text = expiries
+        .iter()
+        .map(|(_, label)| label.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    match soonest {
+        Some(ts) if ts - chrono::Utc::now().timestamp() <= EXPIRY_WARN_SECONDS => {
+            Cell::new(text).fg(Color::Red)
+        }
+        _ => Cell::new(text),
+    }
+}
+
+/// A credit this close to lapsing is effectively use-it-or-lose-it.
+pub const EXPIRY_WARN_SECONDS: i64 = 3 * 24 * 60 * 60;
+
+fn format_date(rfc3339: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .map(|dt| dt.with_timezone(&chrono::Local).format("%b %d").to_string())
+        .unwrap_or_else(|_| rfc3339.to_string())
+}
+
+fn confirm(prompt: &str) -> Result<bool> {
+    use std::io::IsTerminal;
+    // A credit is scarce and non-refundable, so never spend one that a human
+    // could not have approved.
+    if !std::io::stdin().is_terminal() {
+        bail!("no terminal to confirm on; pass --yes to redeem unattended");
+    }
+    Ok(dialoguer::Confirm::new()
+        .with_prompt(prompt)
+        .default(false)
+        .interact()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credit(id: &str, status: &str, expires_at: Option<&str>) -> api::ResetCredit {
+        api::ResetCredit {
+            id: id.to_string(),
+            status: status.to_string(),
+            reset_type: None,
+            granted_at: None,
+            expires_at: expires_at.map(|e| e.to_string()),
+            title: None,
+            description: None,
+        }
+    }
+
+    // Expiries render in local time, so these compare against `format_date`
+    // rather than hard-coded dates.
+    const SOON: &str = "2036-07-26T00:00:00Z";
+    const LATE: &str = "2036-08-12T00:00:00Z";
+
+    #[test]
+    fn expiries_list_available_credits_soonest_first() {
+        let credits = vec![
+            credit("late", "available", Some(LATE)),
+            credit("soon", "available", Some(SOON)),
+        ];
+        let rendered = expiries_cell(&credits).content().to_string();
+        let soon = rendered
+            .find(&format_date(SOON))
+            .expect("soonest expiry listed");
+        let late = rendered
+            .find(&format_date(LATE))
+            .expect("later expiry listed");
+        assert!(soon < late, "soonest expiry must come first: {rendered}");
+    }
+
+    #[test]
+    fn expiries_ignore_credits_that_cannot_be_redeemed() {
+        let credits = vec![
+            credit("spent", "redeemed", Some(SOON)),
+            credit("live", "available", Some(LATE)),
+        ];
+        let rendered = expiries_cell(&credits).content().to_string();
+        assert!(
+            !rendered.contains(&format_date(SOON)),
+            "redeemed credit listed: {rendered}"
+        );
+        assert!(rendered.contains(&format_date(LATE)));
+    }
+
+    #[test]
+    fn expiries_render_a_dash_when_nothing_is_redeemable() {
+        let credits = vec![credit("spent", "redeemed", Some(SOON))];
+        assert_eq!(expiries_cell(&credits).content().to_string(), "-");
+    }
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL_CONDENSED};
 
 use crate::api;
+use crate::commands::resets;
 use crate::config;
 use crate::profile;
 
@@ -27,6 +28,14 @@ struct RateLimitedAccount {
     h5_reset: String,
     d7_reset: String,
     token_expiry: Option<i64>,
+    /// Banked rate-limit resets held by this account.
+    reset_credits: i64,
+    /// How many of them can be redeemed right now (nonzero only once a window
+    /// is exhausted).
+    reset_credits_applicable: i64,
+    /// When the soonest redeemable credit lapses. An unspent credit is simply
+    /// lost, so this is the part worth acting on.
+    reset_credit_expiry: Option<i64>,
     is_active: bool,
     is_error: bool,
     error_msg: String,
@@ -213,7 +222,9 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
     println!("{title}");
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec!["Account", "5h", "5h Reset", "7d", "7d Reset", "Token"]);
+    table.set_header(vec![
+        "Account", "5h", "5h Reset", "7d", "7d Reset", "Resets", "Token",
+    ]);
     for account in accounts {
         table.add_row(render_rate_limited_row(account));
     }
@@ -286,6 +297,9 @@ async fn fetch_and_split(
     let mut rate_limited = Vec::new();
     let mut usage_based = Vec::new();
     let mut ub_needing_settings: Vec<(usize, String, String)> = Vec::new();
+    // Only accounts that actually hold banked resets need their credit listing
+    // read, so the common case stays at one request per profile.
+    let mut rl_needing_credits: Vec<(usize, String, Option<String>)> = Vec::new();
 
     for (alias, plan_from_meta, is_active, auth, usage_result) in &results {
         let account_id = auth.as_ref().ok().and_then(|a| a.account_id.clone());
@@ -313,6 +327,9 @@ async fn fetch_and_split(
                         h5_reset: "-".to_string(),
                         d7_reset: "-".to_string(),
                         token_expiry: None,
+                        reset_credits: 0,
+                        reset_credits_applicable: 0,
+                        reset_credit_expiry: None,
                         is_active: *is_active,
                         is_error: true,
                         error_msg: "bad auth.json".to_string(),
@@ -353,6 +370,9 @@ async fn fetch_and_split(
                         h5_reset: "-".to_string(),
                         d7_reset: "-".to_string(),
                         token_expiry,
+                        reset_credits: 0,
+                        reset_credits_applicable: 0,
+                        reset_credit_expiry: None,
                         is_active: *is_active,
                         is_error: true,
                         error_msg: msg.to_string(),
@@ -400,13 +420,14 @@ async fn fetch_and_split(
                 ub_needing_settings.push((idx, auth.access_token.clone(), account_id));
             }
         } else {
-            let primary = usage.rate_limit.as_ref().and_then(|r| r.primary());
-            let secondary = usage.rate_limit.as_ref().and_then(|r| r.secondary());
+            let primary = usage.rate_limit.as_ref().and_then(|r| r.short_window());
+            let secondary = usage.rate_limit.as_ref().and_then(|r| r.long_window());
             let h5_pct = primary.map(|w| w.used_percent);
             let d7_pct = secondary.map(|w| w.used_percent);
             let h5_reset = format_window_reset(primary);
             let d7_reset = format_window_reset(secondary);
 
+            let idx = rate_limited.len();
             rate_limited.push(RateLimitedAccount {
                 alias: alias.clone(),
                 h5_pct,
@@ -414,10 +435,17 @@ async fn fetch_and_split(
                 h5_reset,
                 d7_reset,
                 token_expiry,
+                reset_credits: usage.reset_credits_available(),
+                reset_credits_applicable: usage.reset_credits_applicable(),
+                reset_credit_expiry: None,
                 is_active: *is_active,
                 is_error: false,
                 error_msg: String::new(),
             });
+
+            if usage.reset_credits_available() > 0 {
+                rl_needing_credits.push((idx, auth.access_token.clone(), account_id.clone()));
+            }
         }
     }
 
@@ -460,6 +488,34 @@ async fn fetch_and_split(
         }
     }
 
+    // Phase 4: read banked-reset expiries. The usage response carries the
+    // counts but not when each credit lapses, and a credit that lapses unspent
+    // is simply lost — which is the part worth showing.
+    let credit_futures: Vec<_> = rl_needing_credits
+        .iter()
+        .map(|(idx, token, account_id)| {
+            let client = client.clone();
+            let token = token.clone();
+            let account_id = account_id.clone();
+            async move {
+                let result =
+                    api::fetch_reset_credits_async(&client, &token, account_id.as_deref()).await;
+                (*idx, result)
+            }
+        })
+        .collect();
+
+    for (idx, result) in futures::future::join_all(credit_futures).await {
+        if let Ok(details) = result {
+            rate_limited[idx].reset_credit_expiry = details
+                .credits
+                .iter()
+                .filter(|c| c.is_available())
+                .filter_map(|c| c.expires_at_timestamp())
+                .min();
+        }
+    }
+
     (rate_limited, usage_based)
 }
 
@@ -469,6 +525,7 @@ fn render_rate_limited_row(s: &RateLimitedAccount) -> Vec<Cell> {
     if s.is_error {
         return vec![
             Cell::new(alias),
+            Cell::new("-"),
             Cell::new("-"),
             Cell::new("-"),
             Cell::new("-"),
@@ -492,8 +549,33 @@ fn render_rate_limited_row(s: &RateLimitedAccount) -> Vec<Cell> {
         Cell::new(&s.h5_reset),
         colorize_usage(&d7_str),
         Cell::new(&s.d7_reset),
+        resets_cell(s),
         token_cell(s.token_expiry, false, &s.error_msg),
     ]
+}
+
+/// The "Resets" column: banked rate-limit resets, and how many of them can be
+/// redeemed right now. Green means `codexctl reset <alias>` would work this
+/// second; red means a credit lapses within [`resets::EXPIRY_WARN_SECONDS`] and
+/// would be lost unspent.
+fn resets_cell(s: &RateLimitedAccount) -> Cell {
+    if s.reset_credits <= 0 {
+        return Cell::new("-");
+    }
+    if s.reset_credits_applicable > 0 {
+        return Cell::new(format!(
+            "{} ({} now)",
+            s.reset_credits, s.reset_credits_applicable
+        ))
+        .fg(Color::Green);
+    }
+    let cell = Cell::new(s.reset_credits.to_string());
+    match s.reset_credit_expiry {
+        Some(expiry) if expiry - chrono::Utc::now().timestamp() <= resets::EXPIRY_WARN_SECONDS => {
+            cell.fg(Color::Red)
+        }
+        _ => cell,
+    }
 }
 
 fn render_usage_based_row(s: &UsageBasedAccount) -> Vec<Cell> {
@@ -666,21 +748,67 @@ mod tests {
         assert_eq!(auth_failure_label(&token), "expired");
     }
 
-    #[test]
-    fn render_rate_limited_row_has_expected_column_count() {
-        let account = RateLimitedAccount {
+    fn rate_limited_account() -> RateLimitedAccount {
+        RateLimitedAccount {
             alias: "amir+8@sawmills.ai".to_string(),
             h5_pct: Some(10.0),
             d7_pct: Some(20.0),
             h5_reset: "in 1h 00m".to_string(),
             d7_reset: "in 1d 00h".to_string(),
             token_expiry: None,
+            reset_credits: 0,
+            reset_credits_applicable: 0,
+            reset_credit_expiry: None,
             is_active: false,
             is_error: false,
             error_msg: String::new(),
+        }
+    }
+
+    #[test]
+    fn render_rate_limited_row_has_expected_column_count() {
+        assert_eq!(render_rate_limited_row(&rate_limited_account()).len(), 7);
+    }
+
+    /// The error row must line up with the normal row or the table breaks.
+    #[test]
+    fn render_rate_limited_error_row_has_expected_column_count() {
+        let account = RateLimitedAccount {
+            is_error: true,
+            error_msg: "expired".to_string(),
+            ..rate_limited_account()
         };
 
-        assert_eq!(render_rate_limited_row(&account).len(), 6);
+        assert_eq!(render_rate_limited_row(&account).len(), 7);
+    }
+
+    #[test]
+    fn resets_column_is_blank_without_banked_credits() {
+        assert_eq!(resets_cell(&rate_limited_account()).content(), "-");
+    }
+
+    #[test]
+    fn resets_column_calls_out_credits_redeemable_now() {
+        let account = RateLimitedAccount {
+            reset_credits: 3,
+            reset_credits_applicable: 2,
+            ..rate_limited_account()
+        };
+
+        assert_eq!(resets_cell(&account).content(), "3 (2 now)");
+    }
+
+    /// Held but not yet applicable: the count alone, since a reset only clears
+    /// an already-exhausted window.
+    #[test]
+    fn resets_column_shows_the_bare_count_when_nothing_applies_yet() {
+        let account = RateLimitedAccount {
+            reset_credits: 3,
+            reset_credits_applicable: 0,
+            ..rate_limited_account()
+        };
+
+        assert_eq!(resets_cell(&account).content(), "3");
     }
 
     #[test]

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -33,13 +33,13 @@ pub fn run() -> Result<()> {
                     let h5 = u
                         .rate_limit
                         .as_ref()
-                        .and_then(|r| r.primary())
+                        .and_then(|r| r.short_window())
                         .map(|w| format!("{:.0}%", w.used_percent))
                         .unwrap_or_else(|| "-".to_string());
                     let d7 = u
                         .rate_limit
                         .as_ref()
-                        .and_then(|r| r.secondary())
+                        .and_then(|r| r.long_window())
                         .map(|w| format!("{:.0}%", w.used_percent))
                         .unwrap_or_else(|| "-".to_string());
                     format!(" — 5h: {h5}, 7d: {d7}")

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -1,9 +1,11 @@
+use std::cmp::Ordering;
 use std::path::Path;
 
 use anyhow::{Result, bail};
 
 use crate::api;
 use crate::commands::alias;
+use crate::commands::resets;
 use crate::commands::status;
 use crate::config;
 use crate::profile;
@@ -12,20 +14,24 @@ use crate::profile;
 /// 100% — i.e. the account has no usable headroom right now.
 const RATE_LIMIT_EXHAUSTED: f64 = 500.0;
 
-pub fn run(alias: Option<&str>) -> Result<()> {
-    run_to_auth_json(alias, &config::codex_auth_json()?)
+pub fn run(alias: Option<&str>, allow_resets: bool) -> Result<()> {
+    run_to_auth_json(alias, &config::codex_auth_json()?, allow_resets)
 }
 
-pub fn run_to_auth_json(alias: Option<&str>, auth_json: &Path) -> Result<()> {
-    run_to_auth_json_excluding(alias, auth_json, None)
+pub fn run_to_auth_json(alias: Option<&str>, auth_json: &Path, allow_resets: bool) -> Result<()> {
+    run_to_auth_json_excluding(alias, auth_json, None, allow_resets)
 }
 
 pub fn run_to_auth_json_excluding(
     alias: Option<&str>,
     auth_json: &Path,
     excluded_alias: Option<&str>,
+    allow_resets: bool,
 ) -> Result<()> {
     match alias::optional(alias) {
+        // An explicit target is switched to as asked — never redeemed against,
+        // since `codexctl reset <alias>` is the way to spend a credit on a
+        // named account.
         Some(a) => {
             let email = profile::switch_to_auth_json(a, auth_json)?;
             println!("switched to {} ({})", a, email);
@@ -33,7 +39,7 @@ pub fn run_to_auth_json_excluding(
             status::run_focused(a)?;
         }
         None => {
-            let best = find_most_available_excluding(excluded_alias)?;
+            let best = find_most_available_excluding(excluded_alias, allow_resets)?;
             let email = profile::switch_to_auth_json(&best, auth_json)?;
             println!("auto-selected most available: {} ({})", best, email);
             println!();
@@ -43,7 +49,10 @@ pub fn run_to_auth_json_excluding(
     Ok(())
 }
 
-fn find_most_available_excluding(excluded_alias: Option<&str>) -> Result<String> {
+fn find_most_available_excluding(
+    excluded_alias: Option<&str>,
+    allow_resets: bool,
+) -> Result<String> {
     let all_profiles = profile::list_profiles()?;
     let had_profiles = !all_profiles.is_empty();
     let profiles = profiles_after_excluding(all_profiles, excluded_alias);
@@ -70,6 +79,45 @@ fn find_most_available_excluding(excluded_alias: Option<&str>) -> Result<String>
         })
         .collect();
 
+    // An account that still has headroom is always preferred and spends nothing.
+    if let Some(alias) = select_with_headroom(&scored, reset_aware()) {
+        return Ok(alias.to_string());
+    }
+
+    // Nothing is usable as-is. Redeeming a banked reset is the only way to hand
+    // back an account that actually works, so apply the same cost-ranked ladder
+    // `codexctl codex` uses on recovery.
+    if let Some(candidate) = best_candidate_from_usages(usages)?
+        && let Some(plan) = candidate.reset_plan()
+    {
+        if !resets::approve_redemption(
+            &candidate.alias,
+            plan.expires_at,
+            plan.expires_unused,
+            allow_resets,
+            &mut std::io::stdout(),
+        ) {
+            bail!(
+                "every account is out of rate-limit headroom and redeeming a banked reset for {} was not approved",
+                candidate.alias
+            );
+        }
+        let response = resets::redeem(&candidate.alias, plan.credit_id.as_deref())?;
+        resets::report_outcome(&candidate.alias, &response);
+        if response.code != api::ConsumeResetCode::Reset {
+            bail!(
+                "redeeming a banked reset for {} did not clear its rate limit",
+                candidate.alias
+            );
+        }
+        // Otherwise the status printed right after the switch still shows the
+        // old 100% and the redemption looks like it did nothing.
+        resets::settle_after_redeem(&candidate.alias);
+        return Ok(candidate.alias);
+    }
+
+    // No reset can help either: fall back to the least-bad account, exactly as
+    // before, so `use` still hands back something rather than failing outright.
     match select_most_available(&scored, reset_aware()) {
         Some(alias) => Ok(alias.to_string()),
         None => bail!("no usable accounts found (all expired or errored)"),
@@ -104,7 +152,7 @@ fn secondary_reset_ts(usage: &api::RateLimitResponse) -> i64 {
     usage
         .rate_limit
         .as_ref()
-        .and_then(|r| r.secondary())
+        .and_then(|r| r.long_window())
         .and_then(|w| w.reset_timestamp())
         .unwrap_or(i64::MAX)
 }
@@ -127,23 +175,8 @@ struct SelectionCandidate {
 /// soonest 7d reset, breaking ties by most headroom; if none have headroom, fall
 /// back to the default pick so the behavior degrades identically to today.
 fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Option<&str> {
-    if reset_aware {
-        let staggered = scored
-            .iter()
-            .filter(|candidate| candidate.score < RATE_LIMIT_EXHAUSTED)
-            .min_by(|a, b| {
-                a.bills_credits
-                    .cmp(&b.bills_credits)
-                    .then(a.secondary_reset_ts.cmp(&b.secondary_reset_ts))
-                    .then(
-                        a.score
-                            .partial_cmp(&b.score)
-                            .unwrap_or(std::cmp::Ordering::Equal),
-                    )
-            });
-        if let Some(candidate) = staggered {
-            return Some(candidate.alias.as_str());
-        }
+    if let Some(alias) = select_with_headroom(scored, reset_aware) {
+        return Some(alias);
     }
     scored
         .iter()
@@ -153,6 +186,31 @@ fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Op
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
         .filter(|candidate| candidate.score < f64::MAX)
+        .map(|candidate| candidate.alias.as_str())
+}
+
+/// The best account that still has usable rate-limit headroom, or `None` when
+/// every account is exhausted (or usage-based, which is never auto-selected).
+///
+/// Reset-aware: no-bill accounts first, then the soonest 7d reset, then most
+/// headroom. Default: most headroom — which, since any exhausted account scores
+/// at least [`RATE_LIMIT_EXHAUSTED`] and any account with headroom scores below
+/// it, is the same account the legacy global-minimum pick would have chosen.
+fn select_with_headroom(scored: &[SelectionCandidate], reset_aware: bool) -> Option<&str> {
+    scored
+        .iter()
+        .filter(|candidate| candidate.score < RATE_LIMIT_EXHAUSTED)
+        .min_by(|a, b| {
+            let by_score = a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal);
+            if reset_aware {
+                a.bills_credits
+                    .cmp(&b.bills_credits)
+                    .then(a.secondary_reset_ts.cmp(&b.secondary_reset_ts))
+                    .then(by_score)
+            } else {
+                by_score
+            }
+        })
         .map(|candidate| candidate.alias.as_str())
 }
 
@@ -172,15 +230,50 @@ pub struct RecoveryCandidate {
     /// True when overage is open (spend cap NOT reached), so the account draws
     /// credits ($) once it passes 100% of its rate limit. These require consent.
     pub bills_credits: bool,
+    /// What it costs to put this account to work.
+    pub cost: RecoveryCost,
+}
+
+impl RecoveryCandidate {
+    /// The banked reset that has to be redeemed before this account is usable,
+    /// if any.
+    pub fn reset_plan(&self) -> Option<&ResetPlan> {
+        match &self.cost {
+            RecoveryCost::Headroom => None,
+            RecoveryCost::ResetCredit(plan) => Some(plan),
+        }
+    }
+}
+
+/// What switching to a recovery candidate costs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveryCost {
+    /// The account still has rate-limit headroom; switching to it costs nothing.
+    Headroom,
+    /// The account is exhausted, but a banked reset credit can clear its window.
+    ResetCredit(ResetPlan),
+}
+
+/// The banked reset codexctl would redeem to make an exhausted account usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResetPlan {
+    /// The soonest-expiring redeemable credit. `None` lets the backend pick,
+    /// which is the safe fallback when the credit listing could not be read.
+    pub credit_id: Option<String>,
+    pub expires_at: Option<i64>,
+    /// The credit expires before this account's window would reset on its own.
+    /// Holding it back cannot pay off — it would lapse unredeemed — so spending
+    /// it now is strictly free and needs no consent.
+    pub expires_unused: bool,
 }
 
 /// Pick the next spend-cap recovery account, excluding any `tried` aliases.
 ///
-/// Prefers accounts that will not bill credits — spend cap already reached, so
-/// they hard-stop at 100% rather than drawing credits — over ones that can.
-/// Usage-based accounts are never selected, and accounts without rate-limit
-/// headroom (a window already at 100%) are skipped, since switching to them
-/// would immediately re-trigger the cap.
+/// Candidates are ranked cheapest-first: an account with rate-limit headroom
+/// that will not bill, then one whose banked reset would expire unused anyway,
+/// then one that must spend a bankable reset, and only then accounts that draw
+/// credits ($). Usage-based accounts are never selected, and an exhausted
+/// account is skipped unless a banked reset can actually clear its window.
 pub fn find_recovery_candidate(tried: &[String]) -> Result<Option<RecoveryCandidate>> {
     let profiles: Vec<profile::Profile> = profile::list_profiles()?
         .into_iter()
@@ -191,73 +284,218 @@ pub fn find_recovery_candidate(tried: &[String]) -> Result<Option<RecoveryCandid
     }
 
     let usages = fetch_usages(&profiles)?;
-    let candidates: Vec<(String, bool, f64, i64)> = usages
+    best_candidate_from_usages(usages)
+}
+
+/// Rank already-fetched accounts cheapest-first and return the winner. Shared
+/// by `codexctl codex` recovery and by `codexctl use`, so both spend resources
+/// in the same order.
+fn best_candidate_from_usages(
+    usages: Vec<(String, Option<api::RateLimitResponse>)>,
+) -> Result<Option<RecoveryCandidate>> {
+    let classified: Vec<(String, api::RateLimitResponse, RecoveryClass)> = usages
         .into_iter()
         .filter_map(|(alias, usage)| {
             let usage = usage?;
-            let (bills_credits, score) = recovery_score(&usage)?;
-            Some((alias, bills_credits, score, secondary_reset_ts(&usage)))
+            let class = recovery_class(&usage)?;
+            Some((alias, usage, class))
+        })
+        .collect();
+
+    // Only accounts that must redeem need their credit listing read, so the
+    // common case (someone has headroom) stays at one request per profile.
+    let needs_credits: Vec<String> = classified
+        .iter()
+        .filter(|(_, _, class)| class.needs_reset)
+        .map(|(alias, _, _)| alias.clone())
+        .collect();
+    let credit_details = fetch_reset_credits(&needs_credits)?;
+
+    let candidates: Vec<ScoredRecovery> = classified
+        .into_iter()
+        .map(|(alias, usage, class)| {
+            let cost = if class.needs_reset {
+                let details = credit_details
+                    .iter()
+                    .find(|(a, _)| *a == alias)
+                    .and_then(|(_, details)| details.as_ref());
+                RecoveryCost::ResetCredit(reset_plan(details, natural_reset_ts(&usage)))
+            } else {
+                RecoveryCost::Headroom
+            };
+            let tiebreak_ts = match &cost {
+                // Spend the credit closest to lapsing first.
+                RecoveryCost::ResetCredit(plan) => plan.expires_at.unwrap_or(i64::MAX),
+                RecoveryCost::Headroom => secondary_reset_ts(&usage),
+            };
+            ScoredRecovery {
+                alias,
+                bills_credits: class.bills_credits,
+                score: class.score,
+                tiebreak_ts,
+                cost,
+            }
         })
         .collect();
 
     Ok(select_recovery(candidates, reset_aware()))
 }
 
-/// Choose the recovery candidate. No-bill accounts (`bills_credits == false`)
-/// always win over billing ones — preserved in both modes. Within a bill class,
-/// default picks most headroom; reset-aware picks the soonest 7d reset first,
-/// then most headroom.
+#[derive(Debug, Clone)]
+struct ScoredRecovery {
+    alias: String,
+    bills_credits: bool,
+    score: f64,
+    /// Soonest-first tiebreak: the 7d window reset for headroom candidates, the
+    /// credit expiry for reset candidates.
+    tiebreak_ts: i64,
+    cost: RecoveryCost,
+}
+
+impl ScoredRecovery {
+    /// Cheapest first. A banked reset costs no money, so redeeming one beats
+    /// any account that would draw credits; a reset that would lapse unredeemed
+    /// costs nothing at all, so it even beats one worth keeping in the bank.
+    fn rank(&self) -> u8 {
+        match (&self.cost, self.bills_credits) {
+            (RecoveryCost::Headroom, false) => 0,
+            (RecoveryCost::ResetCredit(plan), false) if plan.expires_unused => 1,
+            (RecoveryCost::ResetCredit(_), false) => 2,
+            // A lapsing credit is free even on an account that can bill later,
+            // and salvaging it leaves that account no worse off than simply
+            // switching to one — so it comes first among the billing options.
+            (RecoveryCost::ResetCredit(plan), true) if plan.expires_unused => 3,
+            (RecoveryCost::Headroom, true) => 4,
+            (RecoveryCost::ResetCredit(_), true) => 5,
+        }
+    }
+}
+
+/// Choose the recovery candidate. Cheapest [`ScoredRecovery::rank`] always wins
+/// — so no-bill accounts still beat billing ones in both modes. Within a rank,
+/// default picks most headroom; reset-aware picks the soonest 7d reset (or
+/// soonest-lapsing credit) first, then most headroom.
 fn select_recovery(
-    candidates: Vec<(String, bool, f64, i64)>,
+    candidates: Vec<ScoredRecovery>,
     reset_aware: bool,
 ) -> Option<RecoveryCandidate> {
     candidates
         .into_iter()
         .min_by(|a, b| {
-            let by_bill = a.1.cmp(&b.1);
+            let by_rank = a.rank().cmp(&b.rank());
             if reset_aware {
-                by_bill
-                    .then(a.3.cmp(&b.3))
-                    .then(a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+                by_rank
+                    .then(a.tiebreak_ts.cmp(&b.tiebreak_ts))
+                    .then(a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal))
             } else {
-                by_bill.then(a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+                by_rank.then(a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal))
             }
         })
-        .map(|(alias, bills_credits, _, _)| RecoveryCandidate {
-            alias,
-            bills_credits,
+        .map(|candidate| RecoveryCandidate {
+            alias: candidate.alias,
+            bills_credits: candidate.bills_credits,
+            cost: candidate.cost,
         })
 }
 
-/// Classify an account for spend-cap recovery as `(bills_credits, score)`, or
-/// `None` when it must not be used (usage-based, or no rate-limit headroom).
-fn recovery_score(usage: &api::RateLimitResponse) -> Option<(bool, f64)> {
+#[derive(Debug, Clone, PartialEq)]
+struct RecoveryClass {
+    bills_credits: bool,
+    score: f64,
+    /// The account is out of rate-limit headroom, so only redeeming a banked
+    /// reset can make it usable.
+    needs_reset: bool,
+}
+
+/// Classify an account for spend-cap recovery, or `None` when it must not be
+/// used: usage-based (bills real credits), or out of headroom with no banked
+/// reset to clear the window.
+fn recovery_class(usage: &api::RateLimitResponse) -> Option<RecoveryClass> {
     let plan = usage.plan_type.as_deref().unwrap_or("");
     if plan.contains("usage_based") {
-        return None;
-    }
-    let score = rate_limit_score(usage);
-    if score >= RATE_LIMIT_EXHAUSTED {
-        // A rate-limit window is already at 100% — not usable right now.
         return None;
     }
     // Spend cap reached => overage closed => the account hard-stops at 100% and
     // never bills. Spend cap NOT reached => overage open => it draws credits ($).
     let bills_credits = !usage.spend_control.as_ref().is_some_and(|s| s.reached);
-    Some((bills_credits, score))
+    let score = rate_limit_score(usage);
+    if score >= RATE_LIMIT_EXHAUSTED {
+        // A rate-limit window is already at 100%. The backend only reports a
+        // credit as applicable once there is a window to clear, so this is the
+        // authoritative test for "a reset would actually make this usable".
+        if usage.reset_credits_applicable() <= 0 {
+            return None;
+        }
+        return Some(RecoveryClass {
+            bills_credits,
+            score,
+            needs_reset: true,
+        });
+    }
+    Some(RecoveryClass {
+        bills_credits,
+        score,
+        needs_reset: false,
+    })
+}
+
+/// When this account's exhausted window(s) would clear without spending a
+/// credit — the moment a banked reset stops being worth anything here.
+fn natural_reset_ts(usage: &api::RateLimitResponse) -> Option<i64> {
+    let rate_limit = usage.rate_limit.as_ref()?;
+    [rate_limit.short_window(), rate_limit.long_window()]
+        .into_iter()
+        .flatten()
+        .filter(|w| w.used_percent >= 100.0)
+        .filter_map(|w| w.reset_timestamp())
+        .max()
+}
+
+/// Plan which banked reset to spend: the soonest-expiring redeemable one.
+///
+/// A missing or unreadable listing still yields a plan with no credit id — the
+/// usage response already confirmed a credit is applicable, so the backend can
+/// pick one itself.
+fn reset_plan(
+    details: Option<&api::ResetCreditsDetails>,
+    natural_reset_ts: Option<i64>,
+) -> ResetPlan {
+    let credit = details.and_then(|d| {
+        d.credits
+            .iter()
+            .filter(|c| c.is_available())
+            .min_by_key(|c| c.expires_at_timestamp().unwrap_or(i64::MAX))
+    });
+    let Some(credit) = credit else {
+        return ResetPlan {
+            credit_id: None,
+            expires_at: None,
+            expires_unused: false,
+        };
+    };
+    let expires_at = credit.expires_at_timestamp();
+    let expires_unused = match (expires_at, natural_reset_ts) {
+        (Some(expiry), Some(reset)) => expiry < reset,
+        _ => false,
+    };
+    ResetPlan {
+        credit_id: Some(credit.id.clone()),
+        expires_at,
+        expires_unused,
+    }
 }
 
 fn rate_limit_score(usage: &api::RateLimitResponse) -> f64 {
     let h5 = usage
         .rate_limit
         .as_ref()
-        .and_then(|r| r.primary())
+        .and_then(|r| r.short_window())
         .map(|w| w.used_percent)
         .unwrap_or(0.0);
     let d7 = usage
         .rate_limit
         .as_ref()
-        .and_then(|r| r.secondary())
+        .and_then(|r| r.long_window())
         .map(|w| w.used_percent)
         .unwrap_or(0.0);
     if h5 >= 100.0 && d7 >= 100.0 {
@@ -307,6 +545,45 @@ fn fetch_usages(
     }))
 }
 
+/// Read the banked-reset listing for the given aliases, in parallel. A profile
+/// whose listing cannot be read yields `None` rather than failing the pick.
+fn fetch_reset_credits(
+    aliases: &[String],
+) -> Result<Vec<(String, Option<api::ResetCreditsDetails>)>> {
+    if aliases.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let client = reqwest::Client::new();
+
+    Ok(rt.block_on(async {
+        let futs: Vec<_> = aliases
+            .iter()
+            .map(|alias| {
+                let client = client.clone();
+                let alias = alias.clone();
+                let auth = profile::get_profile(&alias)
+                    .and_then(|p| api::read_auth_json(&p.auth_json_path()));
+                async move {
+                    let details = match auth {
+                        Ok(a) => api::fetch_reset_credits_async(
+                            &client,
+                            &a.access_token,
+                            a.account_id.as_deref(),
+                        )
+                        .await
+                        .ok(),
+                        Err(_) => None,
+                    };
+                    (alias, details)
+                }
+            })
+            .collect();
+        futures::future::join_all(futs).await
+    }))
+}
+
 fn profiles_after_excluding(
     mut profiles: Vec<profile::Profile>,
     excluded_alias: Option<&str>,
@@ -344,6 +621,17 @@ mod tests {
         }
     }
 
+    fn window_resetting_at(used_percent: f64, reset_at: i64) -> api::RateLimitWindow {
+        api::RateLimitWindow {
+            used_percent,
+            window_minutes: None,
+            limit_window_seconds: None,
+            resets_at: Some(reset_at),
+            reset_at: None,
+            reset_after_seconds: None,
+        }
+    }
+
     fn team_response(h5: f64, d7: f64, spend_reached: bool) -> api::RateLimitResponse {
         api::RateLimitResponse {
             plan_type: Some("team".to_string()),
@@ -357,6 +645,23 @@ mod tests {
             spend_control: Some(api::SpendControl {
                 reached: spend_reached,
             }),
+            rate_limit_reset_credits: None,
+        }
+    }
+
+    /// A team account with `applicable` banked resets redeemable right now.
+    fn team_response_with_resets(
+        h5: f64,
+        d7: f64,
+        spend_reached: bool,
+        applicable: i64,
+    ) -> api::RateLimitResponse {
+        api::RateLimitResponse {
+            rate_limit_reset_credits: Some(api::ResetCreditsSummary {
+                available_count: applicable,
+                applicable_available_count: applicable,
+            }),
+            ..team_response(h5, d7, spend_reached)
         }
     }
 
@@ -371,7 +676,60 @@ mod tests {
                 balance: None,
             }),
             spend_control: Some(api::SpendControl { reached: false }),
+            rate_limit_reset_credits: None,
         }
+    }
+
+    fn credit(id: &str, status: &str, expires_at: Option<&str>) -> api::ResetCredit {
+        api::ResetCredit {
+            id: id.to_string(),
+            status: status.to_string(),
+            reset_type: Some("codex_rate_limits".to_string()),
+            granted_at: None,
+            expires_at: expires_at.map(|e| e.to_string()),
+            title: None,
+            description: None,
+        }
+    }
+
+    fn scored(
+        alias: &str,
+        bills_credits: bool,
+        score: f64,
+        tiebreak_ts: i64,
+        cost: RecoveryCost,
+    ) -> ScoredRecovery {
+        ScoredRecovery {
+            alias: alias.to_string(),
+            bills_credits,
+            score,
+            tiebreak_ts,
+            cost,
+        }
+    }
+
+    fn headroom(alias: &str, bills_credits: bool, score: f64, ts: i64) -> ScoredRecovery {
+        scored(alias, bills_credits, score, ts, RecoveryCost::Headroom)
+    }
+
+    fn with_reset(
+        alias: &str,
+        bills_credits: bool,
+        score: f64,
+        ts: i64,
+        expires_unused: bool,
+    ) -> ScoredRecovery {
+        scored(
+            alias,
+            bills_credits,
+            score,
+            ts,
+            RecoveryCost::ResetCredit(ResetPlan {
+                credit_id: Some(format!("credit-{alias}")),
+                expires_at: Some(ts),
+                expires_unused,
+            }),
+        )
     }
 
     fn selection_candidate(
@@ -407,32 +765,56 @@ mod tests {
 
     #[test]
     fn recovery_skips_usage_based_accounts() {
-        assert_eq!(recovery_score(&usage_based_response()), None);
+        assert_eq!(recovery_class(&usage_based_response()), None);
     }
 
     #[test]
-    fn recovery_skips_accounts_without_rate_limit_headroom() {
-        // 5h window already at 100% -> not usable right now, even though the
-        // spend cap is reached (no-bill).
-        assert_eq!(recovery_score(&team_response(100.0, 20.0, true)), None);
+    fn recovery_skips_exhausted_accounts_without_a_redeemable_reset() {
+        // 5h window already at 100% and no banked reset -> nothing can make it
+        // usable right now, even though the spend cap is reached (no-bill).
+        assert_eq!(recovery_class(&team_response(100.0, 20.0, true)), None);
+    }
+
+    #[test]
+    fn recovery_keeps_exhausted_account_that_can_redeem_a_reset() {
+        // Same exhausted account, but a banked reset is applicable: it becomes
+        // usable again at the cost of one credit.
+        let class = recovery_class(&team_response_with_resets(100.0, 20.0, true, 2)).unwrap();
+        assert!(class.needs_reset);
+        assert!(!class.bills_credits);
+    }
+
+    #[test]
+    fn recovery_ignores_banked_resets_that_are_not_applicable_yet() {
+        // Credits held but none applicable — the backend reports zero until a
+        // window is actually exhausted, so redeeming would waste one.
+        let usage = api::RateLimitResponse {
+            rate_limit_reset_credits: Some(api::ResetCreditsSummary {
+                available_count: 3,
+                applicable_available_count: 0,
+            }),
+            ..team_response(100.0, 20.0, true)
+        };
+        assert_eq!(recovery_class(&usage), None);
     }
 
     #[test]
     fn recovery_treats_spend_capped_account_as_no_bill() {
         // Spend cap reached + headroom -> usable and hard-stops, so won't bill.
-        let (bills_credits, _) = recovery_score(&team_response(10.0, 30.0, true)).unwrap();
+        let class = recovery_class(&team_response(10.0, 30.0, true)).unwrap();
         assert!(
-            !bills_credits,
+            !class.bills_credits,
             "spend-cap-reached accounts hard-stop at 100% and must be treated as no-bill"
         );
+        assert!(!class.needs_reset);
     }
 
     #[test]
     fn recovery_treats_overage_open_account_as_billing() {
         // Spend cap NOT reached -> overage open -> draws credits past 100%.
-        let (bills_credits, _) = recovery_score(&team_response(5.0, 71.0, false)).unwrap();
+        let class = recovery_class(&team_response(5.0, 71.0, false)).unwrap();
         assert!(
-            bills_credits,
+            class.bills_credits,
             "overage-open accounts can draw credits and must require consent"
         );
     }
@@ -520,6 +902,38 @@ mod tests {
         assert_eq!(select_most_available(&scored, true), Some("b"));
     }
 
+    /// The gate that lets `codexctl use` reach for a banked reset: it must
+    /// report "nothing usable" rather than handing back an exhausted account.
+    #[test]
+    fn select_with_headroom_returns_nothing_when_every_account_is_exhausted() {
+        let scored = vec![
+            selection_candidate("a", false, 700.0, 2000),
+            selection_candidate("b", false, 900.0, 1000),
+        ];
+        for mode in [true, false] {
+            assert_eq!(
+                select_with_headroom(&scored, mode),
+                None,
+                "reset_aware={mode}"
+            );
+        }
+        // ...while the legacy fallback still yields the least-bad account.
+        assert_eq!(select_most_available(&scored, true), Some("a"));
+    }
+
+    /// Legacy mode is documented as pure most-headroom ordering, and the
+    /// headroom pre-pass must not change which account that picks.
+    #[test]
+    fn select_with_headroom_matches_the_legacy_pick_when_headroom_exists() {
+        let scored = vec![
+            selection_candidate("billing", true, 20.0, 1000),
+            selection_candidate("no-bill", false, 60.0, 2000),
+            selection_candidate("exhausted", false, 700.0, 500),
+        ];
+        assert_eq!(select_with_headroom(&scored, false), Some("billing"));
+        assert_eq!(select_most_available(&scored, false), Some("billing"));
+    }
+
     #[test]
     fn select_most_available_skips_usage_based_in_both_modes() {
         // Usage-based -> score f64::MAX -> never usable.
@@ -533,8 +947,8 @@ mod tests {
         // A billing account resets soonest; a no-bill account resets later.
         // No-bill must still win — reset is only a tiebreak within a bill class.
         let candidates = vec![
-            ("bills".to_string(), true, 10.0, 1000),
-            ("nobill".to_string(), false, 50.0, 5000),
+            headroom("bills", true, 10.0, 1000),
+            headroom("nobill", false, 50.0, 5000),
         ];
         assert_eq!(select_recovery(candidates, true).unwrap().alias, "nobill");
     }
@@ -542,8 +956,8 @@ mod tests {
     #[test]
     fn reset_aware_recovery_breaks_ties_by_soonest_reset() {
         let candidates = vec![
-            ("late".to_string(), false, 10.0, 5000),
-            ("soon".to_string(), false, 40.0, 1000),
+            headroom("late", false, 10.0, 5000),
+            headroom("soon", false, 40.0, 1000),
         ];
         assert_eq!(
             select_recovery(candidates.clone(), true).unwrap().alias,
@@ -551,5 +965,169 @@ mod tests {
         );
         // Default ignores reset and keeps the most-headroom pick.
         assert_eq!(select_recovery(candidates, false).unwrap().alias, "late");
+    }
+
+    #[test]
+    fn recovery_prefers_headroom_over_spending_a_banked_reset() {
+        // Redeeming is free in money but spends a scarce, expiring asset, so an
+        // account that just works must always win.
+        let candidates = vec![
+            with_reset("exhausted", false, 700.0, 1000, false),
+            headroom("free", false, 90.0, 5000),
+        ];
+        for mode in [true, false] {
+            assert_eq!(
+                select_recovery(candidates.clone(), mode).unwrap().alias,
+                "free",
+                "reset_aware={mode}"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_prefers_a_banked_reset_over_billing_credits() {
+        // A reset costs no money; a billing account eventually does. When no
+        // free-and-ready account is left, redeem before reaching for credits.
+        let candidates = vec![
+            headroom("billing", true, 10.0, 1000),
+            with_reset("reset", false, 700.0, 5000, false),
+        ];
+        for mode in [true, false] {
+            let picked = select_recovery(candidates.clone(), mode).unwrap();
+            assert_eq!(picked.alias, "reset", "reset_aware={mode}");
+            assert!(picked.reset_plan().is_some());
+        }
+    }
+
+    #[test]
+    fn recovery_spends_a_lapsing_reset_before_a_bankable_one() {
+        // A credit that expires before its window would reset anyway is
+        // use-it-or-lose-it: spending it costs nothing.
+        let candidates = vec![
+            with_reset("bankable", false, 700.0, 1000, false),
+            with_reset("lapsing", false, 900.0, 5000, true),
+        ];
+        for mode in [true, false] {
+            assert_eq!(
+                select_recovery(candidates.clone(), mode).unwrap().alias,
+                "lapsing",
+                "reset_aware={mode}"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_salvages_a_lapsing_credit_before_switching_to_a_billing_account() {
+        // Both options leave a billing-capable account in hand, but one also
+        // rescues a credit that would otherwise evaporate.
+        let candidates = vec![
+            headroom("billing", true, 10.0, 1000),
+            with_reset("lapsing", true, 700.0, 5000, true),
+        ];
+        for mode in [true, false] {
+            assert_eq!(
+                select_recovery(candidates.clone(), mode).unwrap().alias,
+                "lapsing",
+                "reset_aware={mode}"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_still_prefers_billing_headroom_over_spending_a_bankable_credit() {
+        let candidates = vec![
+            headroom("billing", true, 10.0, 1000),
+            with_reset("bankable", true, 700.0, 5000, false),
+        ];
+        assert_eq!(
+            select_recovery(candidates, true).unwrap().alias,
+            "billing",
+            "a credit worth keeping must not be spent to avoid a billing switch"
+        );
+    }
+
+    #[test]
+    fn reset_aware_recovery_spends_the_soonest_expiring_credit_first() {
+        let candidates = vec![
+            with_reset("later", false, 700.0, 5000, false),
+            with_reset("sooner", false, 700.0, 1000, false),
+        ];
+        assert_eq!(
+            select_recovery(candidates, true).unwrap().alias,
+            "sooner",
+            "drain the credit closest to lapsing"
+        );
+    }
+
+    #[test]
+    fn natural_reset_ts_uses_the_latest_exhausted_window() {
+        // Only exhausted windows gate the account; the 7d one clears last.
+        let usage = api::RateLimitResponse {
+            rate_limit: Some(api::RateLimit {
+                primary: Some(window_resetting_at(100.0, 1_000)),
+                secondary: Some(window_resetting_at(100.0, 9_000)),
+                primary_window: None,
+                secondary_window: None,
+            }),
+            ..team_response(100.0, 100.0, true)
+        };
+        assert_eq!(natural_reset_ts(&usage), Some(9_000));
+    }
+
+    #[test]
+    fn natural_reset_ts_ignores_windows_with_headroom() {
+        let usage = api::RateLimitResponse {
+            rate_limit: Some(api::RateLimit {
+                primary: Some(window_resetting_at(100.0, 1_000)),
+                secondary: Some(window_resetting_at(40.0, 9_000)),
+                primary_window: None,
+                secondary_window: None,
+            }),
+            ..team_response(100.0, 40.0, true)
+        };
+        assert_eq!(natural_reset_ts(&usage), Some(1_000));
+    }
+
+    #[test]
+    fn reset_plan_picks_the_soonest_expiring_available_credit() {
+        let details = api::ResetCreditsDetails {
+            credits: vec![
+                credit("late", "available", Some("2026-08-12T00:00:00Z")),
+                credit("soon", "available", Some("2026-07-26T00:00:00Z")),
+                // Already spent, and expiring earliest — must be ignored.
+                credit("spent", "redeemed", Some("2026-07-01T00:00:00Z")),
+            ],
+            available_count: 2,
+        };
+        let plan = reset_plan(Some(&details), None);
+        assert_eq!(plan.credit_id.as_deref(), Some("soon"));
+    }
+
+    #[test]
+    fn reset_plan_flags_a_credit_that_would_lapse_before_the_window_resets() {
+        let expires_at = chrono::DateTime::parse_from_rfc3339("2026-07-26T00:00:00Z")
+            .unwrap()
+            .timestamp();
+        let details = api::ResetCreditsDetails {
+            credits: vec![credit("c", "available", Some("2026-07-26T00:00:00Z"))],
+            available_count: 1,
+        };
+
+        // Window clears after the credit lapses -> the credit is worthless if
+        // held, so spending it is free.
+        assert!(reset_plan(Some(&details), Some(expires_at + 60)).expires_unused);
+        // Window clears first -> the credit stays bankable for a later crunch.
+        assert!(!reset_plan(Some(&details), Some(expires_at - 60)).expires_unused);
+        // Unknown reset time -> never assume the credit is free to burn.
+        assert!(!reset_plan(Some(&details), None).expires_unused);
+    }
+
+    #[test]
+    fn reset_plan_without_a_readable_listing_defers_the_pick_to_the_backend() {
+        // The usage response already confirmed a credit is applicable, so a
+        // failed listing must not block recovery.
+        let plan = reset_plan(None, Some(1_000));
+        assert_eq!(plan.credit_id, None);
+        assert!(!plan.expires_unused);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,37 @@ enum Commands {
     Use {
         /// Profile alias to switch to (auto-selects most available if omitted)
         alias: Option<String>,
+        /// When auto-selecting and no account has headroom left, redeem a
+        /// banked reset without prompting (resets are scarce and expire)
+        #[arg(long)]
+        allow_resets: bool,
     },
     /// Interactive fuzzy picker to switch accounts
     Switch,
+    /// List banked rate-limit resets across all accounts
+    Resets {
+        /// Redeem every banked reset that is about to lapse on an account
+        /// that is already rate-limited, instead of just listing them
+        #[arg(long)]
+        claim: bool,
+        /// How soon a credit must lapse to be claimed, in days
+        #[arg(long, default_value_t = 3, requires = "claim")]
+        within_days: i64,
+        /// Claim without confirming (for unattended runs)
+        #[arg(long, short = 'y', requires = "claim")]
+        yes: bool,
+    },
+    /// Redeem a banked rate-limit reset to clear an exhausted window
+    Reset {
+        /// Profile alias to redeem for (defaults to the active account)
+        alias: Option<String>,
+        /// Redeem without confirming (for unattended runs)
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Redeem a specific credit id (defaults to the soonest-expiring one)
+        #[arg(long)]
+        credit: Option<String>,
+    },
     /// List saved profiles
     List,
     /// Remove a saved profile
@@ -59,6 +87,12 @@ enum Commands {
         /// prompting (use for unattended runs; it may spend credits)
         #[arg(long)]
         allow_billing: bool,
+        /// Allow recovery to redeem a banked rate-limit reset without
+        /// prompting (use for unattended runs; resets are scarce and expire).
+        /// A reset that would lapse before its window resets anyway is always
+        /// redeemed without prompting, flag or not.
+        #[arg(long)]
+        allow_resets: bool,
         /// Arguments forwarded to codex
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -94,8 +128,27 @@ fn main() {
         }
         Commands::Login { ref alias } => commands::login::run(alias),
         Commands::Save { ref alias } => commands::save::run(alias.as_deref()),
-        Commands::Use { ref alias } => commands::use_profile::run(alias.as_deref()),
+        Commands::Use {
+            ref alias,
+            allow_resets,
+        } => commands::use_profile::run(alias.as_deref(), allow_resets),
         Commands::Switch => commands::switch::run(),
+        Commands::Resets {
+            claim,
+            within_days,
+            yes,
+        } => {
+            if claim {
+                commands::resets::run_claim(within_days, yes)
+            } else {
+                commands::resets::run_list()
+            }
+        }
+        Commands::Reset {
+            ref alias,
+            yes,
+            ref credit,
+        } => commands::resets::run_redeem(alias.as_deref(), yes, credit.as_deref()),
         Commands::List => commands::list::run(),
         Commands::Remove { ref alias } => commands::remove::run(alias),
         Commands::Whoami => commands::whoami::run(),
@@ -103,8 +156,14 @@ fn main() {
             ref args,
             ref recovery_prompt,
             allow_billing,
-        } => codex_command_outcome(commands::codex::run(args, recovery_prompt, allow_billing))
-            .into_result(),
+            allow_resets,
+        } => codex_command_outcome(commands::codex::run(
+            args,
+            recovery_prompt,
+            allow_billing,
+            allow_resets,
+        ))
+        .into_result(),
         Commands::Completions { shell } => commands::completions::run(shell),
     };
 

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -73,10 +73,10 @@ fn parse_rate_limit_response_old_format() {
     let resp: RateLimitResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.plan_type.as_deref(), Some("pro"));
     let rl = resp.rate_limit.unwrap();
-    let primary = rl.primary().unwrap();
+    let primary = rl.short_window().unwrap();
     assert!((primary.used_percent - 27.0).abs() < f64::EPSILON);
     assert_eq!(primary.reset_timestamp(), Some(1743789600));
-    let secondary = rl.secondary().unwrap();
+    let secondary = rl.long_window().unwrap();
     assert!((secondary.used_percent - 46.0).abs() < f64::EPSILON);
 }
 
@@ -104,11 +104,123 @@ fn parse_rate_limit_response_team_format() {
     let resp: RateLimitResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.plan_type.as_deref(), Some("team"));
     let rl = resp.rate_limit.unwrap();
-    let primary = rl.primary().unwrap();
+    let primary = rl.short_window().unwrap();
     assert!((primary.used_percent - 0.0).abs() < f64::EPSILON);
     assert_eq!(primary.reset_timestamp(), Some(1775369763));
-    let secondary = rl.secondary().unwrap();
+    let secondary = rl.long_window().unwrap();
     assert!((secondary.used_percent - 25.0).abs() < f64::EPSILON);
+}
+
+/// Plans that publish only a weekly window return it in the `primary_window`
+/// slot. Reading windows positionally would report that weekly limit as a 5h
+/// one and leave the 7d reset unknown, which silently disables reset-aware
+/// selection.
+#[test]
+fn parse_rate_limit_response_weekly_only_maps_to_long_window() {
+    let json = r#"{
+        "plan_type": "pro",
+        "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+                "used_percent": 92,
+                "limit_window_seconds": 604800,
+                "reset_after_seconds": 506456,
+                "reset_at": 1785453503
+            },
+            "secondary_window": null
+        }
+    }"#;
+    let resp: RateLimitResponse = serde_json::from_str(json).unwrap();
+    let rl = resp.rate_limit.unwrap();
+    assert!(rl.short_window().is_none());
+    let long = rl.long_window().unwrap();
+    assert!((long.used_percent - 92.0).abs() < f64::EPSILON);
+    assert_eq!(long.reset_timestamp(), Some(1785453503));
+}
+
+#[test]
+fn parse_rate_limit_reset_credits() {
+    let json = r#"{
+        "plan_type": "pro",
+        "rate_limit": null,
+        "rate_limit_reset_credits": {
+            "available_count": 3,
+            "applicable_available_count": 2
+        }
+    }"#;
+    let resp: RateLimitResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(resp.reset_credits_available(), 3);
+    assert_eq!(resp.reset_credits_applicable(), 2);
+}
+
+/// Responses predating banked resets omit the field entirely.
+#[test]
+fn parse_rate_limit_reset_credits_absent() {
+    let json = r#"{"plan_type": "pro", "rate_limit": null}"#;
+    let resp: RateLimitResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(resp.reset_credits_available(), 0);
+    assert_eq!(resp.reset_credits_applicable(), 0);
+}
+
+#[test]
+fn parse_reset_credits_details() {
+    let json = r#"{
+        "credits": [
+            {
+                "id": "RateLimitResetCredit_abc",
+                "reset_type": "codex_rate_limits",
+                "is_supported_by_plan": true,
+                "status": "available",
+                "granted_at": "2026-06-26T23:59:32.757458Z",
+                "expires_at": "2026-07-26T23:59:32.757458Z",
+                "redeemed_at": null,
+                "title": "Full reset",
+                "description": "Thanks for using Codex!"
+            },
+            {
+                "id": "RateLimitResetCredit_def",
+                "reset_type": "codex_rate_limits",
+                "status": "redeemed",
+                "granted_at": "2026-06-01T00:00:00Z",
+                "expires_at": null,
+                "title": null,
+                "description": null
+            }
+        ],
+        "available_count": 1
+    }"#;
+    let details: api::ResetCreditsDetails = serde_json::from_str(json).unwrap();
+    assert_eq!(details.available_count, 1);
+    assert_eq!(details.credits.len(), 2);
+    assert!(details.credits[0].is_available());
+    assert!(!details.credits[1].is_available());
+    assert_eq!(
+        details.credits[0].expires_at_timestamp(),
+        Some(1785110372),
+        "expiry parses as an RFC3339 timestamp"
+    );
+    assert_eq!(details.credits[1].expires_at_timestamp(), None);
+}
+
+#[test]
+fn parse_consume_reset_response_codes() {
+    let reset: api::ConsumeResetResponse =
+        serde_json::from_str(r#"{"code": "reset", "windows_reset": 2}"#).unwrap();
+    assert_eq!(reset.code, api::ConsumeResetCode::Reset);
+    assert_eq!(reset.windows_reset, 2);
+
+    for (raw, expected) in [
+        ("nothing_to_reset", api::ConsumeResetCode::NothingToReset),
+        ("no_credit", api::ConsumeResetCode::NoCredit),
+        ("already_redeemed", api::ConsumeResetCode::AlreadyRedeemed),
+        ("something_new", api::ConsumeResetCode::Unknown),
+    ] {
+        let resp: api::ConsumeResetResponse =
+            serde_json::from_str(&format!(r#"{{"code": "{raw}"}}"#)).unwrap();
+        assert_eq!(resp.code, expected, "code {raw}");
+        assert_eq!(resp.windows_reset, 0);
+    }
 }
 
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -14,7 +14,30 @@ fn help_shows_all_subcommands() {
     assert!(stdout.contains("remove"));
     assert!(stdout.contains("whoami"));
     assert!(stdout.contains("codex"));
+    assert!(stdout.contains("resets"));
+    assert!(stdout.contains("reset"));
     assert!(stdout.contains("completions"));
+}
+
+#[test]
+fn reset_accepts_an_alias_and_unattended_flags() {
+    let mut cmd = Command::cargo_bin("codexctl").unwrap();
+    let output = cmd.args(["reset", "--help"]).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("[ALIAS]"), "alias is optional: {stdout}");
+    assert!(stdout.contains("--yes"));
+    assert!(stdout.contains("--credit"));
+}
+
+/// Spending banked resets and spending credits are separate approvals, so the
+/// wrapper must expose a separate flag for each.
+#[test]
+fn codex_has_independent_reset_and_billing_flags() {
+    let mut cmd = Command::cargo_bin("codexctl").unwrap();
+    let output = cmd.args(["codex", "--help"]).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--allow-billing"));
+    assert!(stdout.contains("--allow-resets"));
 }
 
 #[test]


### PR DESCRIPTION
OpenAI now grants **banked rate-limit resets** — credits that clear an exhausted usage window on demand instead of waiting for it to lapse. They are per-account, expire ~30 days after grant, and are not refundable, so codexctl treats them as a scarce resource rather than something to spend freely.

## Commands

- `codexctl resets` — what each account holds and when each credit lapses.
- `codexctl resets --claim` — redeem credits about to lapse on accounts already at 100% (`--within-days`, default 3).
- `codexctl reset [alias]` — redeem one, spending the soonest-expiring credit.
- `status` gains a `Resets` column, free from the usage response it already fetches.

## Selection

`codexctl use` and `codexctl codex` recovery now share one cost-ranked ladder:

| Rank | Candidate | Consent |
|---|---|---|
| 0 | No-bill account with headroom | automatic (unchanged) |
| 1 | Lapsing credit, no-bill | automatic — costs nothing |
| 2 | Bankable credit, no-bill | ask / `--allow-resets` |
| 3 | Lapsing credit, billing account | automatic — costs nothing |
| 4 | Headroom, billing account | ask / `--allow-billing` |
| 5 | Bankable credit, billing account | ask / `--allow-resets` |

Resets rank ahead of spending money, and `--allow-billing` deliberately does not imply permission to spend resets. A credit that expires before its window would reset anyway is redeemed with no prompt — holding it back cannot pay off. Every redemption is gated on the backend's `applicable_available_count`, which is nonzero only once a window is actually exhausted, so a credit is never wasted on an account that has nothing to reset.

Previously `codexctl use` had no reset awareness at all: with every account exhausted it handed back a seat at 100%.

## Window mapping fix

Rate-limit windows are now matched by their declared duration rather than by position. Plans that publish only a weekly limit return it in the `primary_window` slot; reading that positionally reported a weekly limit under `5h`, left `7d Reset` empty, and silently disabled the reset-aware selection added in v0.1.13 (its tiebreak keyed on a window that always read as absent).

## Verification

Live against a real 4-account fleet:

- Redemption end to end: with only exhausted accounts visible, `codexctl use` picked the seat holding a credit expiring in 2 days, auto-redeemed it (no prompt, since it would have lapsed), and the window went 100% → 0% with a fresh 7-day reset.
- A bankable credit on an exhausted account correctly refused to redeem without consent.
- `resets --claim` salvaged a credit that would have expired unused.
- Redemptions do not land on `wham/usage` immediately, so a bounded poll runs before status is re-read; without it a successful redeem looked like a no-op.

`cargo fmt --check` clean, zero clippy warnings, 151 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhndKg4ohZgH37XjQ48HFg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for banked rate-limit resets with new CLI commands and reset-aware auto-recovery that spends expiring credits before paid usage. Also fixes window mapping so weekly-only plans are detected correctly.

- **New Features**
  - `codexctl resets` lists credits; `--claim` redeems ones about to lapse on exhausted accounts (`--within-days`, `--yes`). `codexctl reset [alias]` redeems one, spending the soonest-expiring; refusals when none apply. Shell completions suggest profile aliases for `reset`.
  - `status` adds a `Resets` column showing held vs redeemable now.
  - Recovery in `codexctl use` and `codexctl codex` ranks by cost: free headroom > lapsing reset > bankable reset > paid usage. `--allow-resets` is separate from `--allow-billing`; `codexctl use --allow-resets` can auto-redeem a lapsing credit when all seats are exhausted.

- **Bug Fixes**
  - Match rate-limit windows by declared duration (short/long) instead of position, so plans that only publish a weekly limit are handled correctly.

<sup>Written for commit dabaf29fd2340780ecab809a0a148242c1e001d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

