### PR TITLE
SAW-9895 Group account limits and remove use billing prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Rate-Limited Accounts
 │ Account              ┆ Limit                 ┆ 7d  ┆ 7d Reset                     ┆ Resets ┆ Token  │
 ╞══════════════════════╪═══════════════════════╪═════╪══════════════════════════════╪════════╪════════╡
 │ * amir@sawmills.ai   ┆ Codex                 ┆ 13% ┆ in 6d 23h (Fri Aug 07 15:31) ┆ -      ┆ 4d 19h │
-│ * amir@sawmills.ai   ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆ -      ┆ -      │
+│                      ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆        ┆        │
 │ amir+2@sawmills.ai   ┆ Codex                 ┆ 100%┆ in 6d 17h (Fri Aug 07 09:29) ┆ 1      ┆ 4d 19h │
-│ amir+2@sawmills.ai   ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆ -      ┆ -      │
+│                      ┆ GPT-5.3-Codex-Spark  ┆ 0%  ┆ in 6d 23h (Fri Aug 07 16:28) ┆        ┆        │
 └──────────────────────┴───────────────────────┴─────┴──────────────────────────────┴────────┴────────┘
 
 Usage-Based Accounts
@@ -68,8 +68,9 @@ The account column is the saved profile alias, with `*` marking the active accou
 
 Rate-limit windows are matched and labeled by their server-declared duration. For example, the
 table can show `15m`, `1h`, `5h`, or `7d` columns. A column appears only when at least one returned
-bucket contains that duration. Named model or feature buckets appear as separate rows. `codexctl`
-does not invent a 5-hour window when the service returns only a weekly window.
+bucket contains that duration. Each account has one table row. Named model or feature buckets use
+aligned lines inside that row. `codexctl` does not invent a 5-hour window when the service returns
+only a weekly window.
 
 OpenAI's current [subscription documentation](https://learn.chatgpt.com/docs/pricing) describes one
 shared agentic usage and credit pool, with plan and model-specific allowances. It does not promise
@@ -204,14 +205,17 @@ ladder, cheapest option first:
 2. A banked reset whose credit would **expire before its window resets anyway** — redeemed without
    prompting, since holding it back cannot pay off.
 3. A banked reset worth keeping — asks for confirmation, or pass `--allow-resets`.
-4. A credit-billing account — asks for confirmation, or pass `--allow-billing`.
+4. A credit-billing account.
 
-Resets rank ahead of credit-billing accounts because they cost no money. `--allow-billing` does
-**not** imply permission to spend resets; each is approved separately.
+Resets rank ahead of credit-billing accounts because they cost no money. `codexctl use` warns when
+the selected account can use paid credits, then continues without confirmation. It still asks
+before it redeems a banked reset. The `codexctl codex` active-session recovery path keeps the
+stronger billing confirmation because that path can resume work and spend credits immediately.
+Its `--allow-billing` flag does **not** imply permission to spend resets; each is approved
+separately.
 
 ```bash
 codexctl use --allow-resets                                       # unattended: may spend resets
-codexctl use --allow-billing                                      # unattended: may spend credits
 codexctl codex --allow-resets -- "start prompt"
 codexctl codex --allow-resets --allow-billing -- "start prompt"   # ...and may spend credits
 ```

--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ codexctl codex --allow-resets -- "start prompt"
 codexctl codex --allow-resets --allow-billing -- "start prompt"   # ...and may spend credits
 ```
 
-So when every account is exhausted, `codexctl use` redeems a reset and hands back an account that
-actually works, instead of a seat sitting at 100%. Passing an explicit alias never redeems — use
-`codexctl reset <alias>` to spend a credit on a named account.
+So when every account is exhausted, `codexctl use` redeems a reset only after confirmation, with
+`--allow-resets`, or when the reset would otherwise lapse before the natural window reset. It then
+hands back an account that works instead of a seat at 100%. Passing an explicit alias never
+redeems — use `codexctl reset <alias>` to spend a credit on a named account.
 
 ### Other commands
 

--- a/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
+++ b/docs/superpowers/specs/2026-04-11-status-usage-based-accounts-design.md
@@ -12,8 +12,9 @@ Split the status output into two tables, one per billing model. Each table has c
 
 Shown when at least one rate-limited account exists. Window columns are adaptive. A 5-hour or
 7-day pair appears only when the API returns a window in that duration class. The `Limit` column
-appears when the response includes additional named model or feature buckets. Each bucket gets a
-separate row.
+appears when the response includes additional named model or feature buckets. Each account gets one
+table row. Multiple buckets use aligned lines within the `Limit`, usage, and reset cells. Account
+level reset-credit and token data appears once.
 
 ```
 Rate-Limited Accounts

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -290,9 +290,7 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
     let columns = RateLimitColumns::for_accounts(accounts);
     table.set_header(columns.headers());
     for account in accounts {
-        for row in render_rate_limited_rows(account, &columns) {
-            table.add_row(row);
-        }
+        table.add_row(render_rate_limited_row(account, &columns));
     }
     println!("{table}");
     true
