### PR TITLE
SAW-9895 Fix Homebrew release authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TAG: ${{ needs.setup.outputs.tag }}
-          VERSION: ${{ needs.setup.outputs.version }}
           SHA_DARWIN_ARM64: ${{ needs.release.outputs.sha_darwin_arm64 }}
           SHA_DARWIN_X86_64: ${{ needs.release.outputs.sha_darwin_x86_64 }}
           SHA_LINUX_X86_64: ${{ needs.release.outputs.sha_linux_x86_64 }}
@@ -206,13 +205,13 @@ jobs:
 
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
+          gh auth setup-git --hostname github.com
           gh repo clone Sawmills/homebrew-tap "${workdir}/tap" -- --depth 1
 
           cat > "${workdir}/tap/Formula/codexctl.rb" << EOF
           class Codexctl < Formula
             desc "Manage multiple OpenAI Codex CLI accounts"
             homepage "https://github.com/Sawmills/codexctl"
-            version "${VERSION}"
             license "Apache-2.0"
 
             on_macos do


### PR DESCRIPTION
## Summary
- configure Git to use the scoped GitHub App token before cloning the public tap
- let Homebrew infer the formula version from release URLs

## Cause
The v0.1.17 release job created a valid app token, but Git did not use it for the tap push. The tap also rejects explicit versions that it can derive from the URL.

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- release.yml YAML parse
- autoreview clean
- live tap PR #92 passed Formula CI and merged
- Homebrew installed codexctl 0.1.17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Homebrew release failures by authenticating tap pushes with the GitHub App token and letting Homebrew infer the formula version from release URLs. Part of SAW-9895 to harden release safety.

- **Bug Fixes**
  - Run `gh auth setup-git` before cloning/pushing the tap to use the scoped app token.
  - Remove explicit `version` in the formula and the `VERSION` env var so Homebrew derives it from asset URLs.

<sup>Written for commit 00b535adc0beb98f71ba140ad4a9a4ec12b3c219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

