### PR TITLE
SAW-9895 Harden account status and profile storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
@@ -36,12 +38,29 @@ jobs:
       - name: Build
         run: cargo build --release
 
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Audit Cargo.lock
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   trunk:
     name: Trunk Check
     # trunk-ignore(actionlint/runner-label): Namespace profile
     runs-on: namespace-profile-sawmills-runner-large
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - name: Cache Trunk and Rust artifacts
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         # yamllint disable-line rule:line-length
@@ -64,6 +83,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -41,7 +41,7 @@ jobs:
     # trunk-ignore(actionlint/runner-label): Namespace profile
     runs-on: namespace-profile-sawmills-runner-large
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Cache Trunk and Rust artifacts
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         # yamllint disable-line rule:line-length
@@ -50,11 +50,11 @@ jobs:
           cache: rust
           path: |
             /home/runner/.cache/trunk
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1
         with:
           cache: false
           check-mode: ${{ github.event_name == 'pull_request' && 'pull_request' || 'all' }}
@@ -63,9 +63,9 @@ jobs:
     name: Build (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build
         run: cargo build --release
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,7 +22,7 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       target: ${{ steps.resolve.outputs.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -55,6 +55,12 @@ jobs:
             exit 1
           fi
 
+          cargo_version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+          if [[ "${tag}" != "v${cargo_version}" ]]; then
+            echo "Tag ${tag} does not match Cargo.toml version ${cargo_version}." >&2
+            exit 1
+          fi
+
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
@@ -79,15 +85,15 @@ jobs:
             target: x86_64-unknown-linux-gnu
             label: Linux_x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.setup.outputs.checkout_ref }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -102,7 +108,7 @@ jobs:
           tar -czf "${archive}" -C "target/${{ matrix.target }}/release" codexctl
           shasum -a 256 "${archive}" > "${archive}.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codexctl_${{ matrix.label }}
           path: |
@@ -113,12 +119,14 @@ jobs:
     name: Publish release
     needs: [setup, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       sha_darwin_arm64: ${{ steps.shas.outputs.darwin_arm64 }}
       sha_darwin_x86_64: ${{ steps.shas.outputs.darwin_x86_64 }}
       sha_linux_x86_64: ${{ steps.shas.outputs.linux_x86_64 }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true
@@ -136,15 +144,30 @@ jobs:
             echo "linux_x86_64=$(sha Linux_x86_64)"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create or update GitHub release
+      - name: Create immutable GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${{ needs.setup.outputs.tag }}"
           if gh release view "${tag}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            gh release upload "${tag}" dist/codexctl_*.tar.gz dist/codexctl_*.tar.gz.sha256 \
-              --repo "${{ github.repository }}" --clobber
+            existing="$(mktemp -d)"
+            trap 'rm -rf "${existing}"' EXIT
+            gh release download "${tag}" --repo "${{ github.repository }}" \
+              --pattern 'codexctl_*' --dir "${existing}"
+            for local_asset in dist/codexctl_*; do
+              asset_name="$(basename "${local_asset}")"
+              remote_asset="${existing}/${asset_name}"
+              if [[ ! -f "${remote_asset}" ]]; then
+                echo "Existing release is missing ${asset_name}; refusing to mutate it." >&2
+                exit 1
+              fi
+              if ! cmp -s "${local_asset}" "${remote_asset}"; then
+                echo "Existing release asset ${asset_name} differs; refusing to replace it." >&2
+                exit 1
+              fi
+            done
+            echo "Existing release assets are byte-identical."
           else
             gh release create "${tag}" dist/codexctl_*.tar.gz dist/codexctl_*.tar.gz.sha256 \
               --repo "${{ github.repository }}" --target "${{ needs.setup.outputs.target }}" \
@@ -158,14 +181,12 @@ jobs:
     steps:
       - id: token
         name: Create token
-        continue-on-error: true
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
           app_id: ${{ vars.SAWMILLS_REPO_APP_ID }}
           private_key: ${{ secrets.SAWMILLS_APP_PRIVATE_KEY }}
 
       - name: Open formula PR on public tap
-        if: steps.token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TAG: ${{ needs.setup.outputs.tag }}
@@ -179,9 +200,7 @@ jobs:
 
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
-          git clone --depth 1 \
-            "https://x-access-token:${GH_TOKEN}@github.com/Sawmills/homebrew-tap.git" \
-            "${workdir}/tap"
+          gh repo clone Sawmills/homebrew-tap "${workdir}/tap" -- --depth 1
 
           cat > "${workdir}/tap/Formula/codexctl.rb" << EOF
           class Codexctl < Formula
@@ -247,7 +266,5 @@ jobs:
               --body "Automated formula update for codexctl ${TAG}, built from https://github.com/${{ github.repository }}/releases/tag/${TAG}."
           fi
 
-          # Best effort: queue auto-merge if the tap enables it; otherwise the
-          # PR stays open for a maintainer to merge once formula-ci is green.
           gh pr merge "${branch}" --repo Sawmills/homebrew-tap --squash --auto --delete-branch \
-            || echo "Auto-merge unavailable; PR left open for manual merge."
+            --match-head-commit "$(git rev-parse HEAD)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: resolve
         env:
@@ -88,6 +89,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.setup.outputs.checkout_ref }}
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
@@ -181,10 +183,14 @@ jobs:
     steps:
       - id: token
         name: Create token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
-          app_id: ${{ vars.SAWMILLS_REPO_APP_ID }}
-          private_key: ${{ secrets.SAWMILLS_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.SAWMILLS_REPO_APP_ID }}
+          private-key: ${{ secrets.SAWMILLS_APP_PRIVATE_KEY }}
+          owner: Sawmills
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Open formula PR on public tap
         env:

--- a/.sisyphus/plans/saw-9895-codexctl-hardening.md
+++ b/.sisyphus/plans/saw-9895-codexctl-hardening.md
@@ -1,0 +1,90 @@
+# SAW-9895 codexctl hardening plan
+
+## Outcome
+
+Make account status accurate for the current multi-bucket subscription contract.
+Prevent unsafe profile paths and billable automatic selection.
+Make auth-file changes private, serialized, and atomic per file.
+Restore dependency and release gates.
+
+## Verified inputs
+
+- Homebrew and `/opt/homebrew/bin/codexctl` both use version `0.1.16`.
+- The live main bucket currently has one 604,800-second window.
+- The live response also has a named `GPT-5.3-Codex-Spark` bucket.
+- The current Codex app-server returns the same `codex` and `codex_bengalfox` buckets.
+- Current OpenAI pricing docs define a shared rolling 5-hour limit and possible weekly limits.
+- The CLI must render the server response. It must not invent a missing 5-hour value.
+- Claude Opus reviewed the architecture. It confirmed the findings and the scope limits below.
+
+## Work
+
+1. Add centralized profile-alias validation and checked profile-path construction.
+   Validate CLI input, stored metadata, active aliases, and server-derived aliases.
+   Reject absolute paths, separators, parent components, control characters, non-ASCII names, hidden staging names, case-fold collisions, and excessive length.
+   Keep existing email aliases valid.
+
+2. Add centralized billing classification in `src/api.rs`.
+   Use `RateLimited`, `UsageBased`, and `Unknown` states.
+   Allow automatic selection and recovery only for confirmed rate-limited accounts.
+   Keep usage-based and unknown accounts out of all no-bill automatic paths.
+
+3. Add a store lock and atomic file primitives.
+   Lock profile mutations and live-auth switches.
+   Write a temporary file in the destination directory, sync it, set private Unix permissions, then rename it.
+   Order a switch so the live auth file is installed before the active marker changes.
+   Preserve the existing active-profile token-refresh ownership checks.
+
+4. Use the live auth file for the active profile.
+   Centralize auth-source selection.
+   Use saved snapshots only for inactive profiles or when the live token subject does not belong to the selected profile.
+
+5. Add bounded HTTP clients.
+   Use explicit connect and total request timeouts for blocking and async calls.
+   Reuse one async client within each multi-account command.
+
+6. Update the status model for the current contract.
+   Parse all returned named rate-limit buckets.
+   Classify windows by their declared duration.
+   Render only window classes returned by the server.
+   Show additional named buckets without exposing auth data.
+   Keep reset-credit and token-expiry data aligned with the main account bucket.
+
+7. Remove state creation from information-only commands.
+   Parse the command before store initialization.
+   Do not create `.codexctl` for help, version, completions, or invalid commands.
+
+8. Update rejected dependencies.
+   Upgrade `anyhow` past RUSTSEC-2026-0190.
+   Upgrade or remove the locked `quinn-proto` version rejected by GHSA-4w2j-m93h-cj5j.
+   Confirm the actual compiled dependency tree and the lockfile scanner result.
+
+9. Harden `.github/workflows/release.yml`.
+   Use least-privilege job permissions.
+   Pin third-party actions to full commit SHAs.
+   Pin the GitHub App private-key consumer.
+   Make a Homebrew update failure fail the workflow.
+   Refuse to replace published assets with different bytes.
+   Verify the tag and Cargo version match.
+
+10. Add regression coverage.
+    Cover path traversal, invalid stored aliases, active marker validation, billing classification, unknown-account exclusion, active auth ownership, atomic permissions, timeouts, adaptive columns, multiple buckets, and no-state CLI paths.
+
+## Gates
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test`
+- `cargo run -- --help`
+- `trunk check`
+- Read-only Claude Opus architecture review of the implementation plan and critical invariants
+- Exact worktree, branch, HEAD, and dirty-state proof
+- Installed-path verification after a release and Homebrew installation
+
+## Scope limits
+
+- Do not refactor `src/commands/codex.rs` in this change.
+- Do not replace all command path wrappers with dependency injection.
+- Do not claim crash consistency across several files without a journal.
+- Do not add Windows locking or permission claims when the shipped targets are macOS and Linux.
+- Do not push, open a pull request, merge, release, or modify the Homebrew tap without explicit authority.

--- a/.sisyphus/plans/saw-9895-codexctl-hardening.md
+++ b/.sisyphus/plans/saw-9895-codexctl-hardening.md
@@ -33,6 +33,8 @@ Restore dependency and release gates.
    Lock profile mutations and live-auth switches.
    Write a temporary file in the destination directory, sync it, set private Unix permissions, then rename it.
    Order a switch so the live auth file is installed before the active marker changes.
+   Accept that a crash between the two atomic files leaves the old marker.
+   In that state, never attribute the new live auth to the old alias; a repeated explicit switch reconciles both files.
    Preserve the existing active-profile token-refresh ownership checks.
 
 4. Use the live auth file for the active profile.
@@ -57,7 +59,7 @@ Restore dependency and release gates.
 8. Update rejected dependencies.
    Upgrade `anyhow` past RUSTSEC-2026-0190.
    Upgrade or remove the locked `quinn-proto` version rejected by GHSA-4w2j-m93h-cj5j.
-   Confirm the actual compiled dependency tree and the lockfile scanner result.
+   Enforce a RustSec lockfile scan in `.github/workflows/ci.yml` and confirm the compiled dependency tree.
 
 9. Harden `.github/workflows/release.yml`.
    Use least-privilege job permissions.
@@ -76,6 +78,7 @@ Restore dependency and release gates.
 - `cargo clippy --all-targets --all-features -- -D warnings`
 - `cargo test`
 - `cargo run -- --help`
+- RustSec `Dependency Audit` CI job
 - `trunk check`
 - Read-only Claude Opus architecture review of the implementation plan and critical invariants
 - Exact worktree, branch, HEAD, and dirty-state proof

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
@@ -170,6 +170,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -246,6 +257,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
+ "fs2",
  "futures",
  "libc",
  "portable-pty",
@@ -301,6 +313,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossterm"
@@ -479,6 +500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,29 +621,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1098,15 +1118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,14 +1185,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1218,43 +1230,34 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2424,26 +2427,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,6 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
- "fs2",
  "futures",
  "libc",
  "portable-pty",
@@ -497,16 +496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ crossterm = "0.29"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 dirs = "6"
 futures = "0.3"
-fs2 = "0.4"
 libc = "0.2"
 portable-pty = "0.9"
 reqwest = { version = "0.12", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"
@@ -15,6 +15,7 @@ crossterm = "0.29"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 dirs = "6"
 futures = "0.3"
+fs2 = "0.4"
 libc = "0.2"
 portable-pty = "0.9"
 reqwest = { version = "0.12", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ If you already logged in with Codex directly, save the current `~/.codex/auth.js
 codexctl save work-main
 ```
 
+Profile aliases use printable ASCII and are unique without regard to letter case. This keeps the
+credential-store namespace identical on default macOS and Linux filesystems.
+
 ### Check rate limits
 
 ```bash
@@ -41,13 +44,14 @@ codexctl status
 Live status fetched at Tue Apr 28 22:20:56
 
 Rate-Limited Accounts
-┌──────────────────────┬─────┬───────────┬─────┬────────────────────────────────┬─────────────┐
-│ Account              ┆ 5h  ┆ 5h Reset  ┆ 7d  ┆ 7d Reset                      ┆ Token       │
-╞══════════════════════╪═════╪═══════════╪═════╪════════════════════════════════╪═════════════╡
-│ amir+5@sawmills.ai   ┆ 0%  ┆ in 5h 00m ┆ 25% ┆ in 4d 18h (Sun May 03 16:20) ┆ 9d 23h      │
-│ * amir@sawmills.ai   ┆ 78% ┆ in 3h 54m ┆ 92% ┆ in 4d 15h (Sun May 03 13:20) ┆ 3h 20m      │
-│ amir+8@sawmills.ai   ┆ -   ┆ -         ┆ -   ┆ -                            ┆ invalidated │
-└──────────────────────┴─────┴───────────┴─────┴────────────────────────────────┴─────────────┘
+┌──────────────────────┬───────────────────────┬─────┬──────────────────────────────┬────────┬────────┐
+│ Account              ┆ Limit                 ┆ 7d  ┆ 7d Reset                     ┆ Resets ┆ Token  │
+╞══════════════════════╪═══════════════════════╪═════╪══════════════════════════════╪════════╪════════╡
+│ * amir@sawmills.ai   ┆ Codex                 ┆ 13% ┆ in 6d 23h (Fri Aug 07 15:31) ┆ -      ┆ 4d 19h │
+│ * amir@sawmills.ai   ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆ -      ┆ -      │
+│ amir+2@sawmills.ai   ┆ Codex                 ┆ 100%┆ in 6d 17h (Fri Aug 07 09:29) ┆ 1      ┆ 4d 19h │
+│ amir+2@sawmills.ai   ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆ -      ┆ -      │
+└──────────────────────┴───────────────────────┴─────┴──────────────────────────────┴────────┴────────┘
 
 Usage-Based Accounts
 ┌───────────────────────────┬─────────┬──────┬─────────┬───────┬─────────┐
@@ -60,6 +64,15 @@ Usage-Based Accounts
 
 Sorted by availability — most available accounts first. All accounts are fetched live in parallel.
 The account column is the saved profile alias, with `*` marking the active account.
+
+Rate-limit windows are matched by their server-declared duration. A 5-hour or 7-day column appears
+only when at least one returned bucket contains that window. Named model or feature buckets appear
+as separate rows. `codexctl` does not show an empty 5-hour column when the service returns only a
+weekly window.
+
+Automatic account selection uses the main `Codex` bucket. Additional buckets are model-specific or
+feature-specific status. They do not block general account selection without a reliable mapping
+from the requested model or feature to that bucket.
 
 The `Resets` column shows banked rate-limit resets (see [Banked resets](#banked-resets)):
 `3 (2 now)` means three are held and two can be redeemed this second; a bare count turns red when
@@ -115,7 +128,7 @@ session, pass `resume <session-id>` so the wrapper can recover without discovery
 
 Account selection during recovery:
 
-- **Never** switches to usage-based accounts (they bill credits).
+- **Never** switches to usage-based or unknown-billing accounts.
 - Auto-rotates only among rate-limited accounts that won't bill — spend cap reached (overage
   closed, so they hard-stop at 100% instead of drawing credits) with rate-limit headroom —
   preferring the soonest-resetting seat by default (see Reset-aware selection), and moving to the

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Resets rank ahead of credit-billing accounts because they cost no money. `--allo
 
 ```bash
 codexctl use --allow-resets                                       # unattended: may spend resets
+codexctl use --allow-billing                                      # unattended: may spend credits
 codexctl codex --allow-resets -- "start prompt"
 codexctl codex --allow-resets --allow-billing -- "start prompt"   # ...and may spend credits
 ```
@@ -242,7 +243,7 @@ Completions dynamically list profile names for `use` and `remove`.
 
 ## How it works
 
-Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a copy of `auth.json` and `meta.json`. `codexctl login <alias>` runs `codex login --device-auth` with an isolated `CODEX_HOME` under `~/.codexctl/login-homes/<alias>/`, imports that auth file, then switches to the saved profile. Switching copies the profile's `auth.json` into `~/.codex/auth.json`.
+Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a copy of `auth.json` and `meta.json`. `codexctl login <alias>` runs `codex login --device-auth` with a unique isolated `CODEX_HOME` under `~/.codexctl/login-homes/<alias>/`, imports that auth file, removes the temporary login home, then switches to the saved profile. Switching copies the profile's `auth.json` into `~/.codex/auth.json`.
 
 Rate limits are fetched from `chatgpt.com/backend-api/wham/usage` using the stored access tokens.
 When an account ID is available, codexctl sends it as `chatgpt-account-id` so the usage response is

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ codexctl login amir+2@example.com
 After an account is saved, switch with `codexctl use <alias>` instead of running `codex --login`
 again. A fresh Codex login can invalidate another saved seat on the same ChatGPT account/workspace;
 `codexctl login` avoids logging over `~/.codex/auth.json` by running Codex with
-`CODEX_HOME=~/.codexctl/login-homes/<alias>`, and `codexctl use` only swaps the local auth file.
+`CODEX_HOME=~/.codexctl/login-homes/<alias>/session-*`, and `codexctl use` only swaps the local auth file.
 
 If you already logged in with Codex directly, save the current `~/.codex/auth.json`:
 
@@ -31,8 +31,9 @@ If you already logged in with Codex directly, save the current `~/.codex/auth.js
 codexctl save work-main
 ```
 
-Profile aliases use printable ASCII and are unique without regard to letter case. This keeps the
-credential-store namespace identical on default macOS and Linux filesystems.
+Profile aliases use printable ASCII, hold at most 128 bytes, and are unique without regard to
+letter case. An alias cannot start with `.` or contain control characters, `/`, or `\`. This keeps
+the credential-store namespace identical on default macOS and Linux filesystems.
 
 ### Check rate limits
 
@@ -244,6 +245,11 @@ Completions dynamically list profile names for `use` and `remove`.
 ## How it works
 
 Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a copy of `auth.json` and `meta.json`. `codexctl login <alias>` runs `codex login --device-auth` with a unique isolated `CODEX_HOME` under `~/.codexctl/login-homes/<alias>/`, imports that auth file, removes the temporary login home, then switches to the saved profile. Switching copies the profile's `auth.json` into `~/.codex/auth.json`.
+
+The live auth file and active marker are separate atomic files. A switch installs auth first and
+writes the marker last. If the process stops between those writes, the marker can remain on the
+previous alias. Status reads then use saved profile auth instead of attributing the new live auth
+to the old alias. Run `codexctl use <alias>` again to reconcile both files.
 
 Rate limits are fetched from `chatgpt.com/backend-api/wham/usage` using the stored access tokens.
 When an account ID is available, codexctl sends it as `chatgpt-account-id` so the usage response is

--- a/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
+++ b/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
@@ -56,9 +56,11 @@ An account is "usage-based" when:
 - `rate_limit` is `null` AND `credits` is present with `has_credits: true`, OR
 - `plan_type` contains `usage_based`
 
-All other accounts with rate limit windows are "rate-limited".
+An account is "rate-limited" only when it has rate-limit windows, its `plan_type` is in the known
+subscription allowlist, and it has no conflicting positive credit evidence.
 
-Successful responses with neither rate-limit windows nor positive credit evidence are `Unknown`.
+New plan names, mixed rate-limit and positive-credit responses, and successful responses with
+neither rate-limit windows nor positive credit evidence are `Unknown`.
 Unknown accounts can appear as status errors, but automatic selection and recovery must not use
 them. This keeps unfamiliar subscription metadata out of any path that can spend credits.
 

--- a/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
+++ b/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
@@ -87,6 +87,7 @@ pub struct RateLimitResponse {
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
+    pub rate_limit_reset_credits: Option<ResetCreditsSummary>,
 }
 
 pub struct Credits {

--- a/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
+++ b/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
@@ -10,7 +10,10 @@ Split the status output into two tables, one per billing model. Each table has c
 
 ### Table 1: Rate-Limited Accounts
 
-No changes to the existing table. Shown when at least one rate-limited account exists.
+Shown when at least one rate-limited account exists. Window columns are adaptive. A 5-hour or
+7-day pair appears only when the API returns a window in that duration class. The `Limit` column
+appears when the response includes additional named model or feature buckets. Each bucket gets a
+separate row.
 
 ```
 Rate-Limited Accounts
@@ -55,6 +58,10 @@ An account is "usage-based" when:
 
 All other accounts with rate limit windows are "rate-limited".
 
+Successful responses with neither rate-limit windows nor positive credit evidence are `Unknown`.
+Unknown accounts can appear as status errors, but automatic selection and recovery must not use
+them. This keeps unfamiliar subscription metadata out of any path that can spend credits.
+
 Error accounts (bad auth, expired tokens) appear in whichever table matches their last known plan type from `meta.json`. If no plan is known, they appear in the rate-limited table (legacy default).
 
 ### CLI Flags
@@ -77,6 +84,7 @@ pub struct RateLimitResponse {
     pub rate_limit: Option<RateLimit>,
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
+    pub additional_rate_limits: Vec<AdditionalRateLimit>,
 }
 
 pub struct Credits {

--- a/src/api.rs
+++ b/src/api.rs
@@ -48,19 +48,23 @@ pub struct RateLimitResponse {
 impl RateLimitResponse {
     /// Classify the account before any automatic selection can spend credits.
     pub fn billing_class(&self) -> BillingClass {
-        if self
-            .plan_type
-            .as_deref()
-            .is_some_and(|plan| plan.contains("usage_based"))
-        {
+        let plan = self.plan_type.as_deref();
+        if plan.is_some_and(|plan| plan.contains("usage_based")) {
             return BillingClass::UsageBased;
         }
+        let has_credit_billing = self.credits.as_ref().is_some_and(|credits| {
+            credits.has_credits || credits.unlimited || credits.overage_limit_reached
+        });
         if self.rate_limit.as_ref().is_some_and(RateLimit::has_window) {
+            // A new plan name or mixed rate-limit and credit evidence is not
+            // proof that automatic use is free. Keep it out of selection until
+            // its contract is understood and added deliberately.
+            if has_credit_billing || !plan.is_some_and(is_known_rate_limited_plan) {
+                return BillingClass::Unknown;
+            }
             return BillingClass::RateLimited;
         }
-        if self.credits.as_ref().is_some_and(|credits| {
-            credits.has_credits || credits.unlimited || credits.overage_limit_reached
-        }) {
+        if has_credit_billing {
             return BillingClass::UsageBased;
         }
         BillingClass::Unknown
@@ -81,6 +85,13 @@ impl RateLimitResponse {
             .as_ref()
             .map_or(0, |c| c.applicable_available_count)
     }
+}
+
+fn is_known_rate_limited_plan(plan: &str) -> bool {
+    matches!(
+        plan,
+        "free" | "go" | "plus" | "pro" | "team" | "business" | "enterprise" | "edu"
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Supports both formats:
 /// - Codex CLI: `{"auth_mode": "chatgpt", "tokens": {"access_token": "...", "refresh_token": "..."}}`
 /// - Simple: `{"access_token": "...", "refresh_token": "..."}`
@@ -35,11 +38,34 @@ pub struct RateLimitResponse {
     pub rate_limit: Option<RateLimit>,
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
+    /// Extra feature or model buckets returned alongside the main Codex limit.
+    #[serde(default)]
+    pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Banked rate-limit reset credits, when the plan has any.
     pub rate_limit_reset_credits: Option<ResetCreditsSummary>,
 }
 
 impl RateLimitResponse {
+    /// Classify the account before any automatic selection can spend credits.
+    pub fn billing_class(&self) -> BillingClass {
+        if self
+            .plan_type
+            .as_deref()
+            .is_some_and(|plan| plan.contains("usage_based"))
+        {
+            return BillingClass::UsageBased;
+        }
+        if self.rate_limit.as_ref().is_some_and(RateLimit::has_window) {
+            return BillingClass::RateLimited;
+        }
+        if self.credits.as_ref().is_some_and(|credits| {
+            credits.has_credits || credits.unlimited || credits.overage_limit_reached
+        }) {
+            return BillingClass::UsageBased;
+        }
+        BillingClass::Unknown
+    }
+
     /// How many banked resets are held, redeemable or not.
     pub fn reset_credits_available(&self) -> i64 {
         self.rate_limit_reset_credits
@@ -57,6 +83,20 @@ impl RateLimitResponse {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BillingClass {
+    RateLimited,
+    UsageBased,
+    Unknown,
+}
+
+#[derive(Deserialize)]
+pub struct AdditionalRateLimit {
+    pub limit_name: Option<String>,
+    pub metered_feature: Option<String>,
+    pub rate_limit: Option<RateLimit>,
+}
+
 #[derive(Deserialize)]
 pub struct RateLimit {
     // API returns both naming conventions depending on plan
@@ -71,6 +111,10 @@ pub struct RateLimit {
 const SHORT_WINDOW_MAX_SECONDS: u64 = 24 * 60 * 60;
 
 impl RateLimit {
+    fn has_window(&self) -> bool {
+        self.first().is_some() || self.second().is_some()
+    }
+
     fn first(&self) -> Option<&RateLimitWindow> {
         self.primary.as_ref().or(self.primary_window.as_ref())
     }
@@ -358,8 +402,24 @@ pub async fn fetch_account_settings_async(
 
 const USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
 
+pub fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .context("failed to build HTTP client")
+}
+
+pub fn blocking_http_client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .context("failed to build blocking HTTP client")
+}
+
 pub fn fetch_usage(access_token: &str, account_id: Option<&str>) -> Result<RateLimitResponse> {
-    let client = reqwest::blocking::Client::new();
+    let client = blocking_http_client()?;
     let mut request = client.get(USAGE_URL).bearer_auth(access_token);
     if let Some(account_id) = account_id {
         request = request.header("chatgpt-account-id", account_id);

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -1,15 +1,13 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 
-pub(super) fn optional(alias: Option<&str>) -> Option<&str> {
-    alias.map(str::trim).filter(|alias| !alias.is_empty())
+use crate::store;
+
+pub(super) fn optional(alias: Option<&str>) -> Result<Option<&str>> {
+    alias.map(store::validate_alias).transpose()
 }
 
 pub(super) fn required(alias: &str) -> Result<&str> {
-    let alias = alias.trim();
-    if alias.is_empty() {
-        bail!("profile alias cannot be empty");
-    }
-    Ok(alias)
+    store::validate_alias(alias)
 }
 
 #[cfg(test)]
@@ -19,15 +17,15 @@ mod tests {
     #[test]
     fn optional_trims_alias() {
         assert_eq!(
-            optional(Some("  amir+8@sawmills.ai  ")),
+            optional(Some("  amir+8@sawmills.ai  ")).unwrap(),
             Some("amir+8@sawmills.ai")
         );
     }
 
     #[test]
     fn optional_drops_blank_alias() {
-        assert_eq!(optional(Some("   ")), None);
-        assert_eq!(optional(None), None);
+        assert!(optional(Some("   ")).is_err());
+        assert_eq!(optional(None).unwrap(), None);
     }
 
     #[test]
@@ -41,5 +39,12 @@ mod tests {
     #[test]
     fn required_rejects_blank_alias() {
         assert!(required("   ").is_err());
+    }
+
+    #[test]
+    fn aliases_reject_path_traversal() {
+        for alias in ["../escape", "/tmp/escape", "a/b", "a\\b"] {
+            assert!(required(alias).is_err(), "accepted {alias:?}");
+        }
     }
 }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -23,7 +23,7 @@ mod tests {
     }
 
     #[test]
-    fn optional_drops_blank_alias() {
+    fn optional_rejects_blank_alias() {
         assert!(optional(Some("   ")).is_err());
         assert_eq!(optional(None).unwrap(), None);
     }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, bail};
 use crate::commands::{alias, status};
 use crate::config::{self, Paths};
 use crate::profile;
+use crate::store;
 
 trait CodexLoginRunner {
     fn run_codex_login(&mut self, codex_home: &Path) -> Result<()>;
@@ -15,8 +16,7 @@ struct CodexCliLoginRunner;
 
 impl CodexLoginRunner for CodexCliLoginRunner {
     fn run_codex_login(&mut self, codex_home: &Path) -> Result<()> {
-        std::fs::create_dir_all(codex_home)
-            .with_context(|| format!("failed to create {}", codex_home.display()))?;
+        store::ensure_private_dir(codex_home)?;
 
         let status = Command::new("codex")
             .arg("login")
@@ -47,7 +47,12 @@ pub fn run(alias: &str) -> Result<()> {
 
 fn run_from(paths: &Paths, alias: &str, runner: &mut impl CodexLoginRunner) -> Result<()> {
     let alias = alias::required(alias)?;
-    let codex_home = isolated_login_home(paths, alias);
+    let codex_home = {
+        let _lock = store::lock(paths)?;
+        let home = isolated_login_home(paths, alias)?;
+        store::ensure_private_dir(&home)?;
+        home
+    };
     runner.run_codex_login(&codex_home)?;
 
     let auth_path = codex_home.join("auth.json");
@@ -56,14 +61,13 @@ fn run_from(paths: &Paths, alias: &str, runner: &mut impl CodexLoginRunner) -> R
     }
 
     let email = email_from_alias(alias);
-    profile::save_profile_to(paths, alias, email.as_deref(), &auth_path)?;
-    activate_imported_profile(paths, alias)?;
+    profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)?;
 
     Ok(())
 }
 
-fn isolated_login_home(paths: &Paths, alias: &str) -> PathBuf {
-    paths.login_homes_dir().join(alias)
+fn isolated_login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    store::login_home(paths, alias)
 }
 
 fn email_from_alias(alias: &str) -> Option<String> {
@@ -72,25 +76,6 @@ fn email_from_alias(alias: &str) -> Option<String> {
     } else {
         None
     }
-}
-
-fn activate_imported_profile(paths: &Paths, alias: &str) -> Result<()> {
-    let codex_auth = paths.codex_auth_json();
-    if let Some(parent) = codex_auth.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-
-    if profile::get_active_from(paths)?.as_deref() == Some(alias) {
-        let profile = profile::get_profile_from(paths, alias)?;
-        std::fs::copy(profile.auth_json_path(), &codex_auth)
-            .with_context(|| "failed to copy auth.json to ~/.codex/")?;
-        profile::set_active_from(paths, alias)?;
-        return Ok(());
-    }
-
-    profile::switch_to_from(paths, alias)?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -134,7 +119,7 @@ mod tests {
         let (_tmp, paths) = setup_test_env();
 
         assert_eq!(
-            isolated_login_home(&paths, "amir+8@sawmills.ai"),
+            isolated_login_home(&paths, "amir+8@sawmills.ai").unwrap(),
             paths
                 .codexctl_dir()
                 .join("login-homes")
@@ -151,7 +136,11 @@ mod tests {
 
         assert_eq!(
             runner.seen_home.as_deref(),
-            Some(isolated_login_home(&paths, "amir+8@sawmills.ai").as_path())
+            Some(
+                isolated_login_home(&paths, "amir+8@sawmills.ai")
+                    .unwrap()
+                    .as_path()
+            )
         );
         let saved = std::fs::read_to_string(
             paths

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 
@@ -47,27 +48,59 @@ pub fn run(alias: &str) -> Result<()> {
 
 fn run_from(paths: &Paths, alias: &str, runner: &mut impl CodexLoginRunner) -> Result<()> {
     let alias = alias::required(alias)?;
-    let codex_home = {
-        let _lock = store::lock(paths)?;
-        let home = isolated_login_home(paths, alias)?;
-        store::ensure_private_dir(&home)?;
-        home
-    };
-    runner.run_codex_login(&codex_home)?;
+    let codex_home = create_isolated_login_home(paths, alias)?;
+    let result = (|| {
+        runner.run_codex_login(&codex_home)?;
 
-    let auth_path = codex_home.join("auth.json");
-    if !auth_path.exists() {
-        bail!("codex login did not create {}", auth_path.display());
+        let auth_path = codex_home.join("auth.json");
+        if !auth_path.exists() {
+            bail!("codex login did not create {}", auth_path.display());
+        }
+
+        let email = email_from_alias(alias);
+        profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)
+    })();
+    let cleanup = remove_isolated_login_home(&codex_home);
+
+    match (result, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(error), Err(cleanup_error)) => Err(error.context(format!(
+            "also failed to remove isolated login home: {cleanup_error:#}"
+        ))),
     }
-
-    let email = email_from_alias(alias);
-    profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)?;
-
-    Ok(())
 }
 
-fn isolated_login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
-    store::login_home(paths, alias)
+fn create_isolated_login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    let _lock = store::lock(paths)?;
+    let alias_home = store::login_home(paths, alias)?;
+    store::ensure_private_dir(&alias_home)?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    for attempt in 0..16 {
+        let home = alias_home.join(format!("session-{}-{nonce}-{attempt}", std::process::id()));
+        match std::fs::create_dir(&home) {
+            Ok(()) => {
+                store::ensure_private_dir(&home)?;
+                return Ok(home);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to create {}", home.display()));
+            }
+        }
+    }
+
+    bail!("failed to allocate a unique isolated login home")
+}
+
+fn remove_isolated_login_home(codex_home: &Path) -> Result<()> {
+    std::fs::remove_dir_all(codex_home)
+        .with_context(|| format!("failed to remove {}", codex_home.display()))
 }
 
 fn email_from_alias(alias: &str) -> Option<String> {
@@ -105,6 +138,22 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FailingLoginRunner {
+        seen_home: Option<PathBuf>,
+    }
+
+    impl CodexLoginRunner for FailingLoginRunner {
+        fn run_codex_login(&mut self, codex_home: &Path) -> Result<()> {
+            self.seen_home = Some(codex_home.to_path_buf());
+            std::fs::write(
+                codex_home.join("auth.json"),
+                r#"{"access_token":"partial"}"#,
+            )?;
+            bail!("simulated login failure")
+        }
+    }
+
     fn setup_test_env() -> (tempfile::TempDir, Paths) {
         let tmp = tempfile::tempdir().unwrap();
         let paths = Paths::from_home(tmp.path().to_path_buf());
@@ -115,16 +164,53 @@ mod tests {
     }
 
     #[test]
-    fn isolated_login_home_is_profile_scoped() {
+    fn isolated_login_home_is_unique_and_profile_scoped() {
         let (_tmp, paths) = setup_test_env();
+        let first = create_isolated_login_home(&paths, "amir+8@sawmills.ai").unwrap();
+        let second = create_isolated_login_home(&paths, "amir+8@sawmills.ai").unwrap();
 
-        assert_eq!(
-            isolated_login_home(&paths, "amir+8@sawmills.ai").unwrap(),
-            paths
-                .codexctl_dir()
-                .join("login-homes")
-                .join("amir+8@sawmills.ai")
-        );
+        assert_ne!(first, second);
+        let alias_home = paths
+            .codexctl_dir()
+            .join("login-homes")
+            .join("amir+8@sawmills.ai");
+        assert_eq!(first.parent(), Some(alias_home.as_path()));
+        assert_eq!(second.parent(), Some(alias_home.as_path()));
+        assert!(first.is_dir());
+        assert!(second.is_dir());
+
+        remove_isolated_login_home(&first).unwrap();
+        remove_isolated_login_home(&second).unwrap();
+    }
+
+    #[test]
+    fn concurrent_login_homes_for_same_alias_do_not_overlap() {
+        use std::sync::{Arc, Barrier};
+
+        let (_tmp, paths) = setup_test_env();
+        let barrier = Arc::new(Barrier::new(3));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let paths = paths.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    create_isolated_login_home(&paths, "amir+8@sawmills.ai").unwrap()
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        let homes: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        assert_ne!(homes[0], homes[1]);
+        assert!(homes.iter().all(|home| home.is_dir()));
+        for home in homes {
+            remove_isolated_login_home(&home).unwrap();
+        }
     }
 
     #[test]
@@ -134,14 +220,12 @@ mod tests {
 
         run_from(&paths, "  amir+8@sawmills.ai  ", &mut runner).unwrap();
 
+        let seen_home = runner.seen_home.as_deref().unwrap();
         assert_eq!(
-            runner.seen_home.as_deref(),
-            Some(
-                isolated_login_home(&paths, "amir+8@sawmills.ai")
-                    .unwrap()
-                    .as_path()
-            )
+            seen_home.parent(),
+            Some(paths.login_homes_dir().join("amir+8@sawmills.ai").as_path())
         );
+        assert!(!seen_home.exists());
         let saved = std::fs::read_to_string(
             paths
                 .profiles_dir()
@@ -190,5 +274,16 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    #[test]
+    fn run_from_removes_isolated_home_after_login_failure() {
+        let (_tmp, paths) = setup_test_env();
+        let mut runner = FailingLoginRunner::default();
+
+        let error = run_from(&paths, "amir+8@sawmills.ai", &mut runner).unwrap_err();
+
+        assert!(error.to_string().contains("simulated login failure"));
+        assert!(!runner.seen_home.unwrap().exists());
     }
 }

--- a/src/commands/resets.rs
+++ b/src/commands/resets.rs
@@ -211,7 +211,7 @@ pub fn redeem(alias: &str, credit_id: Option<&str>) -> Result<api::ConsumeResetR
     let auth = auth_for(alias, is_active(alias)?)?;
     let request_id = api::new_redeem_request_id(alias);
     let rt = tokio::runtime::Runtime::new()?;
-    let client = reqwest::Client::new();
+    let client = api::http_client()?;
     rt.block_on(api::consume_reset_credit_async(
         &client,
         &auth.access_token,
@@ -298,7 +298,9 @@ pub fn settle_after_redeem(alias: &str) {
     let Ok(rt) = tokio::runtime::Runtime::new() else {
         return;
     };
-    let client = reqwest::Client::new();
+    let Ok(client) = api::http_client() else {
+        return;
+    };
 
     for _ in 0..ATTEMPTS {
         std::thread::sleep(DELAY);
@@ -351,9 +353,9 @@ struct ResetsRow {
 }
 
 fn fetch_all(profiles: &[profile::Profile], active: &Option<String>) -> Result<Vec<ResetsRow>> {
-    let codex_auth = config::codex_auth_json()?;
+    let paths = config::default_paths()?;
     let rt = tokio::runtime::Runtime::new()?;
-    let client = reqwest::Client::new();
+    let client = api::http_client()?;
 
     Ok(rt.block_on(async {
         let futs: Vec<_> = profiles
@@ -362,11 +364,8 @@ fn fetch_all(profiles: &[profile::Profile], active: &Option<String>) -> Result<V
                 let client = client.clone();
                 let alias = p.meta.alias.clone();
                 let is_active = active.as_deref() == Some(&p.meta.alias);
-                let auth_path = if is_active {
-                    codex_auth.clone()
-                } else {
-                    p.auth_json_path()
-                };
+                let auth_path =
+                    profile::auth_json_path_for_profile_from(&paths, p, active.as_deref());
                 async move {
                     match api::read_auth_json(&auth_path) {
                         Ok(auth) => fetch_row(&client, alias, is_active, &auth).await,
@@ -432,7 +431,7 @@ async fn fetch_row(
 fn fetch_one(alias: &str, is_active: bool) -> Result<ResetsRow> {
     let auth = auth_for(alias, is_active)?;
     let rt = tokio::runtime::Runtime::new()?;
-    let client = reqwest::Client::new();
+    let client = api::http_client()?;
     let row = rt.block_on(fetch_row(&client, alias.to_string(), is_active, &auth));
     if let Some(error) = &row.error {
         bail!("could not read reset credits for {alias}: {error}");
@@ -443,11 +442,10 @@ fn fetch_one(alias: &str, is_active: bool) -> Result<ResetsRow> {
 /// The active profile's live tokens are Codex-maintained and authoritative; the
 /// stored snapshot can be stale until the next switch or save.
 fn auth_for(alias: &str, is_active: bool) -> Result<api::AuthJson> {
-    let path = if is_active {
-        config::codex_auth_json()?
-    } else {
-        profile::get_profile(alias)?.auth_json_path()
-    };
+    let paths = config::default_paths()?;
+    let profile = profile::get_profile_from(&paths, alias)?;
+    let active = is_active.then_some(alias);
+    let path = profile::auth_json_path_for_profile_from(&paths, &profile, active);
     api::read_auth_json(&path)
 }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -4,6 +4,7 @@ use crate::api;
 use crate::commands::alias;
 use crate::config;
 use crate::profile;
+use crate::store;
 
 pub fn run(alias: Option<&str>) -> Result<()> {
     let auth_path = config::codex_auth_json()?;
@@ -17,10 +18,10 @@ pub fn run(alias: Option<&str>) -> Result<()> {
     let auth = api::read_auth_json(&auth_path)?;
 
     let email = fetch_email(&auth.access_token);
-    let resolved_alias = match alias::optional(alias) {
+    let resolved_alias = match alias::optional(alias)? {
         Some(a) => a.to_string(),
         None => match &email {
-            Some(e) => e.clone(),
+            Some(e) => store::validate_alias(e)?.to_string(),
             None => {
                 anyhow::bail!(
                     "could not detect email (token may be expired). Provide an alias: codexctl save <alias>"
@@ -29,7 +30,7 @@ pub fn run(alias: Option<&str>) -> Result<()> {
         },
     };
 
-    let existing = config::profiles_dir()?.join(&resolved_alias);
+    let existing = store::profile_dir(&config::default_paths()?, &resolved_alias)?;
     if existing.exists() {
         eprint!(
             "profile '{}' already exists. Overwrite? [y/N] ",
@@ -43,15 +44,14 @@ pub fn run(alias: Option<&str>) -> Result<()> {
         }
     }
 
-    profile::save_profile(&resolved_alias, email.as_deref(), &auth_path)?;
-    profile::set_active(&resolved_alias)?;
+    profile::save_profile_and_activate(&resolved_alias, email.as_deref(), &auth_path)?;
 
     println!("saved profile '{}'", resolved_alias);
     Ok(())
 }
 
 fn fetch_email(access_token: &str) -> Option<String> {
-    let client = reqwest::blocking::Client::new();
+    let client = api::blocking_http_client().ok()?;
     let resp = client
         .get("https://chatgpt.com/backend-api/me")
         .bearer_auth(access_token)

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::api;
 use crate::commands::alias;
@@ -21,7 +21,13 @@ pub fn run(alias: Option<&str>) -> Result<()> {
     let resolved_alias = match alias::optional(alias)? {
         Some(a) => a.to_string(),
         None => match &email {
-            Some(e) => store::validate_alias(e)?.to_string(),
+            Some(e) => store::validate_alias(e)
+                .with_context(|| {
+                    format!(
+                        "detected email '{e}' is not a usable alias; provide one: codexctl save <alias>"
+                    )
+                })?
+                .to_string(),
             None => {
                 anyhow::bail!(
                     "could not detect email (token may be expired). Provide an alias: codexctl save <alias>"

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -23,10 +23,7 @@ enum CreditsStatus {
 
 struct RateLimitedAccount {
     alias: String,
-    h5_pct: Option<f64>,
-    d7_pct: Option<f64>,
-    h5_reset: String,
-    d7_reset: String,
+    limits: Vec<LimitStatus>,
     token_expiry: Option<i64>,
     /// Banked rate-limit resets held by this account.
     reset_credits: i64,
@@ -39,6 +36,38 @@ struct RateLimitedAccount {
     is_active: bool,
     is_error: bool,
     error_msg: String,
+}
+
+struct LimitStatus {
+    name: String,
+    h5_pct: Option<f64>,
+    d7_pct: Option<f64>,
+    h5_reset: String,
+    d7_reset: String,
+}
+
+impl LimitStatus {
+    fn from_rate_limit(name: String, rate_limit: &api::RateLimit) -> Self {
+        let short = rate_limit.short_window();
+        let long = rate_limit.long_window();
+        Self {
+            name,
+            h5_pct: short.map(|window| window.used_percent),
+            d7_pct: long.map(|window| window.used_percent),
+            h5_reset: format_window_reset(short),
+            d7_reset: format_window_reset(long),
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self {
+            name: "Codex".to_string(),
+            h5_pct: None,
+            d7_pct: None,
+            h5_reset: "-".to_string(),
+            d7_reset: "-".to_string(),
+        }
+    }
 }
 
 struct UsageBasedAccount {
@@ -58,8 +87,11 @@ impl RateLimitedAccount {
         if self.is_error {
             return 1000.0;
         }
-        let h5 = self.h5_pct.unwrap_or(0.0);
-        let d7 = self.d7_pct.unwrap_or(0.0);
+        let Some(main) = self.limits.first() else {
+            return 1000.0;
+        };
+        let h5 = main.h5_pct.unwrap_or(0.0);
+        let d7 = main.d7_pct.unwrap_or(0.0);
         if h5 >= 100.0 && d7 >= 100.0 {
             return 900.0;
         }
@@ -184,12 +216,12 @@ fn load_sorted_statuses() -> Result<(
         return Ok((Vec::new(), Vec::new(), fetched_at));
     }
 
-    let active = profile::get_active()?;
-    let codex_auth = config::codex_auth_json()?;
+    let paths = config::default_paths()?;
+    let active = profile::get_active_from(&paths)?;
 
     let rt = tokio::runtime::Runtime::new()?;
     let (mut rate_limited, mut usage_based) =
-        rt.block_on(fetch_and_split(&profiles, &active, &codex_auth));
+        rt.block_on(fetch_and_split(&profiles, &active, &paths))?;
 
     rate_limited.sort_by(|a, b| {
         a.availability_score()
@@ -222,14 +254,51 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
     println!("{title}");
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec![
-        "Account", "5h", "5h Reset", "7d", "7d Reset", "Resets", "Token",
-    ]);
+    let columns = RateLimitColumns::for_accounts(accounts);
+    table.set_header(columns.headers());
     for account in accounts {
-        table.add_row(render_rate_limited_row(account));
+        for row in render_rate_limited_rows(account, columns) {
+            table.add_row(row);
+        }
     }
     println!("{table}");
     true
+}
+
+#[derive(Clone, Copy)]
+struct RateLimitColumns {
+    named_limits: bool,
+    short: bool,
+    long: bool,
+}
+
+impl RateLimitColumns {
+    fn for_accounts(accounts: &[&RateLimitedAccount]) -> Self {
+        Self {
+            named_limits: accounts.iter().any(|account| account.limits.len() > 1),
+            short: accounts
+                .iter()
+                .any(|account| account.limits.iter().any(|limit| limit.h5_pct.is_some())),
+            long: accounts
+                .iter()
+                .any(|account| account.limits.iter().any(|limit| limit.d7_pct.is_some())),
+        }
+    }
+
+    fn headers(self) -> Vec<&'static str> {
+        let mut headers = vec!["Account"];
+        if self.named_limits {
+            headers.push("Limit");
+        }
+        if self.short {
+            headers.extend(["5h", "5h Reset"]);
+        }
+        if self.long {
+            headers.extend(["7d", "7d Reset"]);
+        }
+        headers.extend(["Resets", "Token"]);
+        headers
+    }
 }
 
 fn print_usage_based_table(title: &str, accounts: &[&UsageBasedAccount]) -> bool {
@@ -257,9 +326,9 @@ fn is_usage_based_plan(plan: &str) -> bool {
 async fn fetch_and_split(
     profiles: &[profile::Profile],
     active: &Option<String>,
-    codex_auth_path: &std::path::Path,
-) -> (Vec<RateLimitedAccount>, Vec<UsageBasedAccount>) {
-    let client = reqwest::Client::new();
+    paths: &config::Paths,
+) -> Result<(Vec<RateLimitedAccount>, Vec<UsageBasedAccount>)> {
+    let client = api::http_client()?;
 
     // Phase 1: fetch wham/usage for all accounts in parallel
     let futures: Vec<_> = profiles
@@ -269,13 +338,7 @@ async fn fetch_and_split(
             let alias = p.meta.alias.clone();
             let plan_from_meta = p.meta.plan.clone();
             let is_active = active.as_deref() == Some(&p.meta.alias);
-            // The active profile's live, Codex-maintained tokens are the source of
-            // truth; the stored snapshot can be stale until the next switch/save.
-            let auth_path = if is_active {
-                codex_auth_path.to_path_buf()
-            } else {
-                p.auth_json_path()
-            };
+            let auth_path = profile::auth_json_path_for_profile_from(paths, p, active.as_deref());
             let auth = api::read_auth_json(&auth_path);
 
             async move {
@@ -322,10 +385,7 @@ async fn fetch_and_split(
                 } else {
                     rate_limited.push(RateLimitedAccount {
                         alias: alias.clone(),
-                        h5_pct: None,
-                        d7_pct: None,
-                        h5_reset: "-".to_string(),
-                        d7_reset: "-".to_string(),
+                        limits: vec![LimitStatus::unavailable()],
                         token_expiry: None,
                         reset_credits: 0,
                         reset_credits_applicable: 0,
@@ -365,10 +425,7 @@ async fn fetch_and_split(
                 } else {
                     rate_limited.push(RateLimitedAccount {
                         alias: alias.clone(),
-                        h5_pct: None,
-                        d7_pct: None,
-                        h5_reset: "-".to_string(),
-                        d7_reset: "-".to_string(),
+                        limits: vec![LimitStatus::unavailable()],
                         token_expiry,
                         reset_credits: 0,
                         reset_credits_applicable: 0,
@@ -387,10 +444,9 @@ async fn fetch_and_split(
             let _ = profile::update_meta_plan(alias, plan);
         }
 
-        let plan_str = usage.plan_type.as_deref().unwrap_or("-");
-        let is_ub = usage.rate_limit.is_none() && is_usage_based_plan(plan_str);
+        let billing_class = usage.billing_class();
 
-        if is_ub {
+        if billing_class == api::BillingClass::UsageBased {
             let credits = &usage.credits;
             let credits_status = match credits {
                 Some(c) if c.unlimited => CreditsStatus::Unlimited,
@@ -420,27 +476,23 @@ async fn fetch_and_split(
                 ub_needing_settings.push((idx, auth.access_token.clone(), account_id));
             }
         } else {
-            let primary = usage.rate_limit.as_ref().and_then(|r| r.short_window());
-            let secondary = usage.rate_limit.as_ref().and_then(|r| r.long_window());
-            let h5_pct = primary.map(|w| w.used_percent);
-            let d7_pct = secondary.map(|w| w.used_percent);
-            let h5_reset = format_window_reset(primary);
-            let d7_reset = format_window_reset(secondary);
+            let is_unknown = billing_class == api::BillingClass::Unknown;
 
             let idx = rate_limited.len();
             rate_limited.push(RateLimitedAccount {
                 alias: alias.clone(),
-                h5_pct,
-                d7_pct,
-                h5_reset,
-                d7_reset,
+                limits: rate_limit_statuses(usage),
                 token_expiry,
                 reset_credits: usage.reset_credits_available(),
                 reset_credits_applicable: usage.reset_credits_applicable(),
                 reset_credit_expiry: None,
                 is_active: *is_active,
-                is_error: false,
-                error_msg: String::new(),
+                is_error: is_unknown,
+                error_msg: if is_unknown {
+                    "unknown billing".to_string()
+                } else {
+                    String::new()
+                },
             });
 
             if usage.reset_credits_available() > 0 {
@@ -516,42 +568,93 @@ async fn fetch_and_split(
         }
     }
 
-    (rate_limited, usage_based)
+    Ok((rate_limited, usage_based))
 }
 
-fn render_rate_limited_row(s: &RateLimitedAccount) -> Vec<Cell> {
-    let alias = display_alias(&s.alias, s.is_active);
+fn rate_limit_statuses(usage: &api::RateLimitResponse) -> Vec<LimitStatus> {
+    let mut limits = Vec::new();
+    if let Some(rate_limit) = &usage.rate_limit {
+        limits.push(LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            rate_limit,
+        ));
+    }
+    for additional in &usage.additional_rate_limits {
+        let Some(rate_limit) = &additional.rate_limit else {
+            continue;
+        };
+        let raw_name = additional
+            .limit_name
+            .as_deref()
+            .or(additional.metered_feature.as_deref())
+            .unwrap_or("Additional");
+        let name: String = raw_name
+            .trim()
+            .chars()
+            .filter(|character| !character.is_control())
+            .take(80)
+            .collect();
+        limits.push(LimitStatus::from_rate_limit(
+            if name.is_empty() {
+                "Additional".to_string()
+            } else {
+                name
+            },
+            rate_limit,
+        ));
+    }
+    if limits.is_empty() {
+        limits.push(LimitStatus::unavailable());
+    }
+    limits
+}
 
-    if s.is_error {
-        return vec![
-            Cell::new(alias),
-            Cell::new("-"),
-            Cell::new("-"),
-            Cell::new("-"),
-            Cell::new("-"),
-            Cell::new("-"),
-            token_cell(s.token_expiry, true, &s.error_msg),
-        ];
+fn render_rate_limited_rows(
+    account: &RateLimitedAccount,
+    columns: RateLimitColumns,
+) -> Vec<Vec<Cell>> {
+    if account.is_error {
+        let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
+        if columns.named_limits {
+            row.push(Cell::new("-"));
+        }
+        if columns.short {
+            row.extend([Cell::new("-"), Cell::new("-")]);
+        }
+        if columns.long {
+            row.extend([Cell::new("-"), Cell::new("-")]);
+        }
+        row.push(Cell::new("-"));
+        row.push(token_cell(account.token_expiry, true, &account.error_msg));
+        return vec![row];
     }
 
-    let h5_str = s
-        .h5_pct
-        .map(|p| format!("{:.0}%", p))
-        .unwrap_or_else(|| "-".to_string());
-    let d7_str = s
-        .d7_pct
-        .map(|p| format!("{:.0}%", p))
-        .unwrap_or_else(|| "-".to_string());
-
-    vec![
-        Cell::new(alias),
-        colorize_usage(&h5_str),
-        Cell::new(&s.h5_reset),
-        colorize_usage(&d7_str),
-        Cell::new(&s.d7_reset),
-        resets_cell(s),
-        token_cell(s.token_expiry, false, &s.error_msg),
-    ]
+    account
+        .limits
+        .iter()
+        .enumerate()
+        .map(|(index, limit)| {
+            let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
+            if columns.named_limits {
+                row.push(Cell::new(&limit.name));
+            }
+            if columns.short {
+                row.push(colorize_usage(limit.h5_pct));
+                row.push(Cell::new(&limit.h5_reset));
+            }
+            if columns.long {
+                row.push(colorize_usage(limit.d7_pct));
+                row.push(Cell::new(&limit.d7_reset));
+            }
+            if index == 0 {
+                row.push(resets_cell(account));
+                row.push(token_cell(account.token_expiry, false, &account.error_msg));
+            } else {
+                row.extend([Cell::new("-"), Cell::new("-")]);
+            }
+            row
+        })
+        .collect()
 }
 
 /// The "Resets" column: banked rate-limit resets, and how many of them can be
@@ -716,8 +819,10 @@ fn format_duration(secs: i64) -> String {
     }
 }
 
-fn colorize_usage(usage_str: &str) -> Cell {
-    let pct: f64 = usage_str.trim_end_matches('%').parse().unwrap_or(0.0);
+fn colorize_usage(used_percent: Option<f64>) -> Cell {
+    let Some(pct) = used_percent else {
+        return Cell::new("-");
+    };
     let color = if pct >= 80.0 {
         Color::Red
     } else if pct >= 50.0 {
@@ -725,7 +830,7 @@ fn colorize_usage(usage_str: &str) -> Cell {
     } else {
         Color::Green
     };
-    Cell::new(usage_str).fg(color)
+    Cell::new(format!("{pct:.0}%")).fg(color)
 }
 
 #[cfg(test)]
@@ -751,10 +856,13 @@ mod tests {
     fn rate_limited_account() -> RateLimitedAccount {
         RateLimitedAccount {
             alias: "amir+8@sawmills.ai".to_string(),
-            h5_pct: Some(10.0),
-            d7_pct: Some(20.0),
-            h5_reset: "in 1h 00m".to_string(),
-            d7_reset: "in 1d 00h".to_string(),
+            limits: vec![LimitStatus {
+                name: "Codex".to_string(),
+                h5_pct: Some(10.0),
+                d7_pct: Some(20.0),
+                h5_reset: "in 1h 00m".to_string(),
+                d7_reset: "in 1d 00h".to_string(),
+            }],
             token_expiry: None,
             reset_credits: 0,
             reset_credits_applicable: 0,
@@ -767,7 +875,12 @@ mod tests {
 
     #[test]
     fn render_rate_limited_row_has_expected_column_count() {
-        assert_eq!(render_rate_limited_row(&rate_limited_account()).len(), 7);
+        let account = rate_limited_account();
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+        let rows = render_rate_limited_rows(&account, columns);
+        assert_eq!(columns.headers().len(), 7);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].len(), 7);
     }
 
     /// The error row must line up with the normal row or the table breaks.
@@ -779,7 +892,53 @@ mod tests {
             ..rate_limited_account()
         };
 
-        assert_eq!(render_rate_limited_row(&account).len(), 7);
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+        let rows = render_rate_limited_rows(&account, columns);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].len(), columns.headers().len());
+    }
+
+    #[test]
+    fn weekly_only_accounts_omit_empty_five_hour_columns() {
+        let mut account = rate_limited_account();
+        account.limits[0].h5_pct = None;
+        account.limits[0].h5_reset = "-".to_string();
+
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+
+        assert!(!columns.short);
+        assert_eq!(
+            columns.headers(),
+            vec!["Account", "7d", "7d Reset", "Resets", "Token"]
+        );
+        assert_eq!(render_rate_limited_rows(&account, columns)[0].len(), 5);
+    }
+
+    #[test]
+    fn named_additional_limits_render_as_separate_rows() {
+        let mut account = rate_limited_account();
+        account.limits[0].h5_pct = None;
+        account.limits.push(LimitStatus {
+            name: "GPT-5.3-Codex-Spark".to_string(),
+            h5_pct: None,
+            d7_pct: Some(0.0),
+            h5_reset: "-".to_string(),
+            d7_reset: "in 6d 00h".to_string(),
+        });
+
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+        let rows = render_rate_limited_rows(&account, columns);
+
+        assert!(columns.named_limits);
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.len() == columns.headers().len()));
+        assert_eq!(rows[1][1].content(), "GPT-5.3-Codex-Spark");
+    }
+
+    #[test]
+    fn unavailable_usage_is_not_colored_green() {
+        let cell = colorize_usage(None);
+        assert_eq!(cell.content(), "-");
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -274,12 +274,16 @@ struct RateLimitColumns {
 
 impl RateLimitColumns {
     fn for_accounts(accounts: &[&RateLimitedAccount]) -> Self {
+        let healthy: Vec<_> = accounts
+            .iter()
+            .filter(|account| !account.is_error)
+            .collect();
         Self {
-            named_limits: accounts.iter().any(|account| account.limits.len() > 1),
-            short: accounts
+            named_limits: healthy.iter().any(|account| account.limits.len() > 1),
+            short: healthy
                 .iter()
                 .any(|account| account.limits.iter().any(|limit| limit.h5_pct.is_some())),
-            long: accounts
+            long: healthy
                 .iter()
                 .any(|account| account.limits.iter().any(|limit| limit.d7_pct.is_some())),
         }
@@ -912,6 +916,27 @@ mod tests {
             vec!["Account", "7d", "7d Reset", "Resets", "Token"]
         );
         assert_eq!(render_rate_limited_rows(&account, columns)[0].len(), 5);
+    }
+
+    #[test]
+    fn error_rows_do_not_add_hidden_limit_columns() {
+        let mut healthy = rate_limited_account();
+        healthy.limits[0].h5_pct = None;
+        let mut error = rate_limited_account();
+        error.is_error = true;
+        error.limits.push(LimitStatus {
+            name: "Hidden".to_string(),
+            h5_pct: Some(1.0),
+            d7_pct: None,
+            h5_reset: "in 1h 00m".to_string(),
+            d7_reset: "-".to_string(),
+        });
+
+        let columns = RateLimitColumns::for_accounts(&[&healthy, &error]);
+
+        assert!(!columns.named_limits);
+        assert!(!columns.short);
+        assert!(columns.long);
     }
 
     #[test]

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use dialoguer::FuzzySelect;
 
 use crate::api;
+use crate::config;
 use crate::profile;
 
 pub fn run() -> Result<()> {
@@ -11,7 +12,8 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    let active = profile::get_active()?;
+    let paths = config::default_paths()?;
+    let active = profile::get_active_from(&paths)?;
 
     let items: Vec<String> = profiles
         .iter()
@@ -24,26 +26,13 @@ pub fn run() -> Result<()> {
             };
 
             // Try to fetch usage for display — fall back gracefully
-            let usage_info = api::read_auth_json(&p.auth_json_path())
+            let auth_path = profile::auth_json_path_for_profile_from(&paths, p, active.as_deref());
+            let usage_info = api::read_auth_json(&auth_path)
                 .ok()
                 .and_then(|auth| {
                     api::fetch_usage(&auth.access_token, auth.account_id.as_deref()).ok()
                 })
-                .map(|u| {
-                    let h5 = u
-                        .rate_limit
-                        .as_ref()
-                        .and_then(|r| r.short_window())
-                        .map(|w| format!("{:.0}%", w.used_percent))
-                        .unwrap_or_else(|| "-".to_string());
-                    let d7 = u
-                        .rate_limit
-                        .as_ref()
-                        .and_then(|r| r.long_window())
-                        .map(|w| format!("{:.0}%", w.used_percent))
-                        .unwrap_or_else(|| "-".to_string());
-                    format!(" — 5h: {h5}, 7d: {d7}")
-                })
+                .map(|usage| usage_summary(&usage))
                 .unwrap_or_default();
 
             let plan = p.meta.plan.as_deref().unwrap_or("-");
@@ -71,4 +60,22 @@ pub fn run() -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn usage_summary(usage: &api::RateLimitResponse) -> String {
+    let Some(rate_limit) = &usage.rate_limit else {
+        return String::new();
+    };
+    let mut windows = Vec::new();
+    if let Some(short) = rate_limit.short_window() {
+        windows.push(format!("5h: {:.0}%", short.used_percent));
+    }
+    if let Some(long) = rate_limit.long_window() {
+        windows.push(format!("7d: {:.0}%", long.used_percent));
+    }
+    if windows.is_empty() {
+        String::new()
+    } else {
+        format!(" — {}", windows.join(", "))
+    }
 }

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::io::{BufRead, IsTerminal, Write};
 use std::path::Path;
 
 use anyhow::{Result, bail};
@@ -14,18 +15,29 @@ use crate::profile;
 /// 100% — i.e. the account has no usable headroom right now.
 const RATE_LIMIT_EXHAUSTED: f64 = 500.0;
 
-pub fn run(alias: Option<&str>, allow_resets: bool) -> Result<()> {
-    run_to_auth_json(alias, &config::codex_auth_json()?, allow_resets)
+pub fn run(alias: Option<&str>, allow_billing: bool, allow_resets: bool) -> Result<()> {
+    run_to_auth_json(
+        alias,
+        &config::codex_auth_json()?,
+        allow_billing,
+        allow_resets,
+    )
 }
 
-pub fn run_to_auth_json(alias: Option<&str>, auth_json: &Path, allow_resets: bool) -> Result<()> {
-    run_to_auth_json_excluding(alias, auth_json, None, allow_resets)
+pub fn run_to_auth_json(
+    alias: Option<&str>,
+    auth_json: &Path,
+    allow_billing: bool,
+    allow_resets: bool,
+) -> Result<()> {
+    run_to_auth_json_excluding(alias, auth_json, None, allow_billing, allow_resets)
 }
 
 pub fn run_to_auth_json_excluding(
     alias: Option<&str>,
     auth_json: &Path,
     excluded_alias: Option<&str>,
+    allow_billing: bool,
     allow_resets: bool,
 ) -> Result<()> {
     match alias::optional(alias)? {
@@ -39,7 +51,7 @@ pub fn run_to_auth_json_excluding(
             status::run_focused(a)?;
         }
         None => {
-            let best = find_most_available_excluding(excluded_alias, allow_resets)?;
+            let best = find_most_available_excluding(excluded_alias, allow_billing, allow_resets)?;
             let email = profile::switch_to_auth_json(&best, auth_json)?;
             println!("auto-selected most available: {} ({})", best, email);
             println!();
@@ -51,6 +63,7 @@ pub fn run_to_auth_json_excluding(
 
 fn find_most_available_excluding(
     excluded_alias: Option<&str>,
+    allow_billing: bool,
     allow_resets: bool,
 ) -> Result<String> {
     let all_profiles = profile::list_profiles()?;
@@ -79,8 +92,14 @@ fn find_most_available_excluding(
         })
         .collect();
 
-    // An account that still has headroom is always preferred and spends nothing.
+    // Prefer existing headroom before spending a banked reset. A seat that can
+    // bill after its hard window still requires separate billing consent.
     if let Some(alias) = select_with_headroom(&scored, reset_aware()) {
+        let candidate = scored
+            .iter()
+            .find(|candidate| candidate.alias == alias)
+            .expect("selected candidate must exist");
+        require_billing_approval(candidate, allow_billing)?;
         return Ok(alias.to_string());
     }
 
@@ -90,6 +109,7 @@ fn find_most_available_excluding(
     if let Some(candidate) = best_candidate_from_usages(usages)?
         && let Some(plan) = candidate.reset_plan()
     {
+        require_recovery_billing_approval(&candidate, allow_billing)?;
         if !resets::approve_redemption(
             &candidate.alias,
             plan.expires_at,
@@ -119,9 +139,84 @@ fn find_most_available_excluding(
     // No reset can help either: fall back to the least-bad account, exactly as
     // before, so `use` still hands back something rather than failing outright.
     match select_most_available(&scored, reset_aware()) {
-        Some(alias) => Ok(alias.to_string()),
+        Some(alias) => {
+            let candidate = scored
+                .iter()
+                .find(|candidate| candidate.alias == alias)
+                .expect("selected candidate must exist");
+            require_billing_approval(candidate, allow_billing)?;
+            Ok(alias.to_string())
+        }
         None => bail!("no usable accounts found (all expired or errored)"),
     }
+}
+
+fn require_billing_approval(candidate: &SelectionCandidate, allow_billing: bool) -> Result<()> {
+    if !candidate.bills_credits || approve_billing_account(&candidate.alias, allow_billing) {
+        return Ok(());
+    }
+    bail!(
+        "switching to {} may use credits and was not approved",
+        candidate.alias
+    )
+}
+
+fn require_recovery_billing_approval(
+    candidate: &RecoveryCandidate,
+    allow_billing: bool,
+) -> Result<()> {
+    if !candidate.bills_credits || approve_billing_account(&candidate.alias, allow_billing) {
+        return Ok(());
+    }
+    bail!(
+        "switching to {} may use credits and was not approved",
+        candidate.alias
+    )
+}
+
+fn approve_billing_account(alias: &str, allow_billing: bool) -> bool {
+    let stdin = std::io::stdin();
+    let mut input = stdin.lock();
+    approve_billing_account_from(
+        alias,
+        allow_billing,
+        stdin.is_terminal(),
+        &mut input,
+        &mut std::io::stderr(),
+    )
+}
+
+fn approve_billing_account_from(
+    alias: &str,
+    allow_billing: bool,
+    is_terminal: bool,
+    input: &mut impl BufRead,
+    output: &mut impl Write,
+) -> bool {
+    if allow_billing {
+        let _ = writeln!(
+            output,
+            "codexctl: --allow-billing set; switching to {alias} (may use credits)"
+        );
+        return true;
+    }
+    if !is_terminal {
+        let _ = writeln!(
+            output,
+            "codexctl: not switching to {alias} (no terminal to approve credit billing; pass --allow-billing to allow)"
+        );
+        return false;
+    }
+    let _ = write!(
+        output,
+        "codexctl: switch to {alias} and allow it to use credits? [y/N] "
+    );
+    let _ = output.flush();
+    let mut line = String::new();
+    if input.read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 /// Whether selection prefers the soonest-resetting eligible account.
@@ -169,11 +264,10 @@ struct SelectionCandidate {
 
 /// Pick the most-available alias from scored candidates.
 ///
-/// Default (`reset_aware == false`): lowest `selection_score` (most headroom),
-/// exactly as before. Reset-aware: among accounts with usable headroom
-/// (`score < RATE_LIMIT_EXHAUSTED`) pick no-bill accounts first, then the
-/// soonest 7d reset, breaking ties by most headroom; if none have headroom, fall
-/// back to the default pick so the behavior degrades identically to today.
+/// Every mode keeps no-bill accounts ahead of billing accounts. Default
+/// (`reset_aware == false`) then uses the lowest `selection_score` (most
+/// headroom). Reset-aware then uses the soonest 7d reset, breaking ties by most
+/// headroom. If none have headroom, fall back to the least-bad safe class.
 fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Option<&str> {
     if let Some(alias) = select_with_headroom(scored, reset_aware) {
         return Some(alias);
@@ -181,9 +275,11 @@ fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Op
     scored
         .iter()
         .min_by(|a, b| {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            a.bills_credits.cmp(&b.bills_credits).then(
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
         })
         .filter(|candidate| candidate.score < f64::MAX)
         .map(|candidate| candidate.alias.as_str())
@@ -192,10 +288,8 @@ fn select_most_available(scored: &[SelectionCandidate], reset_aware: bool) -> Op
 /// The best account that still has usable rate-limit headroom, or `None` when
 /// every account is exhausted (or usage-based, which is never auto-selected).
 ///
-/// Reset-aware: no-bill accounts first, then the soonest 7d reset, then most
-/// headroom. Default: most headroom — which, since any exhausted account scores
-/// at least [`RATE_LIMIT_EXHAUSTED`] and any account with headroom scores below
-/// it, is the same account the legacy global-minimum pick would have chosen.
+/// Both modes put no-bill accounts first. Reset-aware then uses the soonest 7d
+/// reset and most headroom. Default uses most headroom within the billing class.
 fn select_with_headroom(scored: &[SelectionCandidate], reset_aware: bool) -> Option<&str> {
     scored
         .iter()
@@ -208,7 +302,7 @@ fn select_with_headroom(scored: &[SelectionCandidate], reset_aware: bool) -> Opt
                     .then(a.secondary_reset_ts.cmp(&b.secondary_reset_ts))
                     .then(by_score)
             } else {
-                by_score
+                a.bills_credits.cmp(&b.bills_credits).then(by_score)
             }
         })
         .map(|candidate| candidate.alias.as_str())
@@ -830,6 +924,24 @@ mod tests {
     }
 
     #[test]
+    fn selection_never_picks_unknown_or_mixed_billing_accounts() {
+        let mut unknown = team_response(5.0, 10.0, true);
+        unknown.plan_type = Some("new_plan".to_string());
+        assert_eq!(selection_score(&unknown), f64::MAX);
+        assert_eq!(recovery_class(&unknown), None);
+
+        let mut mixed = team_response(5.0, 10.0, true);
+        mixed.credits = Some(api::Credits {
+            has_credits: true,
+            unlimited: false,
+            overage_limit_reached: false,
+            balance: None,
+        });
+        assert_eq!(selection_score(&mixed), f64::MAX);
+        assert_eq!(recovery_class(&mixed), None);
+    }
+
+    #[test]
     fn recovery_skips_usage_based_accounts() {
         assert_eq!(recovery_class(&usage_based_response()), None);
     }
@@ -911,14 +1023,13 @@ mod tests {
     }
 
     #[test]
-    fn legacy_selection_picks_most_headroom_even_when_it_bills() {
-        // `CODEXCTL_SELECT=most-available` is the explicit legacy opt-out from
-        // reset-aware selection; it must preserve pure most-headroom ordering.
+    fn most_available_selection_keeps_no_bill_first() {
+        // The reset-order opt-out cannot disable the billing safety order.
         let scored = vec![
             selection_candidate("billing", true, 20.0, 1000),
             selection_candidate("no-bill", false, 60.0, 2000),
         ];
-        assert_eq!(select_most_available(&scored, false), Some("billing"));
+        assert_eq!(select_most_available(&scored, false), Some("no-bill"));
     }
 
     #[test]
@@ -987,17 +1098,43 @@ mod tests {
         assert_eq!(select_most_available(&scored, true), Some("a"));
     }
 
-    /// Legacy mode is documented as pure most-headroom ordering, and the
-    /// headroom pre-pass must not change which account that picks.
+    /// Most-headroom mode must not bypass the no-bill safety order.
     #[test]
-    fn select_with_headroom_matches_the_legacy_pick_when_headroom_exists() {
+    fn select_with_headroom_keeps_no_bill_first_in_most_available_mode() {
         let scored = vec![
             selection_candidate("billing", true, 20.0, 1000),
             selection_candidate("no-bill", false, 60.0, 2000),
             selection_candidate("exhausted", false, 700.0, 500),
         ];
-        assert_eq!(select_with_headroom(&scored, false), Some("billing"));
-        assert_eq!(select_most_available(&scored, false), Some("billing"));
+        assert_eq!(select_with_headroom(&scored, false), Some("no-bill"));
+        assert_eq!(select_most_available(&scored, false), Some("no-bill"));
+    }
+
+    #[test]
+    fn billing_approval_requires_a_flag_or_interactive_yes() {
+        for answer in ["y\n", "yes\n"] {
+            assert!(approve_billing_account_from(
+                "billing",
+                false,
+                true,
+                &mut answer.as_bytes(),
+                &mut Vec::new(),
+            ));
+        }
+        assert!(!approve_billing_account_from(
+            "billing",
+            false,
+            false,
+            &mut "yes\n".as_bytes(),
+            &mut Vec::new(),
+        ));
+        assert!(approve_billing_account_from(
+            "billing",
+            true,
+            false,
+            &mut "".as_bytes(),
+            &mut Vec::new(),
+        ));
     }
 
     #[test]

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -28,7 +28,7 @@ pub fn run_to_auth_json_excluding(
     excluded_alias: Option<&str>,
     allow_resets: bool,
 ) -> Result<()> {
-    match alias::optional(alias) {
+    match alias::optional(alias)? {
         // An explicit target is switched to as asked — never redeemed against,
         // since `codexctl reset <alias>` is the way to spend a credit on a
         // named account.
@@ -215,9 +215,9 @@ fn select_with_headroom(scored: &[SelectionCandidate], reset_aware: bool) -> Opt
 }
 
 fn selection_score(usage: &api::RateLimitResponse) -> f64 {
-    let plan = usage.plan_type.as_deref().unwrap_or("");
-    if plan.contains("usage_based") {
-        // Never auto-select usage-based accounts: they bill real credits.
+    if usage.billing_class() != api::BillingClass::RateLimited {
+        // Never auto-select usage-based or unknown accounts. Unknown billing
+        // metadata is not evidence that an account is free to use.
         return f64::MAX;
     }
     rate_limit_score(usage)
@@ -411,8 +411,7 @@ struct RecoveryClass {
 /// used: usage-based (bills real credits), or out of headroom with no banked
 /// reset to clear the window.
 fn recovery_class(usage: &api::RateLimitResponse) -> Option<RecoveryClass> {
-    let plan = usage.plan_type.as_deref().unwrap_or("");
-    if plan.contains("usage_based") {
+    if usage.billing_class() != api::BillingClass::RateLimited {
         return None;
     }
     // Spend cap reached => overage closed => the account hard-stops at 100% and
@@ -442,6 +441,9 @@ fn recovery_class(usage: &api::RateLimitResponse) -> Option<RecoveryClass> {
 /// When this account's exhausted window(s) would clear without spending a
 /// credit — the moment a banked reset stops being worth anything here.
 fn natural_reset_ts(usage: &api::RateLimitResponse) -> Option<i64> {
+    // Reset credits and general recovery use the main Codex bucket. Additional
+    // buckets are model- or feature-specific and cannot be applied without a
+    // requested-model-to-bucket mapping.
     let rate_limit = usage.rate_limit.as_ref()?;
     [rate_limit.short_window(), rate_limit.long_window()]
         .into_iter()
@@ -486,6 +488,9 @@ fn reset_plan(
 }
 
 fn rate_limit_score(usage: &api::RateLimitResponse) -> f64 {
+    // General account selection uses the backward-compatible main Codex
+    // bucket. Treating any model-specific additional bucket as account-wide
+    // exhaustion would hide capacity that other models can still use.
     let h5 = usage
         .rate_limit
         .as_ref()
@@ -516,8 +521,10 @@ fn selection_bills_credits(usage: &api::RateLimitResponse) -> bool {
 fn fetch_usages(
     profiles: &[profile::Profile],
 ) -> Result<Vec<(String, Option<api::RateLimitResponse>)>> {
+    let paths = config::default_paths()?;
+    let active = profile::get_active_from(&paths)?;
     let rt = tokio::runtime::Runtime::new()?;
-    let client = reqwest::Client::new();
+    let client = api::http_client()?;
 
     Ok(rt.block_on(async {
         let futs: Vec<_> = profiles
@@ -525,7 +532,9 @@ fn fetch_usages(
             .map(|p| {
                 let client = client.clone();
                 let alias = p.meta.alias.clone();
-                let auth = api::read_auth_json(&p.auth_json_path());
+                let auth_path =
+                    profile::auth_json_path_for_profile_from(&paths, p, active.as_deref());
+                let auth = api::read_auth_json(&auth_path);
                 async move {
                     let usage = match auth {
                         Ok(a) => api::fetch_usage_async(
@@ -555,7 +564,9 @@ fn fetch_reset_credits(
     }
 
     let rt = tokio::runtime::Runtime::new()?;
-    let client = reqwest::Client::new();
+    let client = api::http_client()?;
+    let paths = config::default_paths()?;
+    let active = profile::get_active_from(&paths)?;
 
     Ok(rt.block_on(async {
         let futs: Vec<_> = aliases
@@ -563,8 +574,11 @@ fn fetch_reset_credits(
             .map(|alias| {
                 let client = client.clone();
                 let alias = alias.clone();
-                let auth = profile::get_profile(&alias)
-                    .and_then(|p| api::read_auth_json(&p.auth_json_path()));
+                let auth = profile::get_profile_from(&paths, &alias).and_then(|p| {
+                    let path =
+                        profile::auth_json_path_for_profile_from(&paths, &p, active.as_deref());
+                    api::read_auth_json(&path)
+                });
                 async move {
                     let details = match auth {
                         Ok(a) => api::fetch_reset_credits_async(
@@ -645,6 +659,7 @@ mod tests {
             spend_control: Some(api::SpendControl {
                 reached: spend_reached,
             }),
+            additional_rate_limits: Vec::new(),
             rate_limit_reset_credits: None,
         }
     }
@@ -676,6 +691,18 @@ mod tests {
                 balance: None,
             }),
             spend_control: Some(api::SpendControl { reached: false }),
+            additional_rate_limits: Vec::new(),
+            rate_limit_reset_credits: None,
+        }
+    }
+
+    fn unknown_billing_response() -> api::RateLimitResponse {
+        api::RateLimitResponse {
+            plan_type: Some("new_subscription_tier".to_string()),
+            rate_limit: None,
+            credits: None,
+            spend_control: None,
+            additional_rate_limits: Vec::new(),
             rate_limit_reset_credits: None,
         }
     }
@@ -690,6 +717,45 @@ mod tests {
             title: None,
             description: None,
         }
+    }
+
+    #[test]
+    fn unknown_billing_is_never_auto_selected_or_recovered() {
+        let usage = unknown_billing_response();
+
+        assert_eq!(usage.billing_class(), api::BillingClass::Unknown);
+        assert_eq!(selection_score(&usage), f64::MAX);
+        assert_eq!(recovery_class(&usage), None);
+
+        let empty_rate_limit = api::RateLimitResponse {
+            rate_limit: Some(api::RateLimit {
+                primary: None,
+                secondary: None,
+                primary_window: None,
+                secondary_window: None,
+            }),
+            ..unknown_billing_response()
+        };
+        assert_eq!(empty_rate_limit.billing_class(), api::BillingClass::Unknown);
+        assert_eq!(selection_score(&empty_rate_limit), f64::MAX);
+        assert_eq!(recovery_class(&empty_rate_limit), None);
+    }
+
+    #[test]
+    fn credits_without_plan_metadata_are_treated_as_usage_based() {
+        let usage = api::RateLimitResponse {
+            credits: Some(api::Credits {
+                has_credits: true,
+                unlimited: false,
+                overage_limit_reached: false,
+                balance: Some("10".to_string()),
+            }),
+            ..unknown_billing_response()
+        };
+
+        assert_eq!(usage.billing_class(), api::BillingClass::UsageBased);
+        assert_eq!(selection_score(&usage), f64::MAX);
+        assert_eq!(recovery_class(&usage), None);
     }
 
     fn scored(

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+use crate::store;
+
 /// All paths codexctl uses. Testable: construct with a custom root.
 #[derive(Clone)]
 pub struct Paths {
@@ -34,9 +36,10 @@ impl Paths {
     }
 
     pub fn ensure_dirs(&self) -> Result<()> {
+        store::ensure_private_dir(&self.codexctl_dir())?;
         let profiles = self.profiles_dir();
-        std::fs::create_dir_all(&profiles)
-            .with_context(|| format!("failed to create {}", profiles.display()))?;
+        store::ensure_private_dir(&profiles)
+            .with_context(|| format!("failed to initialize {}", profiles.display()))?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod config;
 pub mod profile;
+pub mod store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ enum Commands {
     Use {
         /// Profile alias to switch to (auto-selects most available if omitted)
         alias: Option<String>,
+        /// Allow automatic selection of a credit-billing account without
+        /// prompting (use for unattended runs; it may spend credits)
+        #[arg(long)]
+        allow_billing: bool,
         /// When auto-selecting and no account has headroom left, redeem a
         /// banked reset without prompting (resets are scarce and expire)
         #[arg(long)]
@@ -137,8 +141,9 @@ fn main() {
         Commands::Save { ref alias } => commands::save::run(alias.as_deref()),
         Commands::Use {
             ref alias,
+            allow_billing,
             allow_resets,
-        } => commands::use_profile::run(alias.as_deref(), allow_resets),
+        } => commands::use_profile::run(alias.as_deref(), allow_billing, allow_resets),
         Commands::Switch => commands::switch::run(),
         Commands::Resets {
             claim,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-mod api;
 mod commands;
-mod config;
-mod profile;
+
+use codexctl::{api, config, profile, store};
 
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
@@ -109,12 +108,16 @@ enum Commands {
 }
 
 fn main() {
-    if let Err(e) = config::ensure_dirs() {
+    let cli = Cli::parse();
+
+    // Informational commands must work in a read-only or empty home. Clap
+    // exits while parsing help, version, and invalid commands, and shell
+    // completion generation does not need the profile store.
+    let needs_store = !matches!(&cli.command, Commands::Completions { .. });
+    if needs_store && let Err(e) = config::ensure_dirs() {
         eprintln!("error: {e:#}");
         std::process::exit(1);
     }
-
-    let cli = Cli::parse();
 
     let result = match cli.command {
         Commands::Status {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -34,10 +35,12 @@ pub fn list_profiles_from(paths: &Paths) -> Result<Vec<Profile>> {
         return Ok(vec![]);
     }
     let mut profiles = Vec::new();
-    for entry in std::fs::read_dir(&profiles_dir)
+    let mut entries: Vec<_> = std::fs::read_dir(&profiles_dir)
         .with_context(|| format!("failed to read {}", profiles_dir.display()))?
-    {
-        let entry = entry?;
+        .collect::<std::io::Result<_>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    let mut seen_aliases = HashSet::new();
+    for entry in entries {
         if !entry.file_type()?.is_dir() {
             continue;
         }
@@ -49,7 +52,11 @@ pub fn list_profiles_from(paths: &Paths) -> Result<Vec<Profile>> {
             eprintln!("warning: ignored profile directory with an invalid alias");
             continue;
         };
-        let path = store::profile_dir(paths, alias)?;
+        if !seen_aliases.insert(alias.to_ascii_lowercase()) {
+            eprintln!("warning: ignored profile directory with a case-colliding alias");
+            continue;
+        }
+        let path = entry.path();
         let meta_path = path.join("meta.json");
         if !meta_path.exists() {
             continue;
@@ -166,14 +173,20 @@ pub fn get_active_from(paths: &Paths) -> Result<Option<String>> {
     if !active_file.exists() {
         return Ok(None);
     }
-    if std::fs::symlink_metadata(&active_file)?
-        .file_type()
-        .is_symlink()
-    {
+    let metadata = match std::fs::symlink_metadata(&active_file) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
         eprintln!("warning: ignored symbolic-link active profile marker");
         return Ok(None);
     }
-    let contents = std::fs::read_to_string(&active_file)?;
+    let contents = match std::fs::read_to_string(&active_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
     match store::validate_alias(&contents) {
         Ok(alias) => Ok(Some(alias.to_string())),
         Err(_) => {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,10 +1,11 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::api;
 use crate::config::{self, Paths};
+use crate::store;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Meta {
@@ -37,18 +38,32 @@ pub fn list_profiles_from(paths: &Paths) -> Result<Vec<Profile>> {
         .with_context(|| format!("failed to read {}", profiles_dir.display()))?
     {
         let entry = entry?;
-        let path = entry.path();
-        if !path.is_dir() {
+        if !entry.file_type()?.is_dir() {
             continue;
         }
+        let Some(directory_alias) = entry.file_name().to_str().map(str::to_owned) else {
+            eprintln!("warning: ignored profile directory with a non-UTF-8 name");
+            continue;
+        };
+        let Ok(alias) = store::validate_alias(&directory_alias) else {
+            eprintln!("warning: ignored profile directory with an invalid alias");
+            continue;
+        };
+        let path = store::profile_dir(paths, alias)?;
         let meta_path = path.join("meta.json");
         if !meta_path.exists() {
             continue;
         }
         let contents = std::fs::read_to_string(&meta_path)
             .with_context(|| format!("failed to read {}", meta_path.display()))?;
-        let meta: Meta = serde_json::from_str(&contents)
+        let mut meta: Meta = serde_json::from_str(&contents)
             .with_context(|| format!("failed to parse {}", meta_path.display()))?;
+        if meta.alias != alias {
+            eprintln!(
+                "warning: profile metadata alias did not match its directory; using the directory alias"
+            );
+            meta.alias = alias.to_string();
+        }
         profiles.push(Profile { meta, dir: path });
     }
     profiles.sort_by(|a, b| a.meta.alias.cmp(&b.meta.alias));
@@ -56,15 +71,17 @@ pub fn list_profiles_from(paths: &Paths) -> Result<Vec<Profile>> {
 }
 
 pub fn get_profile_from(paths: &Paths, alias: &str) -> Result<Profile> {
-    let dir = paths.profiles_dir().join(alias);
+    let alias = store::validate_alias(alias)?;
+    let dir = store::profile_dir(paths, alias)?;
     if !dir.exists() {
         anyhow::bail!("profile '{}' not found", alias);
     }
     let meta_path = dir.join("meta.json");
     let contents = std::fs::read_to_string(&meta_path)
         .with_context(|| format!("failed to read {}", meta_path.display()))?;
-    let meta: Meta = serde_json::from_str(&contents)
+    let mut meta: Meta = serde_json::from_str(&contents)
         .with_context(|| format!("failed to parse {}", meta_path.display()))?;
+    meta.alias = alias.to_string();
     Ok(Profile { meta, dir })
 }
 
@@ -72,28 +89,71 @@ pub fn save_profile_to(
     paths: &Paths,
     alias: &str,
     email: Option<&str>,
-    auth_json_src: &std::path::Path,
+    auth_json_src: &Path,
 ) -> Result<()> {
-    let dir = paths.profiles_dir().join(alias);
-    std::fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let _lock = store::lock(paths)?;
+    save_profile_unlocked(paths, alias, email, auth_json_src)
+}
+
+/// Save a profile and make it active under one store lock.
+///
+/// When the source is an isolated login home, install it into the live Codex
+/// home. A re-login of the already-active alias deliberately skips capturing
+/// the old live token so it cannot overwrite the new login.
+pub fn save_profile_and_activate_to(
+    paths: &Paths,
+    alias: &str,
+    email: Option<&str>,
+    auth_json_src: &Path,
+) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    let _lock = store::lock(paths)?;
+    let was_active = get_active_from(paths)?.as_deref() == Some(alias);
+    save_profile_unlocked(paths, alias, email, auth_json_src)?;
+
+    let live_auth = paths.codex_auth_json();
+    if auth_json_src != live_auth {
+        if !was_active {
+            capture_auth_file_profile_tokens(paths, &live_auth);
+        }
+        let saved_auth = store::profile_dir(paths, alias)?.join("auth.json");
+        store::atomic_copy(&saved_auth, &live_auth)
+            .with_context(|| format!("failed to install {}", live_auth.display()))?;
+    }
+    set_active_unlocked(paths, alias)
+}
+
+fn save_profile_unlocked(
+    paths: &Paths,
+    alias: &str,
+    email: Option<&str>,
+    auth_json_src: &Path,
+) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    store::ensure_private_dir(&paths.codexctl_dir())?;
+    store::ensure_private_dir(&paths.profiles_dir())?;
+    let dir = store::profile_dir(paths, alias)?;
+    store::ensure_private_dir(&dir)?;
 
     let dest = dir.join("auth.json");
-    std::fs::copy(auth_json_src, &dest)
-        .with_context(|| format!("failed to copy auth.json to {}", dest.display()))?;
+    store::atomic_copy(auth_json_src, &dest)
+        .with_context(|| format!("failed to save auth.json to {}", dest.display()))?;
 
     let meta = Meta {
         alias: alias.to_string(),
-        email: email.map(|s| s.to_string()),
+        email: email.map(str::to_string),
         plan: None,
         saved_at: chrono::Utc::now().to_rfc3339(),
     };
-    let meta_json = serde_json::to_string_pretty(&meta)?;
-    std::fs::write(dir.join("meta.json"), meta_json)?;
+    let meta_json = serde_json::to_vec_pretty(&meta)?;
+    store::atomic_write(&dir.join("meta.json"), &meta_json)?;
     Ok(())
 }
 
 pub fn delete_profile_from(paths: &Paths, alias: &str) -> Result<()> {
-    let dir = paths.profiles_dir().join(alias);
+    let alias = store::validate_alias(alias)?;
+    let _lock = store::lock(paths)?;
+    let dir = store::profile_dir(paths, alias)?;
     if !dir.exists() {
         anyhow::bail!("profile '{}' not found", alias);
     }
@@ -106,54 +166,88 @@ pub fn get_active_from(paths: &Paths) -> Result<Option<String>> {
     if !active_file.exists() {
         return Ok(None);
     }
-    let contents = std::fs::read_to_string(&active_file)?;
-    let alias = contents.trim().to_string();
-    if alias.is_empty() {
+    if std::fs::symlink_metadata(&active_file)?
+        .file_type()
+        .is_symlink()
+    {
+        eprintln!("warning: ignored symbolic-link active profile marker");
         return Ok(None);
     }
-    Ok(Some(alias))
+    let contents = std::fs::read_to_string(&active_file)?;
+    match store::validate_alias(&contents) {
+        Ok(alias) => Ok(Some(alias.to_string())),
+        Err(_) => {
+            eprintln!("warning: ignored invalid active profile marker");
+            Ok(None)
+        }
+    }
 }
 
 pub fn set_active_from(paths: &Paths, alias: &str) -> Result<()> {
-    let active_file = paths.active_file();
-    std::fs::write(&active_file, alias)?;
-    Ok(())
+    let _lock = store::lock(paths)?;
+    set_active_unlocked(paths, alias)
+}
+
+fn set_active_unlocked(paths: &Paths, alias: &str) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    store::ensure_private_dir(&paths.codexctl_dir())?;
+    store::atomic_write(&paths.active_file(), alias.as_bytes())
 }
 
 pub fn switch_to_from(paths: &Paths, alias: &str) -> Result<String> {
     switch_to_auth_json_from(paths, alias, &paths.codex_auth_json())
 }
 
-pub fn switch_to_auth_json_from(
-    paths: &Paths,
-    alias: &str,
-    codex_auth: &std::path::Path,
-) -> Result<String> {
+pub fn switch_to_auth_json_from(paths: &Paths, alias: &str, codex_auth: &Path) -> Result<String> {
+    let alias = store::validate_alias(alias)?;
+    let _lock = store::lock(paths)?;
     let profile = get_profile_from(paths, alias)?;
 
-    // Capture the outgoing active profile's live tokens before we overwrite
-    // ~/.codex/auth.json. OpenAI uses single-use rotating refresh tokens, so the
-    // Codex CLI may have rotated this profile's tokens since it was saved; if we
-    // don't fold them back into the store they're lost and the profile later
-    // looks "expired". See capture_active_profile_tokens for the safety guard.
+    // Capture the outgoing live tokens before installing the next profile.
+    // The exact-token or token-subject guard prevents a foreign live auth file
+    // from overwriting an unrelated saved profile.
     capture_auth_file_profile_tokens(paths, codex_auth);
 
-    if let Some(parent) = codex_auth.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    std::fs::copy(profile.auth_json_path(), codex_auth)
-        .with_context(|| format!("failed to copy auth.json to {}", codex_auth.display()))?;
+    store::atomic_copy(&profile.auth_json_path(), codex_auth)
+        .with_context(|| format!("failed to install auth.json at {}", codex_auth.display()))?;
     if codex_auth == paths.codex_auth_json() {
-        set_active_from(paths, alias)?;
+        // Write the marker last. A crash can leave the old marker, but it cannot
+        // claim that a new alias is active before its auth file is installed.
+        set_active_unlocked(paths, alias)?;
     }
     Ok(profile.meta.email.unwrap_or_else(|| "unknown".to_string()))
 }
 
-pub fn alias_for_auth_json_from(
+/// Pick the live auth file only when it belongs to the active saved profile.
+/// Otherwise use the stored snapshot and avoid attributing a foreign session.
+pub fn auth_json_path_for_profile_from(
     paths: &Paths,
-    auth_json: &std::path::Path,
-) -> Result<Option<String>> {
+    profile: &Profile,
+    active: Option<&str>,
+) -> PathBuf {
+    if active != Some(profile.meta.alias.as_str()) {
+        return profile.auth_json_path();
+    }
+    let live = paths.codex_auth_json();
+    if auth_files_have_same_owner(&live, &profile.auth_json_path()) {
+        live
+    } else {
+        profile.auth_json_path()
+    }
+}
+
+fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
+    let (Ok(left), Ok(right)) = (api::read_auth_json(left), api::read_auth_json(right)) else {
+        return false;
+    };
+    if left.access_token == right.access_token {
+        return true;
+    }
+    let left_subject = api::token_subject(&left.access_token);
+    left_subject.is_some() && left_subject == api::token_subject(&right.access_token)
+}
+
+pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Option<String>> {
     let Ok(target_auth) = api::read_auth_json(auth_json) else {
         return Ok(None);
     };
@@ -186,34 +280,41 @@ pub fn alias_for_auth_json_from(
     Ok(None)
 }
 
-/// Best-effort: copy the live Codex auth file back into the saved profile that
-/// owns that auth, but only when the token matches by exact value or seat (`sub`).
-/// Failures only warn — they must not block a switch.
-fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &std::path::Path) {
+/// Best-effort: fold a live Codex auth file into the saved profile that owns it.
+/// Failures only warn because token capture must not block a requested switch.
+fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path) {
     if !codex_auth.exists() {
         return;
     }
     let Ok(Some(alias)) = alias_for_auth_json_from(paths, codex_auth) else {
         return;
     };
-    let dest = paths.profiles_dir().join(&alias).join("auth.json");
-    if let Err(e) = std::fs::copy(codex_auth, &dest) {
-        eprintln!("warning: failed to capture tokens for profile '{alias}': {e}");
+    let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
+        return;
+    };
+    if let Err(error) = store::atomic_copy(codex_auth, &dest) {
+        eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
     }
 }
 
-pub fn update_meta_plan(alias: &str, plan: &str) -> Result<()> {
-    let dir = config::profiles_dir()?.join(alias);
+pub fn update_meta_plan_from(paths: &Paths, alias: &str, plan: &str) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    let _lock = store::lock(paths)?;
+    let dir = store::profile_dir(paths, alias)?;
     let meta_path = dir.join("meta.json");
     if !meta_path.exists() {
         return Ok(());
     }
     let contents = std::fs::read_to_string(&meta_path)?;
     let mut meta: Meta = serde_json::from_str(&contents)?;
+    meta.alias = alias.to_string();
     meta.plan = Some(plan.to_string());
-    let json = serde_json::to_string_pretty(&meta)?;
-    std::fs::write(&meta_path, json)?;
-    Ok(())
+    let json = serde_json::to_vec_pretty(&meta)?;
+    store::atomic_write(&meta_path, &json)
+}
+
+pub fn update_meta_plan(alias: &str, plan: &str) -> Result<()> {
+    update_meta_plan_from(&config::default_paths()?, alias, plan)
 }
 
 // === Default-paths wrappers (used by commands) ===
@@ -224,12 +325,15 @@ pub fn list_profiles() -> Result<Vec<Profile>> {
 pub fn get_profile(alias: &str) -> Result<Profile> {
     get_profile_from(&config::default_paths()?, alias)
 }
-pub fn save_profile(
+pub fn save_profile(alias: &str, email: Option<&str>, auth_json_src: &Path) -> Result<()> {
+    save_profile_to(&config::default_paths()?, alias, email, auth_json_src)
+}
+pub fn save_profile_and_activate(
     alias: &str,
     email: Option<&str>,
-    auth_json_src: &std::path::Path,
+    auth_json_src: &Path,
 ) -> Result<()> {
-    save_profile_to(&config::default_paths()?, alias, email, auth_json_src)
+    save_profile_and_activate_to(&config::default_paths()?, alias, email, auth_json_src)
 }
 pub fn delete_profile(alias: &str) -> Result<()> {
     delete_profile_from(&config::default_paths()?, alias)
@@ -243,6 +347,6 @@ pub fn set_active(alias: &str) -> Result<()> {
 pub fn switch_to(alias: &str) -> Result<String> {
     switch_to_from(&config::default_paths()?, alias)
 }
-pub fn switch_to_auth_json(alias: &str, auth_json: &std::path::Path) -> Result<String> {
+pub fn switch_to_auth_json(alias: &str, auth_json: &Path) -> Result<String> {
     switch_to_auth_json_from(&config::default_paths()?, alias, auth_json)
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -312,7 +312,10 @@ fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path) {
 
 pub fn update_meta_plan_from(paths: &Paths, alias: &str, plan: &str) -> Result<()> {
     let alias = store::validate_alias(alias)?;
-    let _lock = store::lock(paths)?;
+    let Some(_lock) = store::try_lock(paths)? else {
+        eprintln!("warning: skipped profile metadata update while the store was busy");
+        return Ok(());
+    };
     let dir = store::profile_dir(paths, alias)?;
     let meta_path = dir.join("meta.json");
     if !meta_path.exists() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,286 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use fs2::FileExt;
+
+use crate::config::Paths;
+
+const MAX_ALIAS_BYTES: usize = 128;
+
+/// Validate one profile-store path component.
+///
+/// Email addresses and other existing aliases stay valid. Path syntax,
+/// control characters, and dot-prefixed staging names do not.
+pub fn validate_alias(alias: &str) -> Result<&str> {
+    let alias = alias.trim();
+    if alias.is_empty() {
+        bail!("profile alias cannot be empty");
+    }
+    if alias.len() > MAX_ALIAS_BYTES {
+        bail!("profile alias cannot exceed {MAX_ALIAS_BYTES} bytes");
+    }
+    if !alias.is_ascii() {
+        bail!("profile alias must contain only ASCII characters");
+    }
+    if alias.starts_with('.') {
+        bail!("profile alias cannot start with '.'");
+    }
+    if alias.chars().any(|c| c.is_control()) {
+        bail!("profile alias cannot contain control characters");
+    }
+    if alias.contains('/') || alias.contains('\\') {
+        bail!("profile alias cannot contain path separators");
+    }
+
+    let mut components = Path::new(alias).components();
+    if !matches!(components.next(), Some(Component::Normal(_))) || components.next().is_some() {
+        bail!("profile alias must be one path component");
+    }
+    Ok(alias)
+}
+
+/// Return a checked profile directory below the profile-store root.
+pub fn profile_dir(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    let alias = validate_alias(alias)?;
+    checked_child(&paths.profiles_dir(), alias)
+}
+
+/// Return a checked isolated login home below the login-home root.
+pub fn login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    let alias = validate_alias(alias)?;
+    checked_child(&paths.login_homes_dir(), alias)
+}
+
+fn checked_child(root: &Path, name: &str) -> Result<PathBuf> {
+    if root.exists() {
+        for entry in
+            std::fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))?
+        {
+            let entry = entry?;
+            let Some(existing) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if existing != name && existing.eq_ignore_ascii_case(name) {
+                bail!(
+                    "profile alias conflicts with existing alias '{}' by letter case",
+                    existing
+                );
+            }
+        }
+    }
+    let child = root.join(name);
+    let relative = child
+        .strip_prefix(root)
+        .context("profile path escaped its store root")?;
+    let mut components = relative.components();
+    if !matches!(components.next(), Some(Component::Normal(_))) || components.next().is_some() {
+        bail!("profile path escaped its store root");
+    }
+    if std::fs::symlink_metadata(&child).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        bail!("profile path cannot be a symbolic link");
+    }
+    Ok(child)
+}
+
+/// An exclusive lock for profile-store mutations and live auth switches.
+pub struct StoreLock {
+    file: File,
+}
+
+impl Drop for StoreLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub fn lock(paths: &Paths) -> Result<StoreLock> {
+    ensure_private_dir(&paths.codexctl_dir())?;
+    let lock_path = paths.codexctl_dir().join("store.lock");
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    set_private_file_permissions(&lock_path)?;
+    file.lock_exclusive()
+        .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    Ok(StoreLock { file })
+}
+
+pub fn ensure_private_dir(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    set_private_dir_permissions(path)
+}
+
+/// Replace a file atomically with bytes from `source`.
+pub fn atomic_copy(source: &Path, destination: &Path) -> Result<()> {
+    let mut input =
+        File::open(source).with_context(|| format!("failed to open {}", source.display()))?;
+    atomic_replace(destination, |output| {
+        std::io::copy(&mut input, output)
+            .with_context(|| format!("failed to copy {}", source.display()))?;
+        Ok(())
+    })
+}
+
+/// Replace a file atomically with the supplied bytes.
+pub fn atomic_write(destination: &Path, contents: &[u8]) -> Result<()> {
+    atomic_replace(destination, |output| {
+        output
+            .write_all(contents)
+            .with_context(|| format!("failed to write {}", destination.display()))
+    })
+}
+
+fn atomic_replace(destination: &Path, write: impl FnOnce(&mut File) -> Result<()>) -> Result<()> {
+    let parent = destination
+        .parent()
+        .with_context(|| format!("{} has no parent directory", destination.display()))?;
+    ensure_private_dir(parent)?;
+
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("destination file name is not valid UTF-8")?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    let mut temp_path = None;
+    let mut temp_file = None;
+    for attempt in 0..16 {
+        let candidate = parent.join(format!(
+            ".{file_name}.codexctl-{}-{nonce}-{attempt}.tmp",
+            std::process::id()
+        ));
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&candidate)
+        {
+            Ok(file) => {
+                temp_path = Some(candidate);
+                temp_file = Some(file);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to create temporary file in {}", parent.display())
+                });
+            }
+        }
+    }
+
+    let temp_path = temp_path.context("failed to allocate a unique temporary file")?;
+    let mut temp_file = temp_file.context("failed to open a temporary file")?;
+    let result = (|| {
+        write(&mut temp_file)?;
+        temp_file
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))?;
+        set_private_file_permissions(&temp_path)?;
+        drop(temp_file);
+        std::fs::rename(&temp_path, destination)
+            .with_context(|| format!("failed to atomically replace {}", destination.display()))?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("failed to set private permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_dir_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to set private permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)
+        .and_then(|dir| dir.sync_all())
+        .with_context(|| format!("failed to sync {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_validation_accepts_email_aliases() {
+        assert_eq!(
+            validate_alias("  amir+8@sawmills.ai  ").unwrap(),
+            "amir+8@sawmills.ai"
+        );
+    }
+
+    #[test]
+    fn alias_validation_rejects_path_syntax() {
+        for alias in [
+            "../escape",
+            "a/b",
+            "a\\b",
+            ".",
+            "..",
+            ".hidden",
+            "/tmp/x",
+            "amír@example.com",
+        ] {
+            assert!(validate_alias(alias).is_err(), "accepted {alias:?}");
+        }
+    }
+
+    #[test]
+    fn profile_path_is_one_child_below_store() {
+        let paths = Paths::from_home(PathBuf::from("/tmp/codexctl-store-test"));
+        assert_eq!(
+            profile_dir(&paths, "a@example.com").unwrap(),
+            paths.profiles_dir().join("a@example.com")
+        );
+    }
+
+    #[test]
+    fn profile_path_rejects_case_fold_collisions() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(temp.path().to_path_buf());
+        ensure_private_dir(&paths.profiles_dir()).unwrap();
+        ensure_private_dir(&paths.profiles_dir().join("Work")).unwrap();
+
+        assert!(profile_dir(&paths, "work").is_err());
+        assert!(profile_dir(&paths, "Work").is_ok());
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -90,6 +90,25 @@ pub struct StoreLock {
 }
 
 pub fn lock(paths: &Paths) -> Result<StoreLock> {
+    let (file, lock_path) = open_lock_file(paths)?;
+    file.lock()
+        .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    Ok(StoreLock { _file: file })
+}
+
+/// Try to acquire the store lock without waiting.
+pub fn try_lock(paths: &Paths) -> Result<Option<StoreLock>> {
+    let (file, lock_path) = open_lock_file(paths)?;
+    match file.try_lock() {
+        Ok(()) => Ok(Some(StoreLock { _file: file })),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+        Err(std::fs::TryLockError::Error(error)) => {
+            Err(error).with_context(|| format!("failed to lock {}", lock_path.display()))
+        }
+    }
+}
+
+fn open_lock_file(paths: &Paths) -> Result<(File, PathBuf)> {
     ensure_private_dir(&paths.codexctl_dir())?;
     let lock_path = paths.codexctl_dir().join("store.lock");
     let file = OpenOptions::new()
@@ -100,9 +119,7 @@ pub fn lock(paths: &Paths) -> Result<StoreLock> {
         .open(&lock_path)
         .with_context(|| format!("failed to open {}", lock_path.display()))?;
     set_private_file_permissions(&lock_path)?;
-    file.lock()
-        .with_context(|| format!("failed to lock {}", lock_path.display()))?;
-    Ok(StoreLock { _file: file })
+    Ok((file, lock_path))
 }
 
 pub fn ensure_private_dir(path: &Path) -> Result<()> {
@@ -282,5 +299,14 @@ mod tests {
 
         assert!(profile_dir(&paths, "work").is_err());
         assert!(profile_dir(&paths, "Work").is_ok());
+    }
+
+    #[test]
+    fn try_lock_returns_without_waiting_when_store_is_locked() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(temp.path().to_path_buf());
+        let _lock = lock(&paths).unwrap();
+
+        assert!(try_lock(&paths).unwrap().is_none());
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,7 +4,6 @@ use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
-use fs2::FileExt;
 
 use crate::config::Paths;
 
@@ -87,13 +86,7 @@ fn checked_child(root: &Path, name: &str) -> Result<PathBuf> {
 
 /// An exclusive lock for profile-store mutations and live auth switches.
 pub struct StoreLock {
-    file: File,
-}
-
-impl Drop for StoreLock {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
-    }
+    _file: File,
 }
 
 pub fn lock(paths: &Paths) -> Result<StoreLock> {
@@ -107,9 +100,9 @@ pub fn lock(paths: &Paths) -> Result<StoreLock> {
         .open(&lock_path)
         .with_context(|| format!("failed to open {}", lock_path.display()))?;
     set_private_file_permissions(&lock_path)?;
-    file.lock_exclusive()
+    file.lock()
         .with_context(|| format!("failed to lock {}", lock_path.display()))?;
-    Ok(StoreLock { file })
+    Ok(StoreLock { _file: file })
 }
 
 pub fn ensure_private_dir(path: &Path) -> Result<()> {
@@ -160,11 +153,7 @@ fn atomic_replace(destination: &Path, write: impl FnOnce(&mut File) -> Result<()
             ".{file_name}.codexctl-{}-{nonce}-{attempt}.tmp",
             std::process::id()
         ));
-        match OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&candidate)
-        {
+        match create_private_temp(&candidate) {
             Ok(file) => {
                 temp_path = Some(candidate);
                 temp_file = Some(file);
@@ -198,6 +187,17 @@ fn atomic_replace(destination: &Path, write: impl FnOnce(&mut File) -> Result<()
         let _ = std::fs::remove_file(&temp_path);
     }
     result
+}
+
+fn create_private_temp(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
 }
 
 #[cfg(unix)]

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -183,6 +183,24 @@ fn billing_class_is_conservative_for_missing_or_changed_metadata() {
         serde_json::from_str(r#"{"plan_type":"new_plan","rate_limit":null}"#).unwrap();
     assert_eq!(unknown.billing_class(), BillingClass::Unknown);
 
+    let unknown_with_window: RateLimitResponse = serde_json::from_str(
+        r#"{"plan_type":"new_plan","rate_limit":{"primary_window":{"used_percent":1,"limit_window_seconds":604800}}}"#,
+    )
+    .unwrap();
+    assert_eq!(unknown_with_window.billing_class(), BillingClass::Unknown);
+
+    for credits in [
+        r#"{"has_credits":true}"#,
+        r#"{"has_credits":false,"unlimited":true}"#,
+        r#"{"has_credits":false,"overage_limit_reached":true}"#,
+    ] {
+        let mixed: RateLimitResponse = serde_json::from_str(&format!(
+            r#"{{"plan_type":"pro","rate_limit":{{"primary_window":{{"used_percent":1,"limit_window_seconds":604800}}}},"credits":{credits}}}"#
+        ))
+        .unwrap();
+        assert_eq!(mixed.billing_class(), BillingClass::Unknown);
+    }
+
     let empty_rate_limit: RateLimitResponse =
         serde_json::from_str(r#"{"plan_type":"new_plan","rate_limit":{}}"#).unwrap();
     assert_eq!(empty_rate_limit.billing_class(), BillingClass::Unknown);

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -111,6 +111,89 @@ fn parse_rate_limit_response_team_format() {
     assert!((secondary.used_percent - 25.0).abs() < f64::EPSILON);
 }
 
+#[test]
+fn parse_additional_named_rate_limit_bucket() {
+    let json = r#"{
+        "plan_type": "pro",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 13,
+                "limit_window_seconds": 604800
+            }
+        },
+        "additional_rate_limits": [{
+            "limit_name": "GPT-5.3-Codex-Spark",
+            "metered_feature": "codex_bengalfox",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 0,
+                    "limit_window_seconds": 604800
+                }
+            }
+        }]
+    }"#;
+
+    let response: RateLimitResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(response.additional_rate_limits.len(), 1);
+    let additional = &response.additional_rate_limits[0];
+    assert_eq!(
+        additional.limit_name.as_deref(),
+        Some("GPT-5.3-Codex-Spark")
+    );
+    assert_eq!(
+        additional.metered_feature.as_deref(),
+        Some("codex_bengalfox")
+    );
+    assert_eq!(
+        additional
+            .rate_limit
+            .as_ref()
+            .and_then(|limit| limit.long_window())
+            .map(|window| window.used_percent),
+        Some(0.0)
+    );
+}
+
+#[test]
+fn billing_class_is_conservative_for_missing_or_changed_metadata() {
+    use api::BillingClass;
+
+    let rate_limited: RateLimitResponse = serde_json::from_str(
+        r#"{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":1,"limit_window_seconds":604800}}}"#,
+    )
+    .unwrap();
+    assert_eq!(rate_limited.billing_class(), BillingClass::RateLimited);
+
+    let plan_usage_based: RateLimitResponse = serde_json::from_str(
+        r#"{"plan_type":"self_serve_business_usage_based","rate_limit":{"primary_window":{"used_percent":1,"limit_window_seconds":604800}}}"#,
+    )
+    .unwrap();
+    assert_eq!(plan_usage_based.billing_class(), BillingClass::UsageBased);
+
+    let credits_usage_based: RateLimitResponse = serde_json::from_str(
+        r#"{"plan_type":null,"rate_limit":null,"credits":{"has_credits":true}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        credits_usage_based.billing_class(),
+        BillingClass::UsageBased
+    );
+
+    let unknown: RateLimitResponse =
+        serde_json::from_str(r#"{"plan_type":"new_plan","rate_limit":null}"#).unwrap();
+    assert_eq!(unknown.billing_class(), BillingClass::Unknown);
+
+    let empty_rate_limit: RateLimitResponse =
+        serde_json::from_str(r#"{"plan_type":"new_plan","rate_limit":{}}"#).unwrap();
+    assert_eq!(empty_rate_limit.billing_class(), BillingClass::Unknown);
+}
+
+#[test]
+fn bounded_http_clients_build() {
+    api::http_client().unwrap();
+    api::blocking_http_client().unwrap();
+}
+
 /// Plans that publish only a weekly window return it in the `primary_window`
 /// slot. Reading windows positionally would report that weekly limit as a 5h
 /// one and leave the 7d reset unknown, which silently disables reset-aware

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -40,6 +40,15 @@ fn codex_has_independent_reset_and_billing_flags() {
     assert!(stdout.contains("--allow-resets"));
 }
 
+#[test]
+fn use_has_independent_reset_and_billing_flags() {
+    let mut cmd = Command::cargo_bin("codexctl").unwrap();
+    let output = cmd.args(["use", "--help"]).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--allow-billing"));
+    assert!(stdout.contains("--allow-resets"));
+}
+
 /// Installed builds need to be able to report their own version, so an upgrade
 /// can be confirmed from the binary rather than from the package manager.
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -79,3 +79,45 @@ fn status_accepts_rate_limited_flag() {
     assert!(stdout.contains("--rate-limited"));
     assert!(stdout.contains("--usage-based"));
 }
+
+#[test]
+fn informational_and_invalid_commands_do_not_create_profile_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let commands: &[&[&str]] = &[
+        &["--help"],
+        &["--version"],
+        &["-V"],
+        &["completions", "bash"],
+        &["nonexistent"],
+    ];
+
+    for args in commands {
+        let mut command = Command::cargo_bin("codexctl").unwrap();
+        let output = command
+            .env("HOME", tmp.path())
+            .args(*args)
+            .output()
+            .unwrap();
+        if *args == ["nonexistent"] {
+            assert!(!output.status.success());
+        }
+        assert!(
+            !tmp.path().join(".codexctl").exists(),
+            "created state for {args:?}"
+        );
+    }
+}
+
+#[test]
+fn stateful_command_initializes_private_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut command = Command::cargo_bin("codexctl").unwrap();
+
+    command
+        .env("HOME", tmp.path())
+        .arg("list")
+        .assert()
+        .success();
+
+    assert!(tmp.path().join(".codexctl/profiles").is_dir());
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -91,7 +91,6 @@ fn status_accepts_rate_limited_flag() {
 
 #[test]
 fn informational_and_invalid_commands_do_not_create_profile_state() {
-    let tmp = tempfile::tempdir().unwrap();
     let commands: &[&[&str]] = &[
         &["--help"],
         &["--version"],
@@ -101,15 +100,20 @@ fn informational_and_invalid_commands_do_not_create_profile_state() {
     ];
 
     for args in commands {
+        let tmp = tempfile::tempdir().unwrap();
         let mut command = Command::cargo_bin("codexctl").unwrap();
         let output = command
             .env("HOME", tmp.path())
             .args(*args)
             .output()
             .unwrap();
-        if *args == ["nonexistent"] {
-            assert!(!output.status.success());
-        }
+        let expect_failure = *args == ["nonexistent"];
+        assert_eq!(
+            output.status.success(),
+            !expect_failure,
+            "unexpected status for {args:?}: {:?}",
+            output.status
+        );
         assert!(
             !tmp.path().join(".codexctl").exists(),
             "created state for {args:?}"
@@ -129,4 +133,16 @@ fn stateful_command_initializes_private_store() {
         .success();
 
     assert!(tmp.path().join(".codexctl/profiles").is_dir());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for dir in [".codexctl", ".codexctl/profiles"] {
+            let mode = std::fs::metadata(tmp.path().join(dir))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o700, "{dir} is not private");
+        }
+    }
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -261,3 +261,184 @@ fn switch_skips_capture_for_foreign_codex_auth() {
         std::fs::read_to_string(paths.profiles_dir().join("a@test").join("auth.json")).unwrap();
     assert!(a_store.contains(".old") && !a_store.contains(".live"));
 }
+
+#[test]
+fn profile_aliases_cannot_escape_the_store() {
+    let (tmp, paths) = setup_test_env();
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("keep"), "safe").unwrap();
+
+    assert!(profile::get_profile_from(&paths, "../outside").is_err());
+    assert!(profile::delete_profile_from(&paths, "../outside").is_err());
+    assert!(
+        profile::save_profile_to(&paths, "/tmp/escape", None, &paths.codex_auth_json()).is_err()
+    );
+    assert!(outside.join("keep").exists());
+}
+
+#[test]
+fn directory_alias_is_authoritative_over_stored_metadata() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(&paths, "safe@test", "safe-token");
+    let meta_path = paths.profiles_dir().join("safe@test").join("meta.json");
+    let mut meta: profile::Meta =
+        serde_json::from_str(&std::fs::read_to_string(&meta_path).unwrap()).unwrap();
+    meta.alias = "../../outside".to_string();
+    std::fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+
+    let profiles = profile::list_profiles_from(&paths).unwrap();
+
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].meta.alias, "safe@test");
+    assert_eq!(profiles[0].dir, paths.profiles_dir().join("safe@test"));
+}
+
+#[test]
+fn invalid_active_marker_is_ignored() {
+    let (_tmp, paths) = setup_test_env();
+    std::fs::write(paths.active_file(), "../../outside").unwrap();
+
+    assert_eq!(profile::get_active_from(&paths).unwrap(), None);
+}
+
+#[test]
+fn active_profile_uses_live_auth_only_for_the_same_token_subject() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.stored");
+    let rotated = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.live");
+    let foreign = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.foreign");
+    write_profile(&paths, "a@test", &stored);
+    let profile = profile::get_profile_from(&paths, "a@test").unwrap();
+
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{rotated}"}}"#),
+    )
+    .unwrap();
+    assert_eq!(
+        profile::auth_json_path_for_profile_from(&paths, &profile, Some("a@test")),
+        paths.codex_auth_json()
+    );
+
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{foreign}"}}"#),
+    )
+    .unwrap();
+    assert_eq!(
+        profile::auth_json_path_for_profile_from(&paths, &profile, Some("a@test")),
+        profile.auth_json_path()
+    );
+    assert_eq!(
+        profile::auth_json_path_for_profile_from(&paths, &profile, Some("other@test")),
+        profile.auth_json_path()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn profile_and_live_auth_files_are_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_tmp, paths) = setup_test_env();
+    profile::save_profile_and_activate_to(
+        &paths,
+        "private@test",
+        Some("private@test"),
+        &paths.codex_auth_json(),
+    )
+    .unwrap();
+
+    let profile_dir = paths.profiles_dir().join("private@test");
+    assert_eq!(
+        std::fs::metadata(&profile_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    for path in [
+        profile_dir.join("auth.json"),
+        profile_dir.join("meta.json"),
+        paths.active_file(),
+    ] {
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symbolic_link_profile_directory_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let (tmp, paths) = setup_test_env();
+    let outside = tmp.path().join("outside-profile");
+    std::fs::create_dir_all(&outside).unwrap();
+    symlink(&outside, paths.profiles_dir().join("linked@test")).unwrap();
+
+    assert!(profile::get_profile_from(&paths, "linked@test").is_err());
+    assert!(
+        profile::save_profile_to(&paths, "linked@test", None, &paths.codex_auth_json()).is_err()
+    );
+}
+
+#[test]
+fn concurrent_switches_keep_active_marker_and_live_auth_aligned() {
+    use std::sync::{Arc, Barrier};
+
+    let (_tmp, paths) = setup_test_env();
+    write_profile(&paths, "a@test", "token-a");
+    write_profile(&paths, "b@test", "token-b");
+    let paths = Arc::new(paths);
+    let barrier = Arc::new(Barrier::new(3));
+
+    let handles: Vec<_> = ["a@test", "b@test"]
+        .into_iter()
+        .map(|alias| {
+            let paths = Arc::clone(&paths);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                profile::switch_to_from(&paths, alias).unwrap();
+            })
+        })
+        .collect();
+    barrier.wait();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let active = profile::get_active_from(&paths).unwrap().unwrap();
+    let live = codexctl::api::read_auth_json(&paths.codex_auth_json()).unwrap();
+    let saved = codexctl::api::read_auth_json(
+        &profile::get_profile_from(&paths, &active)
+            .unwrap()
+            .auth_json_path(),
+    )
+    .unwrap();
+    assert_eq!(live.access_token, saved.access_token);
+}
+
+#[test]
+fn case_fold_alias_collision_cannot_overwrite_credentials() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(&paths, "Work", "original-token");
+    std::fs::write(paths.codex_auth_json(), r#"{"access_token":"new-token"}"#).unwrap();
+
+    let result = profile::save_profile_to(&paths, "work", None, &paths.codex_auth_json());
+
+    assert!(result.is_err());
+    let original = std::fs::read_to_string(
+        profile::get_profile_from(&paths, "Work")
+            .unwrap()
+            .auth_json_path(),
+    )
+    .unwrap();
+    assert!(original.contains("original-token"));
+    assert!(!original.contains("new-token"));
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -369,6 +369,30 @@ fn profile_and_live_auth_files_are_private() {
             0o600
         );
     }
+
+    write_profile(&paths, "other@test", "other-token");
+    profile::switch_to_from(&paths, "other@test").unwrap();
+    assert_eq!(
+        std::fs::metadata(paths.codex_auth_json())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn case_colliding_profile_directories_do_not_break_listing() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(&paths, "Work", "upper-token");
+    write_profile(&paths, "work", "lower-token");
+
+    let profiles = profile::list_profiles_from(&paths).unwrap();
+
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].meta.alias, "Work");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- render live Codex rate-limit buckets and omit absent windows
- prevent unsafe or billable automatic account selection
- serialize and atomically install private auth files
- harden dependency, CI, release, and Homebrew publication gates

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test: 175 passed
- trunk check
- live cargo run -- status
- Claude Opus architecture review
- local autoreview, with the confirmed finding fixed

Linear: SAW-9895

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `codexctl` account status, profile storage, and release workflow to meet SAW-9895. Status now renders multi-bucket limits with adaptive windows; auto-select skips billable/unknown accounts unless you pass `use --allow-billing`, and status metadata updates are nonblocking.

- **New Features**
  - Multi-bucket status: parse/render all named buckets; 5h/7d columns appear only when returned.
  - Consent for billable selection: require `--allow-billing` (separate from `--allow-resets`).
  - Bounded HTTP clients with explicit connect (5s) and request (15s) timeouts.
  - Informational and invalid commands no longer create `.codexctl`.

- **Bug Fixes**
  - Centralized alias validation and path containment; reject absolute/parent paths, separators, control/non-ASCII, dot-prefixed names, and case-fold collisions.
  - Serialized, same-directory atomic, private writes for auth and metadata with a store lock; status metadata updates are best-effort and nonblocking; isolate concurrent login sessions; active profile uses the live auth only when its token subject matches.
  - CI/release hardening: least-privileged permissions, actions pinned to SHAs, tag/version match check, immutable release assets, Homebrew failures fail the workflow; added a CI dependency audit.
  - Dependencies: bumped `anyhow`.

<sup>Written for commit 55635793cbf5059e75669b10cfd3b034f2277269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status now displays multiple named rate-limit windows and model or feature buckets.
  * Accounts with usage-based or unknown billing information are handled more accurately during selection and recovery.
  * Profile aliases now support safe, case-insensitive uniqueness validation.
  * Informational commands no longer create local configuration state.

* **Bug Fixes**
  * Improved profile switching, authentication-path handling, and usage summaries when data is unavailable.
  * Strengthened profile storage with safer updates, permissions, and validation.

* **Documentation**
  * Updated usage, rate-limit, profile alias, and account-selection guidance.

* **Chores**
  * Updated the package version to 0.1.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->