@@ -718,10 +716,7 @@ fn rate_limit_statuses(usage: &api::RateLimitResponse) -> Vec<LimitStatus> {
     limits
 }
 
-fn render_rate_limited_rows(
-    account: &RateLimitedAccount,
-    columns: &RateLimitColumns,
-) -> Vec<Vec<Cell>> {
+fn render_rate_limited_row(account: &RateLimitedAccount, columns: &RateLimitColumns) -> Vec<Cell> {
     if account.is_error {
         let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
         if columns.named_limits {
@@ -732,37 +727,48 @@ fn render_rate_limited_rows(
         }
         row.push(Cell::new("-"));
         row.push(token_cell(account.token_expiry, true, &account.error_msg));
-        return vec![row];
+        return row;
     }
 
-    account
-        .limits
-        .iter()
-        .enumerate()
-        .map(|(index, limit)| {
-            let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
-            if columns.named_limits {
-                row.push(Cell::new(&limit.name));
-            }
-            for column in &columns.windows {
-                let window = limit
+    let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
+    if columns.named_limits {
+        row.push(Cell::new(
+            account
+                .limits
+                .iter()
+                .map(|limit| limit.name.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ));
+    }
+    for column in &columns.windows {
+        let windows: Vec<_> = account
+            .limits
+            .iter()
+            .map(|limit| {
+                limit
                     .windows
                     .iter()
-                    .find(|window| column.keys.contains(&window.key));
-                row.push(colorize_usage(window.map(|window| window.used_pct)));
-                row.push(Cell::new(
-                    window.map_or("-", |window| window.reset.as_str()),
-                ));
-            }
-            if index == 0 {
-                row.push(resets_cell(account));
-                row.push(token_cell(account.token_expiry, false, &account.error_msg));
-            } else {
-                row.extend([Cell::new("-"), Cell::new("-")]);
-            }
-            row
-        })
-        .collect()
+                    .find(|window| column.keys.contains(&window.key))
+            })
+            .collect();
+        row.push(colorize_usage_lines(
+            &windows
+                .iter()
+                .map(|window| window.map(|window| window.used_pct))
+                .collect::<Vec<_>>(),
+        ));
+        row.push(Cell::new(
+            windows
+                .iter()
+                .map(|window| window.map_or("-", |window| window.reset.as_str()))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ));
+    }
+    row.push(resets_cell(account));
+    row.push(token_cell(account.token_expiry, false, &account.error_msg));
+    row
 }
 
 /// The "Resets" column: banked rate-limit resets, and how many of them can be
@@ -927,9 +933,14 @@ fn format_duration(secs: i64) -> String {
     }
 }
 
-fn colorize_usage(used_percent: Option<f64>) -> Cell {
-    let Some(pct) = used_percent else {
-        return Cell::new("-");
+fn colorize_usage_lines(used_percent: &[Option<f64>]) -> Cell {
+    let content = used_percent
+        .iter()
+        .map(|pct| pct.map_or_else(|| "-".to_string(), |pct| format!("{pct:.0}%")))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let Some(pct) = used_percent.iter().flatten().copied().reduce(f64::max) else {
+        return Cell::new(content);
     };
     let color = if pct >= 80.0 {
         Color::Red
@@ -938,7 +949,7 @@ fn colorize_usage(used_percent: Option<f64>) -> Cell {
     } else {
         Color::Green
     };
-    Cell::new(format!("{pct:.0}%")).fg(color)
+    Cell::new(content).fg(color)
 }
 
 #[cfg(test)]
@@ -996,10 +1007,9 @@ mod tests {
     fn render_rate_limited_row_has_expected_column_count() {
         let account = rate_limited_account();
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, &columns);
+        let row = render_rate_limited_row(&account, &columns);
         assert_eq!(columns.headers().len(), 7);
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].len(), 7);
+        assert_eq!(row.len(), 7);
     }
 
     /// The error row must line up with the normal row or the table breaks.
@@ -1012,9 +1022,8 @@ mod tests {
         };
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, &columns);
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].len(), columns.headers().len());
+        let row = render_rate_limited_row(&account, &columns);
+        assert_eq!(row.len(), columns.headers().len());
     }
 
     #[test]
