### PR TITLE
feat(cli): report the installed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ codexctl codex -- ...  # run Codex with spend-cap recovery
 codexctl resets        # list banked rate-limit resets
 codexctl reset [alias] # redeem a banked reset
 codexctl remove <alias>
+codexctl --version     # installed version
 ```
 
 ## Shell completions

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,11 @@ use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
 #[derive(Parser)]
-#[command(name = "codexctl", about = "Manage multiple Codex CLI accounts")]
+#[command(
+    name = "codexctl",
+    about = "Manage multiple Codex CLI accounts",
+    version
+)]
 pub struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -40,6 +40,22 @@ fn codex_has_independent_reset_and_billing_flags() {
     assert!(stdout.contains("--allow-resets"));
 }
 
+/// Installed builds need to be able to report their own version, so an upgrade
+/// can be confirmed from the binary rather than from the package manager.
+#[test]
+fn version_flag_reports_the_package_version() {
+    for flag in ["--version", "-V"] {
+        let mut cmd = Command::cargo_bin("codexctl").unwrap();
+        let output = cmd.arg(flag).output().unwrap();
+        assert!(output.status.success(), "{flag} should exit zero");
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(
+            stdout.trim(),
+            format!("codexctl {}", env!("CARGO_PKG_VERSION"))
+        );
+    }
+}
+
 #[test]
 fn unknown_subcommand_fails() {
     let mut cmd = Command::cargo_bin("codexctl").unwrap();


### PR DESCRIPTION
`codexctl --version` failed outright:

```text
$ codexctl --version
error: unexpected argument '--version' found
```

The clap derive never enabled `version`, so an installed build could not say which version it was — confirming an upgrade meant asking Homebrew instead of the binary. That is exactly the check you want after `brew upgrade`.

```text
$ codexctl --version
codexctl 0.1.16
$ codexctl -V
codexctl 0.1.16
```

Version comes from `CARGO_PKG_VERSION`, so it tracks `Cargo.toml` with nothing extra to keep in sync. The test asserts both spellings against `env!("CARGO_PKG_VERSION")` rather than a hard-coded string, so it cannot drift at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhndKg4ohZgH37XjQ48HFg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add version reporting to the CLI. `codexctl --version` and `-V` now print the installed version, so users can confirm upgrades from the binary.

- **New Features**
  - Enable version flags in `clap` derive (`version`) for `codexctl`.
  - Version is sourced from `CARGO_PKG_VERSION`, tracking `Cargo.toml` automatically.
  - Tests verify both flags’ output; README now documents `--version`.

<sup>Written for commit 2fabbf6149b716989878ca00276ebf0c3589fc32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` and `-V` options to display the installed `codexctl` version.
* **Documentation**
  * Updated the command reference to include the new version options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->