### PR TITLE
SAW-9895 Render server-declared rate-limit windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codexctl"
 version = "0.1.18"
 edition = "2024"
+rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Manage multiple OpenAI Codex CLI accounts"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -66,10 +66,16 @@ Usage-Based Accounts
 Sorted by availability — most available accounts first. All accounts are fetched live in parallel.
 The account column is the saved profile alias, with `*` marking the active account.
 
-Rate-limit windows are matched by their server-declared duration. A 5-hour or 7-day column appears
-only when at least one returned bucket contains that window. Named model or feature buckets appear
-as separate rows. `codexctl` does not show an empty 5-hour column when the service returns only a
-weekly window.
+Rate-limit windows are matched and labeled by their server-declared duration. For example, the
+table can show `15m`, `1h`, `5h`, or `7d` columns. A column appears only when at least one returned
+bucket contains that duration. Named model or feature buckets appear as separate rows. `codexctl`
+does not invent a 5-hour window when the service returns only a weekly window.
+
+OpenAI's current [subscription documentation](https://learn.chatgpt.com/docs/pricing) describes one
+shared agentic usage and credit pool, with plan and model-specific allowances. It does not promise
+one universal window layout. The live [multi-bucket rate-limit
+response](https://developers.openai.com/codex/app-server#6-rate-limits-chatgpt) is therefore
+authoritative for the columns that `codexctl` shows.
 
 Automatic account selection uses the main `Codex` bucket. Additional buckets are model-specific or
 feature-specific status. They do not block general account selection without a reliable mapping

--- a/src/api.rs
+++ b/src/api.rs
@@ -222,7 +222,7 @@ impl RateLimit {
             .short_window()
             .map_or(0.0, |window| window.used_percent);
         let long = self.long_window().map_or(0.0, |window| window.used_percent);
-        if short >= 100.0 && long >= 100.0 {
+        let score = if short >= 100.0 && long >= 100.0 {
             900.0
         } else if long >= 100.0 {
             700.0 + short
@@ -230,6 +230,14 @@ impl RateLimit {
             500.0 + long
         } else {
             short * 2.0 + long
+        };
+        if self
+            .windows()
+            .any(|(_, window)| window.used_percent >= 100.0)
+        {
+            score.max(500.0)
+        } else {
+            score
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -117,8 +117,9 @@ pub struct RateLimit {
     pub secondary_window: Option<RateLimitWindow>,
 }
 
-/// Windows at or under this duration are the short (5h) window; longer ones are
-/// the long (7d) window.
+/// A single window at or under this duration is the short-term window. A single
+/// longer window is the long-term window. When the server returns two windows,
+/// their declared durations determine which is shorter and which is longer.
 const SHORT_WINDOW_MAX_SECONDS: u64 = 24 * 60 * 60;
 
 impl RateLimit {
@@ -134,37 +135,102 @@ impl RateLimit {
         self.secondary.as_ref().or(self.secondary_window.as_ref())
     }
 
-    /// The short (5h) window.
+    /// Every server-returned window, with `0` for primary and `1` for
+    /// secondary. Keep the slot before filtering so a secondary-only response
+    /// cannot be mislabeled as primary.
+    pub fn windows(&self) -> impl Iterator<Item = (usize, &RateLimitWindow)> {
+        [(0, self.first()), (1, self.second())]
+            .into_iter()
+            .filter_map(|(position, window)| window.map(|window| (position, window)))
+    }
+
+    /// The shorter-term window.
     ///
     /// Windows are matched by their declared duration rather than by position:
-    /// plans that no longer publish a 5h window return their weekly window in
-    /// the `primary_window` slot, and reading that positionally would report a
-    /// weekly limit as a 5h one. Windows with no declared duration fall back to
-    /// the historical positional reading.
+    /// a weekly-only plan can return its window in the `primary_window` slot,
+    /// while newer contracts can return two sub-day windows. Windows with no
+    /// declared duration fall back to the historical positional reading.
     pub fn short_window(&self) -> Option<&RateLimitWindow> {
-        self.window_matching(|seconds| seconds <= SHORT_WINDOW_MAX_SECONDS, Self::first)
-    }
-
-    /// The long (7d) window. See [`RateLimit::short_window`] for how windows are
-    /// matched.
-    pub fn long_window(&self) -> Option<&RateLimitWindow> {
-        self.window_matching(|seconds| seconds > SHORT_WINDOW_MAX_SECONDS, Self::second)
-    }
-
-    fn window_matching(
-        &self,
-        matches: impl Fn(u64) -> bool,
-        positional: impl Fn(&Self) -> Option<&RateLimitWindow>,
-    ) -> Option<&RateLimitWindow> {
-        for window in [self.first(), self.second()].into_iter().flatten() {
-            if window.duration_seconds().is_some_and(&matches) {
-                return Some(window);
+        match (self.first(), self.second()) {
+            (Some(first), Some(second)) => {
+                match (first.duration_seconds(), second.duration_seconds()) {
+                    (Some(first_seconds), Some(second_seconds)) => {
+                        Some(if first_seconds <= second_seconds {
+                            first
+                        } else {
+                            second
+                        })
+                    }
+                    (Some(seconds), None) => (seconds <= SHORT_WINDOW_MAX_SECONDS).then_some(first),
+                    (None, Some(seconds)) => {
+                        if seconds <= SHORT_WINDOW_MAX_SECONDS {
+                            Some(second)
+                        } else {
+                            Some(first)
+                        }
+                    }
+                    (None, None) => Some(first),
+                }
             }
+            (Some(window), None) => window.duration_seconds().map_or(Some(window), |seconds| {
+                (seconds <= SHORT_WINDOW_MAX_SECONDS).then_some(window)
+            }),
+            (None, Some(window)) => window
+                .duration_seconds()
+                .and_then(|seconds| (seconds <= SHORT_WINDOW_MAX_SECONDS).then_some(window)),
+            (None, None) => None,
         }
-        // Nothing declares a duration in this class. Fall back to the historical
-        // positional reading only when that window's duration is unknown, so a
-        // response that does publish durations is never misread.
-        positional(self).filter(|w| w.duration_seconds().is_none())
+    }
+
+    /// The longer-term window. See [`RateLimit::short_window`] for matching.
+    pub fn long_window(&self) -> Option<&RateLimitWindow> {
+        match (self.first(), self.second()) {
+            (Some(first), Some(second)) => {
+                match (first.duration_seconds(), second.duration_seconds()) {
+                    (Some(first_seconds), Some(second_seconds)) => {
+                        Some(if first_seconds > second_seconds {
+                            first
+                        } else {
+                            second
+                        })
+                    }
+                    (Some(seconds), None) => {
+                        if seconds > SHORT_WINDOW_MAX_SECONDS {
+                            Some(first)
+                        } else {
+                            Some(second)
+                        }
+                    }
+                    (None, Some(seconds)) => (seconds > SHORT_WINDOW_MAX_SECONDS).then_some(second),
+                    (None, None) => Some(second),
+                }
+            }
+            (Some(window), None) => window
+                .duration_seconds()
+                .and_then(|seconds| (seconds > SHORT_WINDOW_MAX_SECONDS).then_some(window)),
+            (None, Some(window)) => window.duration_seconds().map_or(Some(window), |seconds| {
+                (seconds > SHORT_WINDOW_MAX_SECONDS).then_some(window)
+            }),
+            (None, None) => None,
+        }
+    }
+
+    /// Availability score used by status sorting and automatic selection.
+    /// Exhausting either returned window makes the account unavailable.
+    pub fn availability_score(&self) -> f64 {
+        let short = self
+            .short_window()
+            .map_or(0.0, |window| window.used_percent);
+        let long = self.long_window().map_or(0.0, |window| window.used_percent);
+        if short >= 100.0 && long >= 100.0 {
+            900.0
+        } else if long >= 100.0 {
+            700.0 + short
+        } else if short >= 100.0 {
+            500.0 + long
+        } else {
+            short * 2.0 + long
+        }
     }
 }
 
@@ -194,6 +260,30 @@ impl RateLimitWindow {
     pub fn duration_seconds(&self) -> Option<u64> {
         self.limit_window_seconds
             .or_else(|| self.window_minutes.map(|m| m * 60))
+    }
+
+    /// A compact label derived from the server-declared window duration.
+    pub fn duration_label(&self) -> Option<String> {
+        self.duration_seconds().map(format_duration_label)
+    }
+}
+
+fn format_duration_label(seconds: u64) -> String {
+    if seconds == 0 {
+        return "0s".to_string();
+    }
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+
+    if seconds.is_multiple_of(DAY) {
+        format!("{}d", seconds / DAY)
+    } else if seconds.is_multiple_of(HOUR) {
+        format!("{}h", seconds / HOUR)
+    } else if seconds.is_multiple_of(MINUTE) {
+        format!("{}m", seconds / MINUTE)
+    } else {
+        format!("{seconds}s")
     }
 }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -344,22 +344,24 @@ impl RateLimitColumns {
         let historical_pair = if windows.len() == 2 {
             let five_hour = windows
                 .iter()
-                .position(|column| column.keys[0] == WindowKey::Duration(5 * 60 * 60, 0));
+                .any(|column| column.keys[0] == WindowKey::Duration(5 * 60 * 60, 0));
             let seven_day = windows
                 .iter()
-                .position(|column| column.keys[0] == WindowKey::Duration(7 * 24 * 60 * 60, 0));
-            five_hour.zip(seven_day)
+                .any(|column| column.keys[0] == WindowKey::Duration(7 * 24 * 60 * 60, 0));
+            (five_hour && seven_day).then_some((
+                WindowKey::Duration(5 * 60 * 60, 0),
+                WindowKey::Duration(7 * 24 * 60 * 60, 0),
+            ))
         } else {
             None
         };
         for (position, label) in positional {
-            let target_index = match (position, historical_pair) {
+            let target = match (position, historical_pair) {
                 (0, Some((five_hour, _))) => Some(five_hour),
                 (1, Some((_, seven_day))) => Some(seven_day),
                 _ => None,
             };
-            let can_alias = target_index.is_some_and(|index| {
-                let target = windows[index].keys[0];
+            let can_alias = target.is_some_and(|target| {
                 healthy.iter().all(|account| {
                     account.limits.iter().all(|limit| {
                         let has_position = limit
@@ -371,7 +373,10 @@ impl RateLimitColumns {
                     })
                 })
             });
-            if let Some(index) = target_index.filter(|_| can_alias) {
+            let target_index = target
+                .filter(|_| can_alias)
+                .and_then(|target| windows.iter().position(|column| column.keys[0] == target));
+            if let Some(index) = target_index {
                 windows[index].keys.push(WindowKey::Position(position));
             } else {
                 let column = WindowColumn {
@@ -1183,6 +1188,64 @@ mod tests {
         );
         assert_eq!(legacy_row[1].content(), "30%");
         assert_eq!(legacy_row[3].content(), "40%");
+    }
+
+    #[test]
+    fn legacy_secondary_alignment_survives_primary_column_insertion() {
+        let declared: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 10, "window_minutes": 300},
+                "secondary_window": {"used_percent": 20, "window_minutes": 10080}
+            }"#,
+        )
+        .unwrap();
+        let conflicting_primary: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 30},
+                "secondary_window": {"used_percent": 40, "window_minutes": 300}
+            }"#,
+        )
+        .unwrap();
+        let legacy_secondary: api::RateLimit =
+            serde_json::from_str(r#"{"secondary_window": {"used_percent": 50}}"#).unwrap();
+        let mut declared_account = rate_limited_account();
+        declared_account.limits =
+            vec![LimitStatus::from_rate_limit("Codex".to_string(), &declared)];
+        let mut conflicting_account = rate_limited_account();
+        conflicting_account.alias = "conflict@sawmills.ai".to_string();
+        conflicting_account.limits = vec![LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            &conflicting_primary,
+        )];
+        let mut secondary_account = rate_limited_account();
+        secondary_account.alias = "secondary@sawmills.ai".to_string();
+        secondary_account.limits = vec![LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            &legacy_secondary,
+        )];
+
+        let columns = RateLimitColumns::for_accounts(&[
+            &declared_account,
+            &conflicting_account,
+            &secondary_account,
+        ]);
+        let secondary_row = &render_rate_limited_rows(&secondary_account, &columns)[0];
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "Primary",
+                "Primary Reset",
+                "5h",
+                "5h Reset",
+                "7d",
+                "7d Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+        assert_eq!(secondary_row[5].content(), "50%");
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL_CONDENSED};
@@ -40,33 +40,77 @@ struct RateLimitedAccount {
 
 struct LimitStatus {
     name: String,
-    h5_pct: Option<f64>,
-    d7_pct: Option<f64>,
-    h5_reset: String,
-    d7_reset: String,
+    windows: Vec<WindowStatus>,
+    availability_score: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum WindowKey {
+    Duration(u64, usize),
+    Position(usize),
+}
+
+struct WindowStatus {
+    key: WindowKey,
+    label: String,
+    used_pct: f64,
+    reset: String,
 }
 
 impl LimitStatus {
     fn from_rate_limit(name: String, rate_limit: &api::RateLimit) -> Self {
-        let short = rate_limit.short_window();
-        let long = rate_limit.long_window();
+        let mut duration_occurrences = HashMap::new();
+        let mut windows: Vec<_> = rate_limit
+            .windows()
+            .map(|(position, window)| {
+                let (key, label) = match window.duration_seconds() {
+                    Some(seconds) => {
+                        let occurrence = duration_occurrences.entry(seconds).or_insert(0);
+                        let key = WindowKey::Duration(seconds, *occurrence);
+                        *occurrence += 1;
+                        let mut label = window
+                            .duration_label()
+                            .unwrap_or_else(|| seconds.to_string());
+                        if *occurrence > 1 {
+                            label = format!("{label} #{}", *occurrence);
+                        }
+                        (key, label)
+                    }
+                    None => (
+                        WindowKey::Position(position),
+                        positional_window_label(position).to_string(),
+                    ),
+                };
+                WindowStatus {
+                    key,
+                    label,
+                    used_pct: window.used_percent,
+                    reset: format_window_reset(Some(window)),
+                }
+            })
+            .collect();
+        windows.sort_by_key(|window| window.key);
         Self {
             name,
-            h5_pct: short.map(|window| window.used_percent),
-            d7_pct: long.map(|window| window.used_percent),
-            h5_reset: format_window_reset(short),
-            d7_reset: format_window_reset(long),
+            windows,
+            availability_score: rate_limit.availability_score(),
         }
     }
 
     fn unavailable() -> Self {
         Self {
             name: "Codex".to_string(),
-            h5_pct: None,
-            d7_pct: None,
-            h5_reset: "-".to_string(),
-            d7_reset: "-".to_string(),
+            windows: Vec::new(),
+            availability_score: 0.0,
         }
+    }
+}
+
+fn positional_window_label(position: usize) -> &'static str {
+    if position == 0 {
+        "Primary"
+    } else {
+        "Secondary"
     }
 }
 
@@ -90,18 +134,7 @@ impl RateLimitedAccount {
         let Some(main) = self.limits.first() else {
             return 1000.0;
         };
-        let h5 = main.h5_pct.unwrap_or(0.0);
-        let d7 = main.d7_pct.unwrap_or(0.0);
-        if h5 >= 100.0 && d7 >= 100.0 {
-            return 900.0;
-        }
-        if d7 >= 100.0 {
-            return 700.0 + h5;
-        }
-        if h5 >= 100.0 {
-            return 500.0 + d7;
-        }
-        h5 * 2.0 + d7
+        main.availability_score
     }
 }
 
@@ -257,7 +290,7 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
     let columns = RateLimitColumns::for_accounts(accounts);
     table.set_header(columns.headers());
     for account in accounts {
-        for row in render_rate_limited_rows(account, columns) {
+        for row in render_rate_limited_rows(account, &columns) {
             table.add_row(row);
         }
     }
@@ -265,11 +298,14 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
     true
 }
 
-#[derive(Clone, Copy)]
 struct RateLimitColumns {
     named_limits: bool,
-    short: bool,
-    long: bool,
+    windows: Vec<WindowColumn>,
+}
+
+struct WindowColumn {
+    keys: Vec<WindowKey>,
+    label: String,
 }
 
 impl RateLimitColumns {
@@ -278,29 +314,93 @@ impl RateLimitColumns {
             .iter()
             .filter(|account| !account.is_error)
             .collect();
+        let mut declared = BTreeMap::new();
+        let mut positional = BTreeMap::new();
+        for account in &healthy {
+            for limit in &account.limits {
+                for window in &limit.windows {
+                    match window.key {
+                        WindowKey::Duration(_, _) => {
+                            declared
+                                .entry(window.key)
+                                .or_insert_with(|| window.label.clone());
+                        }
+                        WindowKey::Position(position) => {
+                            positional
+                                .entry(position)
+                                .or_insert_with(|| window.label.clone());
+                        }
+                    }
+                }
+            }
+        }
+        let mut windows: Vec<_> = declared
+            .into_iter()
+            .map(|(key, label)| WindowColumn {
+                keys: vec![key],
+                label,
+            })
+            .collect();
+        let historical_pair = if windows.len() == 2 {
+            let five_hour = windows
+                .iter()
+                .position(|column| column.keys[0] == WindowKey::Duration(5 * 60 * 60, 0));
+            let seven_day = windows
+                .iter()
+                .position(|column| column.keys[0] == WindowKey::Duration(7 * 24 * 60 * 60, 0));
+            five_hour.zip(seven_day)
+        } else {
+            None
+        };
+        for (position, label) in positional {
+            let target_index = match (position, historical_pair) {
+                (0, Some((five_hour, _))) => Some(five_hour),
+                (1, Some((_, seven_day))) => Some(seven_day),
+                _ => None,
+            };
+            let can_alias = target_index.is_some_and(|index| {
+                let target = windows[index].keys[0];
+                healthy.iter().all(|account| {
+                    account.limits.iter().all(|limit| {
+                        let has_position = limit
+                            .windows
+                            .iter()
+                            .any(|window| window.key == WindowKey::Position(position));
+                        let has_target = limit.windows.iter().any(|window| window.key == target);
+                        !(has_position && has_target)
+                    })
+                })
+            });
+            if let Some(index) = target_index.filter(|_| can_alias) {
+                windows[index].keys.push(WindowKey::Position(position));
+            } else {
+                let column = WindowColumn {
+                    keys: vec![WindowKey::Position(position)],
+                    label,
+                };
+                if position == 0 {
+                    windows.insert(0, column);
+                } else {
+                    windows.push(column);
+                }
+            }
+        }
         Self {
             named_limits: healthy.iter().any(|account| account.limits.len() > 1),
-            short: healthy
-                .iter()
-                .any(|account| account.limits.iter().any(|limit| limit.h5_pct.is_some())),
-            long: healthy
-                .iter()
-                .any(|account| account.limits.iter().any(|limit| limit.d7_pct.is_some())),
+            windows,
         }
     }
 
-    fn headers(self) -> Vec<&'static str> {
-        let mut headers = vec!["Account"];
+    fn headers(&self) -> Vec<String> {
+        let mut headers = vec!["Account".to_string()];
         if self.named_limits {
-            headers.push("Limit");
+            headers.push("Limit".to_string());
         }
-        if self.short {
-            headers.extend(["5h", "5h Reset"]);
+        for window in &self.windows {
+            headers.push(window.label.clone());
+            headers.push(format!("{} Reset", window.label));
         }
-        if self.long {
-            headers.extend(["7d", "7d Reset"]);
-        }
-        headers.extend(["Resets", "Token"]);
+        headers.extend(["Resets".to_string(), "Token".to_string()]);
         headers
     }
 }
@@ -615,17 +715,14 @@ fn rate_limit_statuses(usage: &api::RateLimitResponse) -> Vec<LimitStatus> {
 
 fn render_rate_limited_rows(
     account: &RateLimitedAccount,
-    columns: RateLimitColumns,
+    columns: &RateLimitColumns,
 ) -> Vec<Vec<Cell>> {
     if account.is_error {
         let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
         if columns.named_limits {
             row.push(Cell::new("-"));
         }
-        if columns.short {
-            row.extend([Cell::new("-"), Cell::new("-")]);
-        }
-        if columns.long {
+        for _ in &columns.windows {
             row.extend([Cell::new("-"), Cell::new("-")]);
         }
         row.push(Cell::new("-"));
@@ -642,13 +739,15 @@ fn render_rate_limited_rows(
             if columns.named_limits {
                 row.push(Cell::new(&limit.name));
             }
-            if columns.short {
-                row.push(colorize_usage(limit.h5_pct));
-                row.push(Cell::new(&limit.h5_reset));
-            }
-            if columns.long {
-                row.push(colorize_usage(limit.d7_pct));
-                row.push(Cell::new(&limit.d7_reset));
+            for column in &columns.windows {
+                let window = limit
+                    .windows
+                    .iter()
+                    .find(|window| column.keys.contains(&window.key));
+                row.push(colorize_usage(window.map(|window| window.used_pct)));
+                row.push(Cell::new(
+                    window.map_or("-", |window| window.reset.as_str()),
+                ));
             }
             if index == 0 {
                 row.push(resets_cell(account));
@@ -862,10 +961,21 @@ mod tests {
             alias: "amir+8@sawmills.ai".to_string(),
             limits: vec![LimitStatus {
                 name: "Codex".to_string(),
-                h5_pct: Some(10.0),
-                d7_pct: Some(20.0),
-                h5_reset: "in 1h 00m".to_string(),
-                d7_reset: "in 1d 00h".to_string(),
+                windows: vec![
+                    WindowStatus {
+                        key: WindowKey::Duration(5 * 60 * 60, 0),
+                        label: "5h".to_string(),
+                        used_pct: 10.0,
+                        reset: "in 1h 00m".to_string(),
+                    },
+                    WindowStatus {
+                        key: WindowKey::Duration(7 * 24 * 60 * 60, 0),
+                        label: "7d".to_string(),
+                        used_pct: 20.0,
+                        reset: "in 1d 00h".to_string(),
+                    },
+                ],
+                availability_score: 40.0,
             }],
             token_expiry: None,
             reset_credits: 0,
@@ -881,7 +991,7 @@ mod tests {
     fn render_rate_limited_row_has_expected_column_count() {
         let account = rate_limited_account();
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, columns);
+        let rows = render_rate_limited_rows(&account, &columns);
         assert_eq!(columns.headers().len(), 7);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].len(), 7);
@@ -897,7 +1007,7 @@ mod tests {
         };
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, columns);
+        let rows = render_rate_limited_rows(&account, &columns);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].len(), columns.headers().len());
     }
@@ -905,59 +1015,334 @@ mod tests {
     #[test]
     fn weekly_only_accounts_omit_empty_five_hour_columns() {
         let mut account = rate_limited_account();
-        account.limits[0].h5_pct = None;
-        account.limits[0].h5_reset = "-".to_string();
+        account.limits[0]
+            .windows
+            .retain(|window| window.label == "7d");
+        account.limits[0].availability_score = 20.0;
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
 
-        assert!(!columns.short);
         assert_eq!(
             columns.headers(),
             vec!["Account", "7d", "7d Reset", "Resets", "Token"]
         );
-        assert_eq!(render_rate_limited_rows(&account, columns)[0].len(), 5);
+        assert_eq!(render_rate_limited_rows(&account, &columns)[0].len(), 5);
     }
 
     #[test]
     fn error_rows_do_not_add_hidden_limit_columns() {
         let mut healthy = rate_limited_account();
-        healthy.limits[0].h5_pct = None;
+        healthy.limits[0]
+            .windows
+            .retain(|window| window.label == "7d");
+        healthy.limits[0].availability_score = 20.0;
         let mut error = rate_limited_account();
         error.is_error = true;
         error.limits.push(LimitStatus {
             name: "Hidden".to_string(),
-            h5_pct: Some(1.0),
-            d7_pct: None,
-            h5_reset: "in 1h 00m".to_string(),
-            d7_reset: "-".to_string(),
+            windows: vec![WindowStatus {
+                key: WindowKey::Duration(60 * 60, 0),
+                label: "1h".to_string(),
+                used_pct: 1.0,
+                reset: "in 1h 00m".to_string(),
+            }],
+            availability_score: 2.0,
         });
 
         let columns = RateLimitColumns::for_accounts(&[&healthy, &error]);
 
         assert!(!columns.named_limits);
-        assert!(!columns.short);
-        assert!(columns.long);
+        assert_eq!(columns.windows.len(), 1);
+        assert_eq!(columns.windows[0].label, "7d");
     }
 
     #[test]
     fn named_additional_limits_render_as_separate_rows() {
         let mut account = rate_limited_account();
-        account.limits[0].h5_pct = None;
+        account.limits[0]
+            .windows
+            .retain(|window| window.label == "7d");
+        account.limits[0].availability_score = 20.0;
         account.limits.push(LimitStatus {
             name: "GPT-5.3-Codex-Spark".to_string(),
-            h5_pct: None,
-            d7_pct: Some(0.0),
-            h5_reset: "-".to_string(),
-            d7_reset: "in 6d 00h".to_string(),
+            windows: vec![WindowStatus {
+                key: WindowKey::Duration(7 * 24 * 60 * 60, 0),
+                label: "7d".to_string(),
+                used_pct: 0.0,
+                reset: "in 6d 00h".to_string(),
+            }],
+            availability_score: 0.0,
         });
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, columns);
+        let rows = render_rate_limited_rows(&account, &columns);
 
         assert!(columns.named_limits);
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().all(|row| row.len() == columns.headers().len()));
         assert_eq!(rows[1][1].content(), "GPT-5.3-Codex-Spark");
+    }
+
+    #[test]
+    fn server_declared_durations_drive_window_headers() {
+        let rate_limit: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 25, "window_minutes": 15},
+                "secondary_window": {"used_percent": 42, "window_minutes": 60}
+            }"#,
+        )
+        .unwrap();
+        let mut account = rate_limited_account();
+        account.limits = vec![LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            &rate_limit,
+        )];
+
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "15m",
+                "15m Reset",
+                "1h",
+                "1h Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+        assert_eq!(render_rate_limited_rows(&account, &columns)[0].len(), 7);
+    }
+
+    #[test]
+    fn equal_duration_windows_remain_separate() {
+        let rate_limit: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 25, "window_minutes": 60},
+                "secondary_window": {"used_percent": 42, "window_minutes": 60}
+            }"#,
+        )
+        .unwrap();
+        let mut account = rate_limited_account();
+        account.limits = vec![LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            &rate_limit,
+        )];
+
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+        let row = &render_rate_limited_rows(&account, &columns)[0];
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "1h",
+                "1h Reset",
+                "1h #2",
+                "1h #2 Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+        assert_eq!(row[1].content(), "25%");
+        assert_eq!(row[3].content(), "42%");
+    }
+
+    #[test]
+    fn durationless_legacy_windows_align_with_declared_fleet_columns() {
+        let declared: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 10, "window_minutes": 300},
+                "secondary_window": {"used_percent": 20, "window_minutes": 10080}
+            }"#,
+        )
+        .unwrap();
+        let legacy: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 30},
+                "secondary_window": {"used_percent": 40}
+            }"#,
+        )
+        .unwrap();
+        let mut declared_account = rate_limited_account();
+        declared_account.limits =
+            vec![LimitStatus::from_rate_limit("Codex".to_string(), &declared)];
+        let mut legacy_account = rate_limited_account();
+        legacy_account.alias = "legacy@sawmills.ai".to_string();
+        legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
+
+        let columns = RateLimitColumns::for_accounts(&[&declared_account, &legacy_account]);
+        let legacy_row = &render_rate_limited_rows(&legacy_account, &columns)[0];
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account", "5h", "5h Reset", "7d", "7d Reset", "Resets", "Token"
+            ]
+        );
+        assert_eq!(legacy_row[1].content(), "30%");
+        assert_eq!(legacy_row[3].content(), "40%");
+    }
+
+    #[test]
+    fn weekly_only_declared_window_does_not_absorb_legacy_primary() {
+        let declared: api::RateLimit = serde_json::from_str(
+            r#"{"primary_window": {"used_percent": 20, "window_minutes": 10080}}"#,
+        )
+        .unwrap();
+        let legacy: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 30},
+                "secondary_window": {"used_percent": 40}
+            }"#,
+        )
+        .unwrap();
+        let mut declared_account = rate_limited_account();
+        declared_account.limits =
+            vec![LimitStatus::from_rate_limit("Codex".to_string(), &declared)];
+        let mut legacy_account = rate_limited_account();
+        legacy_account.alias = "legacy@sawmills.ai".to_string();
+        legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
+
+        let columns = RateLimitColumns::for_accounts(&[&declared_account, &legacy_account]);
+        let legacy_row = &render_rate_limited_rows(&legacy_account, &columns)[0];
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "Primary",
+                "Primary Reset",
+                "7d",
+                "7d Reset",
+                "Secondary",
+                "Secondary Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+        assert_eq!(legacy_row[1].content(), "30%");
+        assert_eq!(legacy_row[5].content(), "40%");
+    }
+
+    #[test]
+    fn arbitrary_declared_pair_does_not_absorb_legacy_windows() {
+        let declared: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 10, "window_minutes": 15},
+                "secondary_window": {"used_percent": 20, "window_minutes": 60}
+            }"#,
+        )
+        .unwrap();
+        let legacy: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 30},
+                "secondary_window": {"used_percent": 40}
+            }"#,
+        )
+        .unwrap();
+        let mut declared_account = rate_limited_account();
+        declared_account.limits =
+            vec![LimitStatus::from_rate_limit("Codex".to_string(), &declared)];
+        let mut legacy_account = rate_limited_account();
+        legacy_account.alias = "legacy@sawmills.ai".to_string();
+        legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
+
+        let columns = RateLimitColumns::for_accounts(&[&declared_account, &legacy_account]);
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "Primary",
+                "Primary Reset",
+                "15m",
+                "15m Reset",
+                "1h",
+                "1h Reset",
+                "Secondary",
+                "Secondary Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+    }
+
+    #[test]
+    fn ambiguous_legacy_windows_do_not_alias_into_large_declared_fleet() {
+        let fast: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 10, "window_minutes": 15},
+                "secondary_window": {"used_percent": 20, "window_minutes": 60}
+            }"#,
+        )
+        .unwrap();
+        let standard: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 30, "window_minutes": 300},
+                "secondary_window": {"used_percent": 40, "window_minutes": 10080}
+            }"#,
+        )
+        .unwrap();
+        let legacy: api::RateLimit = serde_json::from_str(
+            r#"{
+                "primary_window": {"used_percent": 50},
+                "secondary_window": {"used_percent": 60}
+            }"#,
+        )
+        .unwrap();
+        let mut fast_account = rate_limited_account();
+        fast_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &fast)];
+        let mut standard_account = rate_limited_account();
+        standard_account.alias = "standard@sawmills.ai".to_string();
+        standard_account.limits =
+            vec![LimitStatus::from_rate_limit("Codex".to_string(), &standard)];
+        let mut legacy_account = rate_limited_account();
+        legacy_account.alias = "legacy@sawmills.ai".to_string();
+        legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
+
+        let columns =
+            RateLimitColumns::for_accounts(&[&fast_account, &standard_account, &legacy_account]);
+
+        assert_eq!(
+            columns.headers(),
+            vec![
+                "Account",
+                "Primary",
+                "Primary Reset",
+                "15m",
+                "15m Reset",
+                "1h",
+                "1h Reset",
+                "5h",
+                "5h Reset",
+                "7d",
+                "7d Reset",
+                "Secondary",
+                "Secondary Reset",
+                "Resets",
+                "Token",
+            ]
+        );
+    }
+
+    #[test]
+    fn durationless_secondary_only_window_keeps_its_slot_label() {
+        let rate_limit: api::RateLimit =
+            serde_json::from_str(r#"{"secondary_window": {"used_percent": 42}}"#).unwrap();
+        let mut account = rate_limited_account();
+        account.limits = vec![LimitStatus::from_rate_limit(
+            "Codex".to_string(),
+            &rate_limit,
+        )];
+
+        let columns = RateLimitColumns::for_accounts(&[&account]);
+
+        assert_eq!(
+            columns.headers(),
+            vec!["Account", "Secondary", "Secondary Reset", "Resets", "Token"]
+        );
     }
 
     #[test]

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -66,16 +66,51 @@ fn usage_summary(usage: &api::RateLimitResponse) -> String {
     let Some(rate_limit) = &usage.rate_limit else {
         return String::new();
     };
-    let mut windows = Vec::new();
-    if let Some(short) = rate_limit.short_window() {
-        windows.push(format!("5h: {:.0}%", short.used_percent));
-    }
-    if let Some(long) = rate_limit.long_window() {
-        windows.push(format!("7d: {:.0}%", long.used_percent));
-    }
+    let windows: Vec<_> = rate_limit
+        .windows()
+        .map(|(position, window)| {
+            let label = window.duration_label().unwrap_or_else(|| {
+                if position == 0 {
+                    "primary".to_string()
+                } else {
+                    "secondary".to_string()
+                }
+            });
+            format!("{label}: {:.0}%", window.used_percent)
+        })
+        .collect();
     if windows.is_empty() {
         String::new()
     } else {
         format!(" — {}", windows.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_summary_uses_declared_durations() {
+        let usage: api::RateLimitResponse = serde_json::from_str(
+            r#"{
+                "rate_limit": {
+                    "primary_window": {"used_percent": 25, "window_minutes": 15},
+                    "secondary_window": {"used_percent": 42, "window_minutes": 60}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(usage_summary(&usage), " — 15m: 25%, 1h: 42%");
+    }
+
+    #[test]
+    fn usage_summary_keeps_secondary_only_position() {
+        let usage: api::RateLimitResponse =
+            serde_json::from_str(r#"{"rate_limit": {"secondary_window": {"used_percent": 42}}}"#)
+                .unwrap();
+
+        assert_eq!(usage_summary(&usage), " — secondary: 42%");
     }
 }

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -585,27 +585,10 @@ fn rate_limit_score(usage: &api::RateLimitResponse) -> f64 {
     // General account selection uses the backward-compatible main Codex
     // bucket. Treating any model-specific additional bucket as account-wide
     // exhaustion would hide capacity that other models can still use.
-    let h5 = usage
+    usage
         .rate_limit
         .as_ref()
-        .and_then(|r| r.short_window())
-        .map(|w| w.used_percent)
-        .unwrap_or(0.0);
-    let d7 = usage
-        .rate_limit
-        .as_ref()
-        .and_then(|r| r.long_window())
-        .map(|w| w.used_percent)
-        .unwrap_or(0.0);
-    if h5 >= 100.0 && d7 >= 100.0 {
-        900.0
-    } else if d7 >= 100.0 {
-        700.0 + h5
-    } else if h5 >= 100.0 {
-        500.0 + d7
-    } else {
-        h5 * 2.0 + d7
-    }
+        .map_or(0.0, api::RateLimit::availability_score)
 }
 
 fn selection_bills_credits(usage: &api::RateLimitResponse) -> bool {

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -293,6 +293,27 @@ fn partial_duration_metadata_does_not_override_declared_weekly_window() {
             .and_then(|window| window.duration_seconds()),
         Some(604800)
     );
+    assert_eq!(rate_limit.availability_score(), 700.0);
+}
+
+#[test]
+fn durationless_exhausted_window_always_makes_account_unavailable() {
+    let response: RateLimitResponse = serde_json::from_str(
+        r#"{
+            "plan_type": "pro",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 20,
+                    "limit_window_seconds": 604800
+                },
+                "secondary_window": {"used_percent": 100}
+            }
+        }"#,
+    )
+    .unwrap();
+    let rate_limit = response.rate_limit.unwrap();
+
+    assert_eq!(rate_limit.availability_score(), 500.0);
 }
 
 #[test]

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -241,6 +241,121 @@ fn parse_rate_limit_response_weekly_only_maps_to_long_window() {
 }
 
 #[test]
+fn parse_two_subday_windows_uses_declared_duration_order() {
+    let json = r#"{
+        "plan_type": "pro",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 42,
+                "window_minutes": 60
+            },
+            "secondary_window": {
+                "used_percent": 25,
+                "window_minutes": 15
+            }
+        }
+    }"#;
+    let response: RateLimitResponse = serde_json::from_str(json).unwrap();
+    let rate_limit = response.rate_limit.unwrap();
+
+    let short = rate_limit.short_window().unwrap();
+    assert_eq!(short.duration_seconds(), Some(15 * 60));
+    assert_eq!(short.duration_label().as_deref(), Some("15m"));
+
+    let long = rate_limit.long_window().unwrap();
+    assert_eq!(long.duration_seconds(), Some(60 * 60));
+    assert_eq!(long.duration_label().as_deref(), Some("1h"));
+
+    assert_eq!(rate_limit.windows().count(), 2);
+}
+
+#[test]
+fn partial_duration_metadata_does_not_override_declared_weekly_window() {
+    let response: RateLimitResponse = serde_json::from_str(
+        r#"{
+            "plan_type": "pro",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 100,
+                    "limit_window_seconds": 604800
+                },
+                "secondary_window": {"used_percent": 0}
+            }
+        }"#,
+    )
+    .unwrap();
+    let rate_limit = response.rate_limit.unwrap();
+
+    assert!(rate_limit.short_window().is_none());
+    assert_eq!(
+        rate_limit
+            .long_window()
+            .and_then(|window| window.duration_seconds()),
+        Some(604800)
+    );
+}
+
+#[test]
+fn durationless_secondary_remains_long_when_primary_declares_short_duration() {
+    let response: RateLimitResponse = serde_json::from_str(
+        r#"{
+            "plan_type": "pro",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 40,
+                    "window_minutes": 300
+                },
+                "secondary_window": {"used_percent": 100}
+            }
+        }"#,
+    )
+    .unwrap();
+    let rate_limit = response.rate_limit.unwrap();
+
+    assert_eq!(
+        rate_limit.short_window().map(|window| window.used_percent),
+        Some(40.0)
+    );
+    assert_eq!(
+        rate_limit.long_window().map(|window| window.used_percent),
+        Some(100.0)
+    );
+    assert_eq!(rate_limit.availability_score(), 740.0);
+}
+
+#[test]
+fn durationless_secondary_only_window_stays_long_term() {
+    let response: RateLimitResponse = serde_json::from_str(
+        r#"{
+            "plan_type": "pro",
+            "rate_limit": {
+                "secondary_window": {
+                    "used_percent": 100,
+                    "reset_at": 1785453503
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    let rate_limit = response.rate_limit.unwrap();
+
+    assert!(rate_limit.short_window().is_none());
+    assert_eq!(
+        rate_limit
+            .long_window()
+            .and_then(|window| window.reset_timestamp()),
+        Some(1785453503)
+    );
+    assert_eq!(
+        rate_limit
+            .windows()
+            .map(|(position, _)| position)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[test]
 fn parse_rate_limit_reset_credits() {
     let json = r#"{
         "plan_type": "pro",


### PR DESCRIPTION
## Summary
- render every server-declared rate-limit duration instead of hard-coding 5h and 7d
- preserve legacy primary and secondary slots only when duration metadata is absent
- use the same duration-aware availability score for status and account selection
- document current subscription and credit behavior from the official Codex docs
- release the fix as v0.1.18

## Architecture review
- consulted Claude Opus on the duration model and fallback rules
- fixed partial metadata, secondary-only, equal-duration, mixed-fleet, and ambiguous legacy-window cases found during review
- local autoreview passed on the exact branch diff

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test (195 tests)
- cargo run --quiet -- --help
- cargo run --quiet -- --version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render server-declared rate-limit windows in `codexctl`, replacing the fixed 5h/7d model and handling ambiguous or durationless metadata to prevent empty columns and mislabels. Status sorting and auto-selection now use the same duration-aware availability score. Addresses SAW-9895. Released v0.1.18.

- **New Features**
  - Columns come from server-declared durations (e.g., 15m, 1h, 5h, 7d); equal durations get “#2”; durationless slots fall back to Primary/Secondary.
  - Safe aliasing: legacy Primary/Secondary only map to 5h/7d when all accounts are consistent; otherwise they remain separate.
  - CLI summaries and status labels use compact duration strings; README documents the live multi-bucket contract.

- **Bug Fixes**
  - No invented 5h columns when only weekly limits are returned; weekly-only declared windows do not absorb legacy primaries.
  - Correct handling for partial metadata, secondary-only, equal-duration pairs, mixed fleets, ambiguous legacy windows, and error rows not altering visible columns; added focused tests for parsing, alignment, and scoring.

<sup>Written for commit a14b44b472bb5750d0080aec14a29a7611df01f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate-limit displays now adapt to server-provided windows and durations, including minutes, hours, and days.
  * Status and profile views support custom, duplicate, and durationless rate-limit windows with consistent labels and alignment.
  * Added clearer duration labels and improved availability scoring across all reported windows.

* **Bug Fixes**
  * Improved handling of unusual or incomplete rate-limit data, including secondary-only windows.

* **Documentation**
  * Clarified how rate-limit windows and displayed columns are determined, with additional examples and reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->