@@ -1031,7 +1040,7 @@ mod tests {
             columns.headers(),
             vec!["Account", "7d", "7d Reset", "Resets", "Token"]
         );
-        assert_eq!(render_rate_limited_rows(&account, &columns)[0].len(), 5);
+        assert_eq!(render_rate_limited_row(&account, &columns).len(), 5);
     }
 
     #[test]
@@ -1062,7 +1071,7 @@ mod tests {
     }
 
     #[test]
-    fn named_additional_limits_render_as_separate_rows() {
+    fn named_additional_limits_render_in_one_account_row() {
         let mut account = rate_limited_account();
         account.limits[0]
             .windows
@@ -1080,12 +1089,14 @@ mod tests {
         });
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let rows = render_rate_limited_rows(&account, &columns);
+        let row = render_rate_limited_row(&account, &columns);
 
         assert!(columns.named_limits);
-        assert_eq!(rows.len(), 2);
-        assert!(rows.iter().all(|row| row.len() == columns.headers().len()));
-        assert_eq!(rows[1][1].content(), "GPT-5.3-Codex-Spark");
+        assert_eq!(row.len(), columns.headers().len());
+        assert_eq!(row[0].content(), "amir+8@sawmills.ai");
+        assert_eq!(row[1].content(), "Codex\nGPT-5.3-Codex-Spark");
+        assert_eq!(row[2].content(), "20%\n0%");
+        assert_eq!(row[3].content(), "in 1d 00h\nin 6d 00h");
     }
 
     #[test]
@@ -1117,7 +1128,7 @@ mod tests {
                 "Token",
             ]
         );
-        assert_eq!(render_rate_limited_rows(&account, &columns)[0].len(), 7);
+        assert_eq!(render_rate_limited_row(&account, &columns).len(), 7);
     }
 
     #[test]
@@ -1136,7 +1147,7 @@ mod tests {
         )];
 
         let columns = RateLimitColumns::for_accounts(&[&account]);
-        let row = &render_rate_limited_rows(&account, &columns)[0];
+        let row = render_rate_limited_row(&account, &columns);
 
         assert_eq!(
             columns.headers(),
@@ -1178,7 +1189,7 @@ mod tests {
         legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
 
         let columns = RateLimitColumns::for_accounts(&[&declared_account, &legacy_account]);
-        let legacy_row = &render_rate_limited_rows(&legacy_account, &columns)[0];
+        let legacy_row = render_rate_limited_row(&legacy_account, &columns);
 
         assert_eq!(
             columns.headers(),
@@ -1229,7 +1240,7 @@ mod tests {
             &conflicting_account,
             &secondary_account,
         ]);
-        let secondary_row = &render_rate_limited_rows(&secondary_account, &columns)[0];
+        let secondary_row = render_rate_limited_row(&secondary_account, &columns);
 
         assert_eq!(
             columns.headers(),
@@ -1269,7 +1280,7 @@ mod tests {
         legacy_account.limits = vec![LimitStatus::from_rate_limit("Codex".to_string(), &legacy)];
 
         let columns = RateLimitColumns::for_accounts(&[&declared_account, &legacy_account]);
-        let legacy_row = &render_rate_limited_rows(&legacy_account, &columns)[0];
+        let legacy_row = render_rate_limited_row(&legacy_account, &columns);
 
         assert_eq!(
             columns.headers(),
@@ -1410,7 +1421,7 @@ mod tests {
 
     #[test]
     fn unavailable_usage_is_not_colored_green() {
-        let cell = colorize_usage(None);
+        let cell = colorize_usage_lines(&[None]);
         assert_eq!(cell.content(), "-");
     }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -939,6 +939,11 @@ fn colorize_usage_lines(used_percent: &[Option<f64>]) -> Cell {
         .map(|pct| pct.map_or_else(|| "-".to_string(), |pct| format!("{pct:.0}%")))
         .collect::<Vec<_>>()
         .join("\n");
+    // A comfy-table cell has one foreground color. Leave multi-bucket cells
+    // uncolored so a severe bucket does not falsely color a healthy one.
+    if used_percent.len() != 1 {
+        return Cell::new(content);
+    }
     let Some(pct) = used_percent.iter().flatten().copied().reduce(f64::max) else {
         return Cell::new(content);
     };
@@ -1422,7 +1427,14 @@ mod tests {
     #[test]
     fn unavailable_usage_is_not_colored_green() {
         let cell = colorize_usage_lines(&[None]);
-        assert_eq!(cell.content(), "-");
+        assert_eq!(cell, Cell::new("-"));
+    }
+
+    #[test]
+    fn mixed_severity_bucket_lines_do_not_share_one_color() {
+        let cell = colorize_usage_lines(&[Some(100.0), Some(0.0)]);
+
+        assert_eq!(cell, Cell::new("100%\n0%"));
     }
 
     #[test]

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::io::{BufRead, IsTerminal, Write};
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Result, bail};
@@ -15,29 +15,18 @@ use crate::profile;
 /// 100% — i.e. the account has no usable headroom right now.
 const RATE_LIMIT_EXHAUSTED: f64 = 500.0;
 
-pub fn run(alias: Option<&str>, allow_billing: bool, allow_resets: bool) -> Result<()> {
-    run_to_auth_json(
-        alias,
-        &config::codex_auth_json()?,
-        allow_billing,
-        allow_resets,
-    )
+pub fn run(alias: Option<&str>, _allow_billing: bool, allow_resets: bool) -> Result<()> {
+    run_to_auth_json(alias, &config::codex_auth_json()?, allow_resets)
 }
 
-pub fn run_to_auth_json(
-    alias: Option<&str>,
-    auth_json: &Path,
-    allow_billing: bool,
-    allow_resets: bool,
-) -> Result<()> {
-    run_to_auth_json_excluding(alias, auth_json, None, allow_billing, allow_resets)
+pub fn run_to_auth_json(alias: Option<&str>, auth_json: &Path, allow_resets: bool) -> Result<()> {
+    run_to_auth_json_excluding(alias, auth_json, None, allow_resets)
 }
 
 pub fn run_to_auth_json_excluding(
     alias: Option<&str>,
     auth_json: &Path,
     excluded_alias: Option<&str>,
-    allow_billing: bool,
     allow_resets: bool,
 ) -> Result<()> {
     match alias::optional(alias)? {
@@ -51,7 +40,7 @@ pub fn run_to_auth_json_excluding(
             status::run_focused(a)?;
         }
         None => {
-            let best = find_most_available_excluding(excluded_alias, allow_billing, allow_resets)?;
+            let best = find_most_available_excluding(excluded_alias, allow_resets)?;
             let email = profile::switch_to_auth_json(&best, auth_json)?;
             println!("auto-selected most available: {} ({})", best, email);
             println!();
@@ -63,7 +52,6 @@ pub fn run_to_auth_json_excluding(
 
 fn find_most_available_excluding(
     excluded_alias: Option<&str>,
-    allow_billing: bool,
     allow_resets: bool,
 ) -> Result<String> {
     let all_profiles = profile::list_profiles()?;
@@ -93,13 +81,13 @@ fn find_most_available_excluding(
         .collect();
 
     // Prefer existing headroom before spending a banked reset. A seat that can
-    // bill after its hard window still requires separate billing consent.
+    // bill after its hard window produces a warning before selection.
     if let Some(alias) = select_with_headroom(&scored, reset_aware()) {
         let candidate = scored
             .iter()
             .find(|candidate| candidate.alias == alias)
             .expect("selected candidate must exist");
-        require_billing_approval(candidate, allow_billing)?;
+        notify_billing_account(&candidate.alias, candidate.bills_credits);
         return Ok(alias.to_string());
     }
 
@@ -109,7 +97,7 @@ fn find_most_available_excluding(
     if let Some(candidate) = best_candidate_from_usages(usages)?
         && let Some(plan) = candidate.reset_plan()
     {
-        require_recovery_billing_approval(&candidate, allow_billing)?;
+        notify_billing_account(&candidate.alias, candidate.bills_credits);
         if !resets::approve_redemption(
             &candidate.alias,
             plan.expires_at,
@@ -144,79 +132,24 @@ fn find_most_available_excluding(
                 .iter()
                 .find(|candidate| candidate.alias == alias)
                 .expect("selected candidate must exist");
-            require_billing_approval(candidate, allow_billing)?;
+            notify_billing_account(&candidate.alias, candidate.bills_credits);
             Ok(alias.to_string())
         }
         None => bail!("no usable accounts found (all expired or errored)"),
     }
 }
 
-fn require_billing_approval(candidate: &SelectionCandidate, allow_billing: bool) -> Result<()> {
-    if !candidate.bills_credits || approve_billing_account(&candidate.alias, allow_billing) {
-        return Ok(());
-    }
-    bail!(
-        "switching to {} may use credits and was not approved",
-        candidate.alias
-    )
+fn notify_billing_account(alias: &str, bills_credits: bool) {
+    notify_billing_account_to(alias, bills_credits, &mut std::io::stderr());
 }
 
-fn require_recovery_billing_approval(
-    candidate: &RecoveryCandidate,
-    allow_billing: bool,
-) -> Result<()> {
-    if !candidate.bills_credits || approve_billing_account(&candidate.alias, allow_billing) {
-        return Ok(());
-    }
-    bail!(
-        "switching to {} may use credits and was not approved",
-        candidate.alias
-    )
-}
-
-fn approve_billing_account(alias: &str, allow_billing: bool) -> bool {
-    let stdin = std::io::stdin();
-    let mut input = stdin.lock();
-    approve_billing_account_from(
-        alias,
-        allow_billing,
-        stdin.is_terminal(),
-        &mut input,
-        &mut std::io::stderr(),
-    )
-}
-
-fn approve_billing_account_from(
-    alias: &str,
-    allow_billing: bool,
-    is_terminal: bool,
-    input: &mut impl BufRead,
-    output: &mut impl Write,
-) -> bool {
-    if allow_billing {
+fn notify_billing_account_to(alias: &str, bills_credits: bool, output: &mut impl Write) {
+    if bills_credits {
         let _ = writeln!(
             output,
-            "codexctl: --allow-billing set; switching to {alias} (may use credits)"
+            "codexctl: {alias} can use paid credits after its included usage; no billing confirmation is required"
         );
-        return true;
     }
-    if !is_terminal {
-        let _ = writeln!(
-            output,
-            "codexctl: not switching to {alias} (no terminal to approve credit billing; pass --allow-billing to allow)"
-        );
-        return false;
-    }
-    let _ = write!(
-        output,
-        "codexctl: switch to {alias} and allow it to use credits? [y/N] "
-    );
-    let _ = output.flush();
-    let mut line = String::new();
-    if input.read_line(&mut line).is_err() {
-        return false;
-    }
-    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 /// Whether selection prefers the soonest-resetting eligible account.
@@ -1094,30 +1027,22 @@ mod tests {
     }
 
     #[test]
-    fn billing_approval_requires_a_flag_or_interactive_yes() {
-        for answer in ["y\n", "yes\n"] {
-            assert!(approve_billing_account_from(
-                "billing",
-                false,
-                true,
-                &mut answer.as_bytes(),
-                &mut Vec::new(),
-            ));
-        }
-        assert!(!approve_billing_account_from(
-            "billing",
-            false,
-            false,
-            &mut "yes\n".as_bytes(),
-            &mut Vec::new(),
-        ));
-        assert!(approve_billing_account_from(
-            "billing",
-            true,
-            false,
-            &mut "".as_bytes(),
-            &mut Vec::new(),
-        ));
+    fn billing_selection_warns_and_does_not_ask_for_permission() {
+        let mut output = Vec::new();
+        notify_billing_account_to("billing", true, &mut output);
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "codexctl: billing can use paid credits after its included usage; no billing confirmation is required\n"
+        );
+    }
+
+    #[test]
+    fn no_bill_selection_does_not_warn() {
+        let mut output = Vec::new();
+        notify_billing_account_to("no-bill", false, &mut output);
+
+        assert!(output.is_empty());
     }
 
     #[test]

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -97,7 +97,6 @@ fn find_most_available_excluding(
     if let Some(candidate) = best_candidate_from_usages(usages)?
         && let Some(plan) = candidate.reset_plan()
     {
-        notify_billing_account(&candidate.alias, candidate.bills_credits);
         if !resets::approve_redemption(
             &candidate.alias,
             plan.expires_at,
@@ -110,6 +109,9 @@ fn find_most_available_excluding(
                 candidate.alias
             );
         }
+        // Warn only after reset approval makes the switch actionable, but
+        // before redeeming the scarce reset.
+        notify_billing_account(&candidate.alias, candidate.bills_credits);
         let response = resets::redeem(&candidate.alias, plan.credit_id.as_deref())?;
         resets::report_outcome(&candidate.alias, &response);
         if response.code != api::ConsumeResetCode::Reset {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,9 @@ enum Commands {
     Use {
         /// Profile alias to switch to (auto-selects most available if omitted)
         alias: Option<String>,
-        /// Allow automatic selection of a credit-billing account without
-        /// prompting (use for unattended runs; it may spend credits)
-        #[arg(long)]
+        /// Deprecated compatibility flag. Automatic selection now warns and
+        /// continues without prompting.
+        #[arg(long, hide = true)]
         allow_billing: bool,
         /// When auto-selecting and no account has headroom left, redeem a
         /// banked reset without prompting (resets are scarce and expire)

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -41,12 +41,19 @@ fn codex_has_independent_reset_and_billing_flags() {
 }
 
 #[test]
-fn use_has_independent_reset_and_billing_flags() {
+fn use_keeps_reset_approval_but_hides_obsolete_billing_approval() {
     let mut cmd = Command::cargo_bin("codexctl").unwrap();
     let output = cmd.args(["use", "--help"]).output().unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("--allow-billing"));
     assert!(stdout.contains("--allow-resets"));
+    assert!(!stdout.contains("--allow-billing"));
+
+    let mut compatibility_cmd = Command::cargo_bin("codexctl").unwrap();
+    let output = compatibility_cmd
+        .args(["use", "--allow-billing", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
 }
 
 /// Installed builds need to be able to report their own version, so an upgrade


### PR DESCRIPTION
## Summary
- render one logical status row per account with aligned multi-bucket cells
- warn and continue when codexctl use selects a billing-capable subscription account
- preserve codex recovery billing consent and independent reset approval
- update current subscription and multi-bucket documentation

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo run -- --help
- local autoreview clean
- exact branch autoreview clean
- live status and non-interactive use proof

Linear: https://linear.app/sawmills/issue/SAW-9895

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups rate-limit status into one row per account with aligned multi-bucket cells and safer usage coloring. Updates `codexctl use` to warn (not prompt) on billing-capable accounts while keeping reset approval; docs clarify reset-approval timing; bumps `codexctl` to 0.1.19. Addresses Linear SAW-9895.

- **New Features**
  - Status: one row per account; named model/feature buckets render as aligned multi-line cells; multi-bucket usage cells are uncolored to avoid mixed severity; single-bucket usage keeps color; error rows align; docs/specs updated.
  - `use`: auto-selection warns to stderr when the chosen account can use paid credits and continues without confirmation; still asks before redeeming a banked reset and warns first; docs clarify when resets auto-redeem if they would lapse; `--allow-billing` is hidden and kept for compatibility; the `codex` recovery path still requires explicit billing approval.
  - Version: `codexctl` -> `0.1.19`.

- **Migration**
  - No action needed. Scripts passing `--allow-billing` to `use` still work but the flag no longer affects selection; keep using `--allow-resets` if unattended reset redemption is desired.

<sup>Written for commit bbce7f89f1e9dab3a6b4c338c882cf7adc968b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved status output by grouping each account into a single row, with multiple usage limits shown on aligned lines.
  * Added clearer usage coloring across all displayed time windows.
  * Documented reset-aware recovery and account selection behavior.

* **Bug Fixes**
  * The `use` command now warns about billing-capable selections without prompting or failing.
  * Preserved compatibility for the deprecated `--allow-billing` option.

* **Chores**
  * Updated the package version to 0.1.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->