### PR TITLE
SAW-10105 profile: tell apart two accounts that share one email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `codexctl` is a Rust 2024 CLI for managing multiple OpenAI Codex CLI accounts.
 - It saves profiles, switches accounts, reports rate limits, manages banked resets, and launches Codex with account recovery.
-- The package version is `0.1.16`.
+- The package version is `0.1.20`.
 - The license is Apache-2.0.
 
 ## Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `codexctl` is a Rust 2024 CLI for managing multiple OpenAI Codex CLI accounts.
 - It saves profiles, switches accounts, reports rate limits, manages banked resets, and launches Codex with account recovery.
-- The package version is `0.1.20`.
+- The package version is `0.1.21`.
 - The license is Apache-2.0.
 
 ## Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@
 - Refuse `codexctl exec` when `CODEX_HOME` is already set. A pinned launch must not replace an inherited Codex home without saying so.
 - Identify an account by its workspace and its login together. Neither identifies it alone: a workspace holds many logins, and a login holds seats in many workspaces.
 - Read a profile's identity from its stored token first and its metadata second, and keep what has been proven when a captured file omits it.
-- Require positive agreement before `login` or `save` replaces stored credentials. "Cannot confirm" is not "yes". The one exception is a profile with no readable token and no recorded account, which is what a repair re-login is for.
+- Require positive agreement before `login` or `save` replaces stored credentials. "Cannot confirm" is not "yes".
+- Separate a conflict that is proven from one that is merely unprovable. Refuse claims that positively disagree; no flag may override that. Where neither side declares enough to compare, ask the operator: prompt on a terminal, refuse without one unless `--allow-adopt` is set.
+- Do not make `remove` the only remedy for a profile the store cannot identify. Deleting the evidence and replacing it unchecked is weaker than the replacement it guards.
 - Capture a token back to the alias the caller named. Fall back to token inspection only when the file does not belong to that alias.
 - Let an exact access token decide ownership on its own; anything rotated needs the claims to agree. Resolve undecidable ownership to no owner rather than a guess.
 - Pass the pinned alias to children in `CODEXCTL_PINNED_ALIAS`. Recovery must exclude the account a pinned launch already selected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
 - Keep `codexctl exec` non-mutating. It must never write `~/.codex/auth.json` or the active marker.
 - Refuse `codexctl exec` when `CODEX_HOME` is already set. A pinned launch must not replace an inherited Codex home without saying so.
 - Identify an account by its workspace and its login together. Neither identifies it alone: a workspace holds many logins, and a login holds seats in many workspaces.
+- Keep every login claim a token makes. A token gaining `chatgpt_user_id` is the ordinary legacy-to-current transition, and collapsing to one preferred claim makes the same seat look like two people.
+- Compare logins only inside one namespace. `uid:` and `sub:` are unrelated facts, so they must never match by coincidence and never prove a difference either.
 - Read a profile's identity from its stored token first and its metadata second, and keep what has been proven when a captured file omits it.
 - Require positive agreement before `login` or `save` replaces stored credentials. "Cannot confirm" is not "yes".
 - Separate a conflict that is proven from one that is merely unprovable. Refuse claims that positively disagree; no flag may override that. Where neither side declares enough to compare, ask the operator: prompt on a terminal, refuse without one unless `--allow-adopt` is set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Compare logins only inside one namespace. `uid:` and `sub:` are unrelated facts, so they must never match by coincidence and never prove a difference either.
 - Read a profile's identity from its stored token first and its metadata second, and keep what has been proven when a captured file omits it.
 - Require positive agreement before `login` or `save` replaces stored credentials. "Cannot confirm" is not "yes".
+- Treat silence from an unreadable profile as absence of evidence, never as a matching claim. Two sides declaring nothing agree only when both can actually be read.
 - Separate a conflict that is proven from one that is merely unprovable. Refuse claims that positively disagree; no flag may override that. Where neither side declares enough to compare, ask the operator: prompt on a terminal, refuse without one unless `--allow-adopt` is set.
 - Do not make `remove` the only remedy for a profile the store cannot identify. Deleting the evidence and replacing it unchecked is weaker than the replacement it guards.
 - Capture a token back to the alias the caller named. Fall back to token inspection only when the file does not belong to that alias.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,11 @@
 - Keep `codexctl use` as a local auth-file swap that does not contact OpenAI.
 - Keep `codexctl exec` non-mutating. It must never write `~/.codex/auth.json` or the active marker.
 - Refuse `codexctl exec` when `CODEX_HOME` is already set. A pinned launch must not replace an inherited Codex home without saying so.
+- Identify an account by its workspace and its login together. Neither identifies it alone: a workspace holds many logins, and a login holds seats in many workspaces.
+- Read a profile's identity from its stored token first and its metadata second, and keep what has been proven when a captured file omits it.
+- Require positive agreement before `login` or `save` replaces stored credentials. "Cannot confirm" is not "yes". The one exception is a profile with no readable token and no recorded account, which is what a repair re-login is for.
 - Capture a token back to the alias the caller named. Fall back to token inspection only when the file does not belong to that alias.
+- Let an exact access token decide ownership on its own; anything rotated needs the claims to agree. Resolve undecidable ownership to no owner rather than a guess.
 - Pass the pinned alias to children in `CODEXCTL_PINNED_ALIAS`. Recovery must exclude the account a pinned launch already selected.
 - Order captured tokens by issued-at and fall back to expiry. Never overwrite a saved token with an older copy of the same seat.
 - Pin a launch with `CODEX_HOME=~/.codexctl/exec-homes/<alias>`. Seed `auth.json` as a real file and share every other `~/.codex` entry by symbolic link. Never replace an entry that already exists, so an entry Codex turned into a real file stays as it left it until the home is deleted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"

--- a/README.md
+++ b/README.md
@@ -249,6 +249,20 @@ codexctl login --label personal amir-personal
 codexctl login --label team     amir-team
 ```
 
+Or keep using the address and let the label separate the seats. When the alias
+you asked for already holds a _different_ account, the label qualifies it
+instead of overwriting:
+
+```bash
+codexctl login amir@sawmills.ai --label personal   # saves 'amir@sawmills.ai'
+codexctl login amir@sawmills.ai --label team       # saves 'amir@sawmills.ai+team'
+```
+
+Logging the same seat in again refreshes whichever alias it already occupies,
+so this is stable across re-logins. Without `--label` there is nothing to
+qualify with, and a login onto an alias held by another account is refused
+rather than allowed to replace its credentials.
+
 `--label` also works on `codexctl save`, and `codexctl label <alias> [text]`
 sets or clears one later.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The `Label` column appears in `list` and `status` only once some profile has
 one.
 
 `codexctl save` without an alias defaults to the detected email. When that
-profile already holds a *different* workspace, the save is refused rather than
+profile already holds a _different_ workspace, the save is refused rather than
 offering an overwrite prompt that would replace the other account's tokens:
 
 ```

--- a/README.md
+++ b/README.md
@@ -228,14 +228,54 @@ redeems — use `codexctl reset <alias>` to spend a credit on a named account.
 ### Other commands
 
 ```bash
-codexctl list          # list saved profiles
-codexctl login <alias> # isolated Codex login and save
-codexctl whoami        # show active account
-codexctl codex -- ...  # run Codex with spend-cap recovery
-codexctl resets        # list banked rate-limit resets
-codexctl reset [alias] # redeem a banked reset
+codexctl list                # list saved profiles
+codexctl login <alias>       # isolated Codex login and save
+codexctl whoami              # show active account
+codexctl label <alias> [text] # name an account (omit text to clear)
+codexctl codex -- ...        # run Codex with spend-cap recovery
+codexctl resets              # list banked rate-limit resets
+codexctl reset [alias]       # redeem a banked reset
 codexctl remove <alias>
-codexctl --version     # installed version
+codexctl --version           # installed version
+```
+
+## Two accounts on one email
+
+A personal account and a workspace seat can share one address, so the email
+cannot tell them apart. Give each profile its own alias and a label:
+
+```bash
+codexctl login --label personal amir-personal
+codexctl login --label team     amir-team
+```
+
+`--label` also works on `codexctl save`, and `codexctl label <alias> [text]`
+sets or clears one later.
+
+```
+$ codexctl list
+┌──────────────────┬──────────┬──────────┬──────────────────┬────────┐
+│ Account          ┆ Label    ┆ Plan     ┆ Email            ┆ Active │
+╞══════════════════╪══════════╪══════════╪══════════════════╪════════╡
+│ amir-personal    ┆ personal ┆ pro      ┆ amir@sawmills.ai ┆        │
+│ amir-team        ┆ team     ┆ business ┆ amir@sawmills.ai ┆ *      │
+└──────────────────┴──────────┴──────────┴──────────────────┴────────┘
+```
+
+The label is display text. The alias stays the only selector for `use`,
+`remove`, and `reset`; `codexctl switch` also matches the label as you type.
+The `Label` column appears in `list` and `status` only once some profile has
+one.
+
+`codexctl save` without an alias defaults to the detected email. When that
+profile already holds a *different* workspace, the save is refused rather than
+offering an overwrite prompt that would replace the other account's tokens:
+
+```
+$ codexctl save
+error: profile 'amir@sawmills.ai' holds a different account
+       (stored workspace 033569a0…, incoming 6df34c28…).
+       Pass an explicit alias: codexctl save <alias>
 ```
 
 ## Shell completions

--- a/README.md
+++ b/README.md
@@ -328,46 +328,50 @@ alone, because a workspace holds many people and one login holds seats in many
 workspaces. Profiles saved before this release recorded neither, so `codexctl`
 reads them out of the stored token and remembers what it finds.
 
-Where it cannot prove two credentials are the same account, it now refuses
-rather than overwriting. Three cases can surprise a store that predates this
-release. All three are recoverable, and each error names its own remedy.
-
-**A second workspace on a profile that never recorded one.** Logging into a
-different workspace under an alias whose stored token carries no workspace
-claim is refused: the profile cannot confirm the arriving account is its own.
+Two credentials that positively disagree are never the same account, and
+`codexctl` refuses to overwrite one with the other. A profile that declares
+*nothing* is a different situation: the store cannot tell whether the account
+arriving is the one it holds, but the operator who just logged in can. Those
+cases ask rather than refuse — on a terminal with a prompt, and elsewhere with
+`--allow-adopt`, the same shape `use` applies to billing and to banked resets.
 
 ```
 $ codexctl login amir@sawmills.ai
-error: profile 'amir@sawmills.ai' holds a different account
-       (stored workspace unknown, this login 6df34c28…).
-       Re-run with --label <name> to save it alongside, choose another alias,
-       or remove it first: codexctl remove amir@sawmills.ai
+codexctl: profile 'amir@sawmills.ai' does not record which account it holds,
+          so this login cannot be matched to it. this login is 6df34c28….
+          Replace it? Its saved credentials are overwritten. [y/N]
 ```
+
+Answering `y` records the workspace, so the profile can answer for itself and
+the question is not asked again. Declining changes nothing. Without a terminal
+the answer defaults to no:
+
+```
+error: profile 'amir@sawmills.ai' does not record which account it holds, so
+       replacing it needs approval and none was given. Re-run on a terminal to
+       confirm, pass --allow-adopt, or choose another alias.
+```
+
+`--allow-adopt` settles only what the store could not work out. It has no
+effect on a conflict the store *did* work out: a stored workspace that
+positively differs from the arriving one stays refused with or without it.
+
+Two habits of a pre-release store change as a result.
 
 **A claimless profile stops absorbing rotations that name a workspace.** Codex
 refreshes tokens in place, and `codexctl` folds those back into the profile
 that owns them. A profile whose stored token declares no workspace no longer
 receives a rotation that declares one — that token may belong to another seat
 of the same login. The profile keeps working; its stored copy goes stale, and
-`status` shows the token ageing. `codexctl save` or a re-login refreshes it and
-records the workspace, after which rotations are captured normally again.
+`status` shows the token ageing. `codexctl save` or a re-login brings it
+forward and records the workspace, after which rotations are captured normally
+again.
 
-**A profile whose token no longer parses.** If its metadata still records the
-workspace, a re-login is refused for the same reason — the stored login cannot
-be read, so nothing proves the arriving one is its owner. Remove it and log in
-again:
-
-```
-$ codexctl remove amir-team && codexctl login amir-team --label team
-```
-
-A profile with nothing left to identify it — no readable token and no recorded
-account — is repaired by `codexctl login <alias>` directly, since there is no
-identity left to protect.
-
-Nothing runs at upgrade time. No profile is rewritten until its next `save`,
-`login`, or `status`, and a `meta.json` written by an earlier version parses
-unchanged.
+**A profile whose token no longer parses.** Its metadata may still record the
+workspace, but the stored login cannot be read, so nothing proves the arriving
+credential is its owner. This asks the same question. Answering `y` replaces it
+in place — which is what `remove` followed by a fresh login would do anyway,
+except that `remove` first destroys the metadata describing what was there.
 
 ## Shell completions
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ reads them out of the stored token and remembers what it finds.
 
 Two credentials that positively disagree are never the same account, and
 `codexctl` refuses to overwrite one with the other. A profile that declares
-*nothing* is a different situation: the store cannot tell whether the account
+_nothing_ is a different situation: the store cannot tell whether the account
 arriving is the one it holds, but the operator who just logged in can. Those
 cases ask rather than refuse — on a terminal with a prompt, and elsewhere with
 `--allow-adopt`, the same shape `use` applies to billing and to banked resets.
@@ -353,7 +353,7 @@ error: profile 'amir@sawmills.ai' does not record which account it holds, so
 ```
 
 `--allow-adopt` settles only what the store could not work out. It has no
-effect on a conflict the store *did* work out: a stored workspace that
+effect on a conflict the store _did_ work out: a stored workspace that
 positively differs from the arriving one stays refused with or without it. It
 also has to name its target — `codexctl save --allow-adopt` without an alias is
 refused, because `save` would otherwise derive the alias from the token's email

--- a/README.md
+++ b/README.md
@@ -354,7 +354,10 @@ error: profile 'amir@sawmills.ai' does not record which account it holds, so
 
 `--allow-adopt` settles only what the store could not work out. It has no
 effect on a conflict the store *did* work out: a stored workspace that
-positively differs from the arriving one stays refused with or without it.
+positively differs from the arriving one stays refused with or without it. It
+also has to name its target — `codexctl save --allow-adopt` without an alias is
+refused, because `save` would otherwise derive the alias from the token's email
+claim and the flag would approve replacing a profile the operator never saw.
 
 Two habits of a pre-release store change as a result.
 
@@ -371,7 +374,11 @@ again.
 workspace, but the stored login cannot be read, so nothing proves the arriving
 credential is its owner. This asks the same question. Answering `y` replaces it
 in place — which is what `remove` followed by a fresh login would do anyway,
-except that `remove` first destroys the metadata describing what was there.
+except that `remove` first destroys the metadata describing what was there. A
+profile with nothing left at all — no readable token and no recorded account —
+is asked about too, rather than quietly replaced: that verdict rests on the
+token having failed to parse, and a future parser change must widen the
+questions rather than the permissions.
 
 ## Shell completions
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,54 @@ error: profile 'amir@sawmills.ai' holds a different account
        Pass an explicit alias: codexctl save <alias>
 ```
 
+## Upgrading an existing store
+
+An account is identified by its workspace and its login together — neither
+alone, because a workspace holds many people and one login holds seats in many
+workspaces. Profiles saved before this release recorded neither, so `codexctl`
+reads them out of the stored token and remembers what it finds.
+
+Where it cannot prove two credentials are the same account, it now refuses
+rather than overwriting. Three cases can surprise a store that predates this
+release. All three are recoverable, and each error names its own remedy.
+
+**A second workspace on a profile that never recorded one.** Logging into a
+different workspace under an alias whose stored token carries no workspace
+claim is refused: the profile cannot confirm the arriving account is its own.
+
+```
+$ codexctl login amir@sawmills.ai
+error: profile 'amir@sawmills.ai' holds a different account
+       (stored workspace unknown, this login 6df34c28…).
+       Re-run with --label <name> to save it alongside, choose another alias,
+       or remove it first: codexctl remove amir@sawmills.ai
+```
+
+**A claimless profile stops absorbing rotations that name a workspace.** Codex
+refreshes tokens in place, and `codexctl` folds those back into the profile
+that owns them. A profile whose stored token declares no workspace no longer
+receives a rotation that declares one — that token may belong to another seat
+of the same login. The profile keeps working; its stored copy goes stale, and
+`status` shows the token ageing. `codexctl save` or a re-login refreshes it and
+records the workspace, after which rotations are captured normally again.
+
+**A profile whose token no longer parses.** If its metadata still records the
+workspace, a re-login is refused for the same reason — the stored login cannot
+be read, so nothing proves the arriving one is its owner. Remove it and log in
+again:
+
+```
+$ codexctl remove amir-team && codexctl login amir-team --label team
+```
+
+A profile with nothing left to identify it — no readable token and no recorded
+account — is repaired by `codexctl login <alias>` directly, since there is no
+identity left to protect.
+
+Nothing runs at upgrade time. No profile is rewritten until its next `save`,
+`login`, or `status`, and a `meta.json` written by an earlier version parses
+unchanged.
+
 ## Shell completions
 
 ```bash

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -4,7 +4,7 @@
 
 A profile is a directory named by its alias under `~/.codexctl/profiles/<alias>/`, and `meta.json`
 records only `alias`, `email`, `plan`, and `saved_at`. The alias is already arbitrary, so two
-accounts can already coexist. Nothing, however, records *which account is which*.
+accounts can already coexist. Nothing, however, records _which account is which_.
 
 This breaks down when one person holds two accounts on one email address — a personal account and a
 seat in a team or business workspace. Both profiles report the same `email`. `codexctl list` prints
@@ -14,7 +14,7 @@ not say "team" or "personal".
 Two existing behaviors turn that from an inconvenience into a hazard:
 
 1. `codexctl save` with no alias defaults the alias to the detected email. For a second account on
-   the same email, that targets the *existing* profile and offers `Overwrite? [y/N]`. Answering `y`
+   the same email, that targets the _existing_ profile and offers `Overwrite? [y/N]`. Answering `y`
    destroys the stored tokens of the first account.
 2. `profile::alias_for_auth_json_from` identifies the live `~/.codex/auth.json` by exact token value
    and, when the token has rotated, falls back to the `sub` claim alone. Two profiles that share one
@@ -30,12 +30,12 @@ it. Keep the alias as the only key and the only selector.
 
 The Codex access token is a JWT whose claims already carry every fact needed:
 
-| Claim                                         | Field                 | Meaning                        |
-| --------------------------------------------- | --------------------- | ------------------------------ |
-| `https://api.openai.com/profile`              | `email`, `name`       | who the human is               |
-| `https://api.openai.com/auth`                 | `chatgpt_account_id`  | which workspace                |
-| `https://api.openai.com/auth`                 | `chatgpt_user_id`     | which login                    |
-| `https://api.openai.com/auth`                 | `chatgpt_plan_type`   | the plan                       |
+| Claim                            | Field                | Meaning          |
+| -------------------------------- | -------------------- | ---------------- |
+| `https://api.openai.com/profile` | `email`, `name`      | who the human is |
+| `https://api.openai.com/auth`    | `chatgpt_account_id` | which workspace  |
+| `https://api.openai.com/auth`    | `chatgpt_user_id`    | which login      |
+| `https://api.openai.com/auth`    | `chatgpt_plan_type`  | the plan         |
 
 A new `api::token_identity(token) -> Option<TokenIdentity>` decodes the payload once and returns
 these together. It reuses the existing private `decode_jwt_payload`.
@@ -66,13 +66,13 @@ exactly when a profile most needs to stay identifiable.
 }
 ```
 
-| Field        | Source                    | Written by                       |
-| ------------ | ------------------------- | -------------------------------- |
-| `label`      | the operator              | `label`, `--label`               |
-| `account_id` | `chatgpt_account_id`      | `save`, `login`                  |
-| `user_id`    | `chatgpt_user_id`         | `save`, `login`                  |
-| `email`      | profile claim, then `/me` | `save`, `login`                  |
-| `plan`       | unchanged                 | `save`, `login`, `status`        |
+| Field        | Source                    | Written by                |
+| ------------ | ------------------------- | ------------------------- |
+| `label`      | the operator              | `label`, `--label`        |
+| `account_id` | `chatgpt_account_id`      | `save`, `login`           |
+| `user_id`    | `chatgpt_user_id`         | `save`, `login`           |
+| `email`      | profile claim, then `/me` | `save`, `login`           |
+| `plan`       | unchanged                 | `save`, `login`, `status` |
 
 Every new field is `Option<T>` with `#[serde(default)]`, so a `meta.json` written by an earlier
 version parses unchanged and simply reports no label. No migration step runs, and no existing
@@ -161,7 +161,7 @@ stored in the target profile's `meta.json`:
 | equal                | equal    | today's `Overwrite? [y/N]` prompt          |
 | different            | known    | refuse, and name an explicit alias to pass |
 
-A refusal needs positive evidence of a *different* account. Whenever either identifier is missing,
+A refusal needs positive evidence of a _different_ account. Whenever either identifier is missing,
 the command falls back to the existing prompt rather than blocking a legitimate re-save.
 
 The refusal is an error, not a prompt, because the destructive answer is a single keystroke and the

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -1,0 +1,218 @@
+# Account Labels: Distinguishing Profiles That Share One Email
+
+## Problem
+
+A profile is a directory named by its alias under `~/.codexctl/profiles/<alias>/`, and `meta.json`
+records only `alias`, `email`, `plan`, and `saved_at`. The alias is already arbitrary, so two
+accounts can already coexist. Nothing, however, records *which account is which*.
+
+This breaks down when one person holds two accounts on one email address — a personal account and a
+seat in a team or business workspace. Both profiles report the same `email`. `codexctl list` prints
+only the alias and the plan. The alias string becomes the sole signal, and a plan value alone does
+not say "team" or "personal".
+
+Two existing behaviors turn that from an inconvenience into a hazard:
+
+1. `codexctl save` with no alias defaults the alias to the detected email. For a second account on
+   the same email, that targets the *existing* profile and offers `Overwrite? [y/N]`. Answering `y`
+   destroys the stored tokens of the first account.
+2. `profile::alias_for_auth_json_from` identifies the live `~/.codex/auth.json` by exact token value
+   and, when the token has rotated, falls back to the `sub` claim alone. Two profiles that share one
+   OpenAI login make that fallback ambiguous, so it returns `None` and the rotated tokens are never
+   captured back into the profile. The profile later reports `expired` for no visible reason.
+
+## Design
+
+Record identity that the account itself asserts, and let the operator attach a human name on top of
+it. Keep the alias as the only key and the only selector.
+
+### Identity comes from the token, not the network
+
+The Codex access token is a JWT whose claims already carry every fact needed:
+
+| Claim                                         | Field                 | Meaning                        |
+| --------------------------------------------- | --------------------- | ------------------------------ |
+| `https://api.openai.com/profile`              | `email`, `name`       | who the human is               |
+| `https://api.openai.com/auth`                 | `chatgpt_account_id`  | which workspace                |
+| `https://api.openai.com/auth`                 | `chatgpt_user_id`     | which login                    |
+| `https://api.openai.com/auth`                 | `chatgpt_plan_type`   | the plan                       |
+
+A new `api::token_identity(token) -> Option<TokenIdentity>` decodes the payload once and returns
+these together. It reuses the existing private `decode_jwt_payload`.
+
+This replaces two unreliable sources:
+
+- `commands::save::fetch_email` performs a live `GET /backend-api/me`. That call is best-effort and
+  swallows every failure into `None`. It is also not dependable in practice: the endpoint answers
+  `403` with an HTML challenge page to a plain client. It remains only as a fallback when the token
+  carries no profile claim.
+- `commands::login::email_from_alias` infers the email by testing the alias for an `@`. An alias
+  such as `amir-team` therefore stores `email: null`. The claim supplies the real address instead.
+
+Claim decoding needs no network, is deterministic, and still works on an expired token — which is
+exactly when a profile most needs to stay identifiable.
+
+### `meta.json` gains four optional fields
+
+```json
+{
+  "alias": "amir-team",
+  "label": "team",
+  "email": "amir@sawmills.ai",
+  "plan": "business",
+  "account_id": "6df34c28-6856-42d4-8da8-a664980ec77d",
+  "user_id": "user-uT4WAfEcoEA4I0gJ1ZM853Cq",
+  "saved_at": "2026-08-06T18:00:00+00:00"
+}
+```
+
+| Field        | Source                    | Written by                       |
+| ------------ | ------------------------- | -------------------------------- |
+| `label`      | the operator              | `label`, `--label`               |
+| `account_id` | `chatgpt_account_id`      | `save`, `login`                  |
+| `user_id`    | `chatgpt_user_id`         | `save`, `login`                  |
+| `email`      | profile claim, then `/me` | `save`, `login`                  |
+| `plan`       | unchanged                 | `save`, `login`, `status`        |
+
+Every new field is `Option<T>` with `#[serde(default)]`, so a `meta.json` written by an earlier
+version parses unchanged and simply reports no label. No migration step runs, and no existing
+profile is rewritten until its next `save`, `login`, or `status`.
+
+`account_id` and `user_id` are workspace and user identifiers, not credentials. They are already
+present in plaintext inside the stored `auth.json`.
+
+### Setting the label
+
+```
+codexctl label <alias> [text]     # set; omit text to clear
+codexctl login --label <text> <alias>
+codexctl save  --label <text> [alias]
+```
+
+`label` resolves the profile through `store::profile_dir`, so it inherits the existing path,
+case-collision, and symlink checks. It takes the store lock and writes `meta.json` through
+`store::atomic_write`, matching how every other mutation is persisted.
+
+Label validation mirrors `store::validate_alias` minus the path rules, because a label is display
+text and never a path component:
+
+- trimmed; an empty result clears the label
+- at most 40 bytes
+- ASCII only
+- no control characters
+
+A label is deliberately **not** required to be unique. It is display text, so two profiles may both
+read `team` without creating an unresolvable name.
+
+### The label never becomes a selector
+
+`use`, `remove`, `reset`, and `label` continue to accept the alias only. One namespace means no
+resolution order, no ambiguity rule, and no path by which a mistyped label switches the wrong
+account. The label reaches selection only through the `switch` fuzzy picker, where it is part of the
+matched display string and the operator confirms the highlighted row before anything changes.
+
+### Display
+
+`list` currently pads columns by hand with `{:<width$}`. It moves to `comfy_table` with the
+`UTF8_FULL_CONDENSED` preset already used by `status`, so both commands render the same way.
+
+```
+$ codexctl list
+┌───────────────────┬──────────┬──────────┬────────────────────┬────────┐
+│ Account           ┆ Label    ┆ Plan     ┆ Email              ┆ Active │
+╞═══════════════════╪══════════╪══════════╪════════════════════╪════════╡
+│ amir@sawmills.ai  ┆ personal ┆ pro      ┆ amir@sawmills.ai   ┆        │
+│ amir-team         ┆ team     ┆ business ┆ amir@sawmills.ai   ┆ *      │
+└───────────────────┴──────────┴──────────┴────────────────────┴────────┘
+```
+
+The `Label` column appears in `list` and `status` only when at least one profile carries a label.
+Until the feature is used, both tables keep their current shape. This mirrors how
+`RateLimitColumns::for_accounts` already adds the `Limit` column only when some account needs it.
+
+Colors follow the existing `status` conventions: the active marker and the label render in
+`Color::Cyan`, and no color is applied to a cell whose meaning is not a severity.
+
+`whoami` gains the label in the same position:
+
+```
+$ codexctl whoami
+amir-team — team (amir@sawmills.ai) [business]
+```
+
+`switch` appends the label to each picker row so that typing `team` selects it:
+
+```
+amir-team — team (amir@sawmills.ai) [business] — 5h: 2%, 7d: 16%
+```
+
+A profile with no label renders `-` in a table cell and omits the ` — label` segment in the
+single-line forms, so nothing shifts for an unlabeled store.
+
+### Refusing to overwrite a different account
+
+`save` resolves its alias, then compares the incoming token's `account_id` against the `account_id`
+stored in the target profile's `meta.json`:
+
+| Stored               | Incoming | Result                                     |
+| -------------------- | -------- | ------------------------------------------ |
+| absent (old profile) | any      | today's `Overwrite? [y/N]` prompt          |
+| any                  | absent   | today's `Overwrite? [y/N]` prompt          |
+| equal                | equal    | today's `Overwrite? [y/N]` prompt          |
+| different            | known    | refuse, and name an explicit alias to pass |
+
+A refusal needs positive evidence of a *different* account. Whenever either identifier is missing,
+the command falls back to the existing prompt rather than blocking a legitimate re-save.
+
+The refusal is an error, not a prompt, because the destructive answer is a single keystroke and the
+correct action is always to choose a different alias:
+
+```
+$ codexctl save
+error: profile 'amir@sawmills.ai' holds a different account
+       (stored workspace 033569a0…, incoming 6df34c28…).
+       Pass an explicit alias: codexctl save <alias>
+```
+
+This is the check that makes adding a second account on one email safe, so it belongs to this work
+rather than to a later cleanup.
+
+### Disambiguating the rotated-token fallback
+
+`alias_for_auth_json_from` keeps its exact-token-match pass unchanged. Its `sub` fallback gains
+`account_id` as a second key: a candidate matches when the subject matches **and** the account
+identifiers either both exist and are equal, or at least one is absent.
+
+Two profiles for one login in two workspaces therefore stay distinguishable, and
+`capture_auth_file_profile_tokens` keeps folding rotated tokens back into the right profile. When
+either side lacks the claim, the behavior is exactly today's, so no existing store regresses.
+
+## Testing
+
+Focused unit tests:
+
+- `token_identity` extracts email, account id, user id, and plan from a synthetic JWT, and returns
+  `None` for a malformed or claimless token.
+- Label validation accepts a normal label, trims, clears on empty, and rejects over-length,
+  non-ASCII, and control-character input.
+- `alias_for_auth_json_from` returns the right alias for two profiles that share a `sub` and differ
+  by `account_id`, and preserves today's result when a claim is absent.
+- `Meta` deserializes a `meta.json` that predates the new fields.
+
+CLI tests:
+
+- `label` sets, overwrites, and clears; it fails on an unknown alias.
+- `login --label` and `save --label` persist the label.
+- `list` and `status` omit the `Label` column with no labels present and include it once one is set.
+- `save` refuses when the target profile holds a different `account_id`.
+
+Per `AGENTS.md`, no real token value enters a fixture. Test tokens are unsigned JWTs carrying only
+synthetic claims, following the existing `JWT_HDR` pattern in `commands/status.rs`.
+
+## Out of scope
+
+- Renaming an existing profile. The alias remains fixed after creation; a rename would have to move
+  the profile directory, the login home, and the active pointer together, which is its own design.
+- Selecting a profile by label. Recorded here as a deliberate rejection, not an oversight.
+- Any change to automatic selection, billing approval, or reset redemption. Labels are descriptive
+  and never influence which account `use` picks.

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -151,18 +151,30 @@ single-line forms, so nothing shifts for an unlabeled store.
 
 ### Refusing to overwrite a different account
 
-`save` resolves its alias, then compares the incoming token's `account_id` against the `account_id`
-stored in the target profile's `meta.json`:
+An account is identified by **both** its workspace (`chatgpt_account_id`) and its login
+(`chatgpt_user_id`, falling back to the token's `sub`). Neither half identifies an account alone: a
+workspace holds many people, and one login holds seats in many workspaces. A profile's workspace is
+read from its stored token first and its `meta.json` second, so a profile written before the field
+existed is still identified.
 
-| Stored               | Incoming | Result                                     |
-| -------------------- | -------- | ------------------------------------------ |
-| absent (old profile) | any      | today's `Overwrite? [y/N]` prompt          |
-| any                  | absent   | today's `Overwrite? [y/N]` prompt          |
-| equal                | equal    | today's `Overwrite? [y/N]` prompt          |
-| different            | known    | refuse, and name an explicit alias to pass |
+`login` and `save` replace what is stored, so they require positive agreement rather than the mere
+absence of contradiction:
 
-A refusal needs positive evidence of a _different_ account. Whenever either identifier is missing,
-the command falls back to the existing prompt rather than blocking a legitimate re-save.
+| Stored workspace | Incoming workspace | Result                                             |
+| ---------------- | ------------------ | -------------------------------------------------- |
+| equal            | equal              | allowed (`save` still prompts before overwriting)  |
+| different        | known              | refuse, and name an explicit alias to pass         |
+| absent           | known              | refuse — the profile cannot confirm this account   |
+| known            | absent             | refuse — the token cannot prove it is this account |
+| absent           | absent             | allowed                                            |
+
+The login is checked alongside it: a login that differs is a refusal, and a token naming no login at
+all cannot overwrite a profile that names one. The single deliberate exception is a profile whose
+stored token cannot be read: nothing there can be identified or used, so an explicit re-login
+repairs it rather than destroying it.
+
+**This is fail-closed by design.** "Cannot confirm" is not "yes"; reading it as yes is what let a
+second workspace replace the first seat's credentials.
 
 The refusal is an error, not a prompt, because the destructive answer is a single keystroke and the
 correct action is always to choose a different alias:
@@ -179,13 +191,27 @@ rather than to a later cleanup.
 
 ### Disambiguating the rotated-token fallback
 
-`alias_for_auth_json_from` keeps its exact-token-match pass unchanged. Its `sub` fallback gains
-`account_id` as a second key: a candidate matches when the subject matches **and** the account
-identifiers either both exist and are equal, or at least one is absent.
+Capture also overwrites a profile, so attribution follows the same rule, with one exception for
+evidence strong enough to stand alone.
 
-Two profiles for one login in two workspaces therefore stay distinguishable, and
-`capture_auth_file_profile_tokens` keeps folding rotated tokens back into the right profile. When
-either side lacks the claim, the behavior is exactly today's, so no existing store regresses.
+An **identical access token** is the same credential, so it resolves to its profile even when only
+one side declares a workspace — this is what lets a profile record its own workspace claim once
+Codex starts stamping one. Among several profiles holding one token, the one declaring the target's
+workspace wins; equally strong matches, or a sibling declaring a different workspace, resolve to no
+owner rather than letting directory order decide.
+
+Any **rotated** token needs the claims to agree. In particular a rotation declaring a workspace is
+not attributed to a same-login profile that never recorded one, because a native login elsewhere can
+put another seat's credential in the live file. A claimless rotation is likewise not attributed to a
+claimless profile when a declared sibling shares that login — either could own it.
+
+An alias the caller supplies (the active marker, or `CODEXCTL_PINNED_ALIAS`) breaks ties that token
+inspection cannot, but only after evidence: an exact-token owner outranks it, and it stands aside
+when the match is undecided.
+
+_Behaviour change:_ a profile whose stored token declares no workspace stops capturing rotations
+that declare one, so it goes stale until its next `save` or `login`. That is recoverable;
+overwriting its credentials is not.
 
 ## Testing
 
@@ -196,7 +222,7 @@ Focused unit tests:
 - Label validation accepts a normal label, trims, clears on empty, and rejects over-length,
   non-ASCII, and control-character input.
 - `alias_for_auth_json_from` returns the right alias for two profiles that share a `sub` and differ
-  by `account_id`, and preserves today's result when a claim is absent.
+  by `account_id`, and returns no owner when a claim is absent on either side of a rotation.
 - `Meta` deserializes a `meta.json` that predates the new fields.
 
 CLI tests:
@@ -204,7 +230,9 @@ CLI tests:
 - `label` sets, overwrites, and clears; it fails on an unknown alias.
 - `login --label` and `save --label` persist the label.
 - `list` and `status` omit the `Label` column with no labels present and include it once one is set.
-- `save` refuses when the target profile holds a different `account_id`.
+- `save` refuses when the target profile holds a different `account_id`, when either side's
+  workspace claim is missing, and when a concurrent write changes the profile or the live file
+  after the operator has confirmed the overwrite.
 
 Per `AGENTS.md`, no real token value enters a fixture. Test tokens are unsigned JWTs carrying only
 synthetic claims, following the existing `JWT_HDR` pattern in `commands/status.rs`.

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -169,13 +169,13 @@ replacement guards ask, while capture and seat lookup require positive agreement
 `login` and `save` replace what is stored, so they require positive agreement rather than the mere
 absence of contradiction:
 
-| Stored workspace | Incoming workspace | Result                                              |
-| ---------------- | ------------------ | --------------------------------------------------- |
-| equal            | equal              | allowed (`save` still prompts before overwriting)   |
-| different        | known              | refuse, and name an explicit alias to pass          |
+| Stored workspace | Incoming workspace | Result                                                |
+| ---------------- | ------------------ | ----------------------------------------------------- |
+| equal            | equal              | allowed (`save` still prompts before overwriting)     |
+| different        | known              | refuse, and name an explicit alias to pass            |
 | absent           | known              | ask — the profile cannot confirm or deny this account |
-| known            | absent             | ask — the token cannot prove it is this account      |
-| absent           | absent             | allowed                                             |
+| known            | absent             | ask — the token cannot prove it is this account       |
+| absent           | absent             | allowed                                               |
 
 The login is checked alongside it, and unprovable in either direction is never read as agreement: a
 token naming no login does not silently overwrite a profile that names one, and a profile whose
@@ -187,7 +187,7 @@ second workspace replace the first seat's credentials.
 
 But "cannot confirm" is not "no" either, and the two failures need different answers. A workspace
 that positively differs is never this account, so it is refused outright and no flag overrides it.
-A profile that declares *nothing* — which is precisely what every profile predating this design
+A profile that declares _nothing_ — which is precisely what every profile predating this design
 looks like — is a question the store cannot settle and the operator usually can. Refusing those
 outright leaves `codexctl remove` as the only way forward: it destroys the metadata that could have
 identified the profile and then performs the same replacement with nothing checked at all. The

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -163,29 +163,48 @@ equal on a coincidental value.
 `login` and `save` replace what is stored, so they require positive agreement rather than the mere
 absence of contradiction:
 
-| Stored workspace | Incoming workspace | Result                                             |
-| ---------------- | ------------------ | -------------------------------------------------- |
-| equal            | equal              | allowed (`save` still prompts before overwriting)  |
-| different        | known              | refuse, and name an explicit alias to pass         |
-| absent           | known              | refuse — the profile cannot confirm this account   |
-| known            | absent             | refuse — the token cannot prove it is this account |
-| absent           | absent             | allowed                                            |
+| Stored workspace | Incoming workspace | Result                                              |
+| ---------------- | ------------------ | --------------------------------------------------- |
+| equal            | equal              | allowed (`save` still prompts before overwriting)   |
+| different        | known              | refuse, and name an explicit alias to pass          |
+| absent           | known              | ask — the profile cannot confirm or deny this account |
+| known            | absent             | ask — the token cannot prove it is this account      |
+| absent           | absent             | allowed                                             |
 
-The login is checked alongside it, and unprovable in either direction is a refusal: a token naming
-no login cannot overwrite a profile that names one, and a profile whose stored login cannot be
-recovered is not open to a token that happens to name one — otherwise anyone in a shared workspace
-could replace a damaged profile by naming its alias.
-
-The single deliberate exception is a profile with **no readable token and no recorded account**:
-nothing there can be identified or used, so an explicit re-login repairs it rather than destroying
-it. A damaged profile that still records its workspace does not qualify — it is refused, and the
-error names `codexctl remove <alias>` as the way through.
+The login is checked alongside it, and unprovable in either direction is never read as agreement: a
+token naming no login does not silently overwrite a profile that names one, and a profile whose
+stored login cannot be recovered is not open to a token that happens to name one — otherwise anyone
+in a shared workspace could replace a damaged profile by naming its alias.
 
 **This is fail-closed by design.** "Cannot confirm" is not "yes"; reading it as yes is what let a
 second workspace replace the first seat's credentials.
 
-The refusal is an error, not a prompt, because the destructive answer is a single keystroke and the
-correct action is always to choose a different alias:
+But "cannot confirm" is not "no" either, and the two failures need different answers. A workspace
+that positively differs is never this account, so it is refused outright and no flag overrides it.
+A profile that declares *nothing* — which is precisely what every profile predating this design
+looks like — is a question the store cannot settle and the operator usually can. Refusing those
+outright leaves `codexctl remove` as the only way forward: it destroys the metadata that could have
+identified the profile and then performs the same replacement with nothing checked at all. The
+guard would be strictly weaker than the act it forbids.
+
+So an unprovable conflict is an approval, following the consent idiom `use` already applies to
+billing and to banked resets: prompt on a terminal, refuse without one unless `--allow-adopt` says
+the operator already decided. Approval settles only what could not be worked out; it has no effect
+on a conflict that was.
+
+One case still needs no approval: a profile with **no readable token and no recorded account**.
+Nothing there can be identified or used, so there is no occupant to consult the operator about and
+an explicit re-login simply repairs it. A damaged profile that still records its workspace does have
+an occupant, and is asked about like any other.
+
+```
+$ codexctl login amir@sawmills.ai
+codexctl: profile 'amir@sawmills.ai' does not record which account it holds,
+          so this login cannot be matched to it. Replace it? [y/N]
+```
+
+A proven conflict stays an error, not a prompt, because the destructive answer is a single keystroke
+and the correct action is always to choose a different alias:
 
 ```
 $ codexctl save
@@ -193,6 +212,11 @@ error: profile 'amir@sawmills.ai' holds a different account
        (stored workspace 033569a0…, incoming 6df34c28…).
        Pass an explicit alias: codexctl save <alias>
 ```
+
+Adoption also closes a loop the refusal opened. A claimless profile stops absorbing rotations that
+name a workspace, and the documented way to bring it forward is `save` or a re-login — both of which
+route through this same check. Were that check an unconditional refusal, the remedy would be refused
+by the rule it is meant to escape.
 
 This is the check that makes adding a second account on one email safe, so it belongs to this work
 rather than to a later cleanup.
@@ -238,9 +262,12 @@ CLI tests:
 - `label` sets, overwrites, and clears; it fails on an unknown alias.
 - `login --label` and `save --label` persist the label.
 - `list` and `status` omit the `Label` column with no labels present and include it once one is set.
-- `save` refuses when the target profile holds a different `account_id`, when either side's
-  workspace claim is missing, and when a concurrent write changes the profile or the live file
-  after the operator has confirmed the overwrite.
+- `save` refuses when the target profile holds a different `account_id`, asks for approval when
+  either side's workspace claim is missing, refuses that same case with no terminal and no
+  `--allow-adopt`, and refuses when a concurrent write changes the profile or the live file after
+  the operator has confirmed the overwrite.
+- `--allow-adopt` does not override a proven conflict, and an approval given for one profile is not
+  reused after the store changes underneath it.
 
 Per `AGENTS.md`, no real token value enters a fixture. Test tokens are unsigned JWTs carrying only
 synthetic claims, following the existing `JWT_HDR` pattern in `commands/status.rs`.

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -158,7 +158,13 @@ read from its stored token first and its `meta.json` second, so a profile writte
 existed is still identified.
 
 The login carries the claim it came from — `uid:` or `sub:` — so the two namespaces never compare
-equal on a coincidental value.
+equal on a coincidental value. Both claims are kept rather than one chosen: a token gaining
+`chatgpt_user_id` is the ordinary legacy-to-current transition, and preferring a single claim makes
+the same seat before and after look like two people — which refuses the refresh, drops the rotation,
+and splits the profile in two on the next labelled login. Comparison happens inside whichever
+namespace both sides supply. Sharing none proves nothing in either direction, so such a pair is
+neither the same nor different, and each caller decides what to do about not knowing: the
+replacement guards ask, while capture and seat lookup require positive agreement.
 
 `login` and `save` replace what is stored, so they require positive agreement rather than the mere
 absence of contradiction:

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -192,10 +192,14 @@ billing and to banked resets: prompt on a terminal, refuse without one unless `-
 the operator already decided. Approval settles only what could not be worked out; it has no effect
 on a conflict that was.
 
-One case still needs no approval: a profile with **no readable token and no recorded account**.
-Nothing there can be identified or used, so there is no occupant to consult the operator about and
-an explicit re-login simply repairs it. A damaged profile that still records its workspace does have
-an occupant, and is asked about like any other.
+One case is settled rather than asked about, deliberately: a workspace that matches with **neither
+side naming a login**. Both tokens predate `chatgpt_user_id`, and adopting would record no login
+either — so the question would return on every refresh, and a prompt its own answer cannot satisfy is
+noise rather than consent. A matching workspace with nothing contradicting it is the strongest
+evidence such a token can offer. Two seats in one workspace behind tokens that old are the residual
+exposure, and a token carrying the claim closes it permanently.
+
+A profile with **no readable token and no recorded account** is asked about like any other.
 
 ```
 $ codexctl login amir@sawmills.ai

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -199,7 +199,10 @@ the operator already decided. Approval settles only what could not be worked out
 on a conflict that was.
 
 One case is settled rather than asked about, deliberately: a workspace that matches with **neither
-side naming a login**. Both tokens predate `chatgpt_user_id`, and adopting would record no login
+side naming a login**, and only while the stored credentials actually read. A profile whose token
+will not parse is not saying nothing — nothing could be read from it, which is absence of evidence
+rather than a matching claim, and a shared workspace would otherwise let anyone holding a seat in it
+replace a damaged profile by naming its alias. Both tokens predate `chatgpt_user_id`, and adopting would record no login
 either — so the question would return on every refresh, and a prompt its own answer cannot satisfy is
 noise rather than consent. A matching workspace with nothing contradicting it is the strongest
 evidence such a token can offer. Two seats in one workspace behind tokens that old are the residual

--- a/docs/superpowers/specs/2026-08-06-account-labels-design.md
+++ b/docs/superpowers/specs/2026-08-06-account-labels-design.md
@@ -153,9 +153,12 @@ single-line forms, so nothing shifts for an unlabeled store.
 
 An account is identified by **both** its workspace (`chatgpt_account_id`) and its login
 (`chatgpt_user_id`, falling back to the token's `sub`). Neither half identifies an account alone: a
-workspace holds many people, and one login holds seats in many workspaces. A profile's workspace is
-read from its stored token first and its `meta.json` second, so a profile written before the field
+workspace holds many people, and one login holds seats in many workspaces. A profile's identity is
+read from its stored token first and its `meta.json` second, so a profile written before the fields
 existed is still identified.
+
+The login carries the claim it came from — `uid:` or `sub:` — so the two namespaces never compare
+equal on a coincidental value.
 
 `login` and `save` replace what is stored, so they require positive agreement rather than the mere
 absence of contradiction:
@@ -168,10 +171,15 @@ absence of contradiction:
 | known            | absent             | refuse — the token cannot prove it is this account |
 | absent           | absent             | allowed                                            |
 
-The login is checked alongside it: a login that differs is a refusal, and a token naming no login at
-all cannot overwrite a profile that names one. The single deliberate exception is a profile whose
-stored token cannot be read: nothing there can be identified or used, so an explicit re-login
-repairs it rather than destroying it.
+The login is checked alongside it, and unprovable in either direction is a refusal: a token naming
+no login cannot overwrite a profile that names one, and a profile whose stored login cannot be
+recovered is not open to a token that happens to name one — otherwise anyone in a shared workspace
+could replace a damaged profile by naming its alias.
+
+The single deliberate exception is a profile with **no readable token and no recorded account**:
+nothing there can be identified or used, so an explicit re-login repairs it rather than destroying
+it. A damaged profile that still records its workspace does not qualify — it is refused, and the
+error names `codexctl remove <alias>` as the way through.
 
 **This is fail-closed by design.** "Cannot confirm" is not "yes"; reading it as yes is what let a
 second workspace replace the first seat's credentials.

--- a/src/api.rs
+++ b/src/api.rs
@@ -39,7 +39,12 @@ pub struct RateLimitResponse {
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
     /// Extra feature or model buckets returned alongside the main Codex limit.
-    #[serde(default)]
+    ///
+    /// Some plans send an explicit `null` here instead of omitting the key or
+    /// sending `[]`. `serde(default)` only covers a missing key, so the null
+    /// has to be absorbed too — otherwise the whole response fails to parse and
+    /// the account renders as an unexplained error.
+    #[serde(default, deserialize_with = "null_as_default")]
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Banked rate-limit reset credits, when the plan has any.
     pub rate_limit_reset_credits: Option<ResetCreditsSummary>,
@@ -85,6 +90,18 @@ impl RateLimitResponse {
             .as_ref()
             .map_or(0, |c| c.applicable_available_count)
     }
+}
+
+/// Treat an explicit JSON `null` as the type's default.
+///
+/// The usage API uses `null` and "key absent" interchangeably for optional
+/// collections, and which one arrives varies by plan.
+fn null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::deserialize(deserializer)?.unwrap_or_default())
 }
 
 fn is_known_rate_limited_plan(plan: &str) -> bool {

--- a/src/api.rs
+++ b/src/api.rs
@@ -620,14 +620,49 @@ fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
     serde_json::from_slice(&bytes).ok()
 }
 
+const AUTH_CLAIM: &str = "https://api.openai.com/auth";
+const PROFILE_CLAIM: &str = "https://api.openai.com/profile";
+
+/// What a Codex access token asserts about the account behind it.
+///
+/// Every field is read from the token's own claims, so resolving an identity
+/// needs no network call and still works once the token has expired — which is
+/// precisely when a profile most needs to stay identifiable.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TokenIdentity {
+    pub email: Option<String>,
+    pub name: Option<String>,
+    /// `chatgpt_account_id`: the workspace. Two profiles for one login differ here.
+    pub account_id: Option<String>,
+    /// `chatgpt_user_id`: the login. Two seats for one human share this.
+    pub user_id: Option<String>,
+    pub plan: Option<String>,
+}
+
+/// Read the identity claims out of an access token. `None` only when the token
+/// is not a decodable JWT; a decodable token missing every claim yields an
+/// empty identity so callers keep a single code path.
+pub fn token_identity(token: &str) -> Option<TokenIdentity> {
+    let value = decode_jwt_payload(token)?;
+    let profile = value.get(PROFILE_CLAIM);
+    let auth = value.get(AUTH_CLAIM);
+    Some(TokenIdentity {
+        email: string_claim(profile, "email"),
+        name: string_claim(profile, "name"),
+        account_id: string_claim(auth, "chatgpt_account_id")
+            .or_else(|| string_claim(auth, "account_id")),
+        user_id: string_claim(auth, "chatgpt_user_id"),
+        plan: string_claim(auth, "chatgpt_plan_type"),
+    })
+}
+
+fn string_claim(object: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    object?.get(key)?.as_str().map(str::to_string)
+}
+
 /// Extract account_id from JWT access_token claims when auth.json does not store it directly.
 pub fn extract_account_id(token: &str) -> Option<String> {
-    let value = decode_jwt_payload(token)?;
-    let auth = value.get("https://api.openai.com/auth")?;
-    auth.get("chatgpt_account_id")
-        .or_else(|| auth.get("account_id"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+    token_identity(token)?.account_id
 }
 
 /// The `sub` (subject) claim — identifies the individual seat/user behind a token.

--- a/src/api.rs
+++ b/src/api.rs
@@ -685,9 +685,18 @@ pub fn extract_account_id(token: &str) -> Option<String> {
 /// without it two seats in one workspace both resolve to "unknown" and an
 /// ownership guard reads that as agreement.
 pub fn token_login(token: &str) -> Option<String> {
-    token_identity(token)
-        .and_then(|identity| identity.user_id)
-        .or_else(|| token_subject(token))
+    // Tagged with the claim it came from, so the two never compare equal by
+    // accident: `chatgpt_user_id` and `sub` are different namespaces, and a
+    // token naming one must not match a profile identified by the other.
+    if let Some(user_id) = token_identity(token).and_then(|identity| identity.user_id) {
+        return Some(format!("uid:{user_id}"));
+    }
+    token_subject(token).map(|subject| format!("sub:{subject}"))
+}
+
+/// The same tag for a `chatgpt_user_id` already recorded in metadata.
+pub fn recorded_login(user_id: &str) -> String {
+    format!("uid:{user_id}")
 }
 
 /// The `sub` (subject) claim — identifies the individual seat/user behind a token.

--- a/src/api.rs
+++ b/src/api.rs
@@ -685,18 +685,94 @@ pub fn extract_account_id(token: &str) -> Option<String> {
 /// without it two seats in one workspace both resolve to "unknown" and an
 /// ownership guard reads that as agreement.
 pub fn token_login(token: &str) -> Option<String> {
-    // Tagged with the claim it came from, so the two never compare equal by
-    // accident: `chatgpt_user_id` and `sub` are different namespaces, and a
-    // token naming one must not match a profile identified by the other.
-    if let Some(user_id) = token_identity(token).and_then(|identity| identity.user_id) {
-        return Some(format!("uid:{user_id}"));
+    token_logins(token).canonical()
+}
+
+/// Every login claim a token makes, kept apart by the claim it came from.
+///
+/// Both are retained rather than one chosen, because a token gaining
+/// `chatgpt_user_id` is the ordinary legacy-to-current transition: the same seat
+/// keeps its `sub` and adds a `uid`. Collapsing to a single preferred claim
+/// makes the before and after look like two different people, which breaks the
+/// one migration this design exists to serve.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Logins {
+    /// From `chatgpt_user_id`.
+    pub uid: Option<String>,
+    /// From the JWT subject.
+    pub sub: Option<String>,
+}
+
+impl Logins {
+    pub fn is_empty(&self) -> bool {
+        self.uid.is_none() && self.sub.is_none()
     }
-    token_subject(token).map(|subject| format!("sub:{subject}"))
+
+    /// The identifier to record or show, tagged with where it came from so the
+    /// two namespaces never read as one value.
+    pub fn canonical(&self) -> Option<String> {
+        if let Some(uid) = &self.uid {
+            return Some(format!("uid:{uid}"));
+        }
+        self.sub.as_ref().map(|sub| format!("sub:{sub}"))
+    }
+
+    /// The claim both sides make, if there is one. Comparison only ever happens
+    /// inside a single namespace — `uid:X` and `sub:X` are unrelated facts that
+    /// happen to share a string, and must never match by coincidence.
+    fn shared<'a>(&'a self, other: &'a Logins) -> Option<(&'a str, &'a str)> {
+        if let (Some(mine), Some(theirs)) = (&self.uid, &other.uid) {
+            return Some((mine, theirs));
+        }
+        match (&self.sub, &other.sub) {
+            (Some(mine), Some(theirs)) => Some((mine, theirs)),
+            _ => None,
+        }
+    }
+
+    /// Whether these two make claims that can be weighed against each other at
+    /// all. Without a shared namespace neither confirms nor denies the other,
+    /// and a caller that reads silence as a rival claim will block on profiles
+    /// that say nothing about the token in hand.
+    pub fn comparable(&self, other: &Logins) -> bool {
+        self.shared(other).is_some()
+    }
+
+    /// Positive proof of the same login.
+    pub fn same(&self, other: &Logins) -> bool {
+        self.shared(other)
+            .is_some_and(|(mine, theirs)| mine == theirs)
+    }
+
+    /// Positive proof of a different login. Sharing no namespace proves
+    /// nothing, so it is neither the same nor different — the caller decides
+    /// what to do about not knowing.
+    pub fn differs(&self, other: &Logins) -> bool {
+        self.shared(other)
+            .is_some_and(|(mine, theirs)| mine != theirs)
+    }
+}
+
+/// Every login claim a token makes.
+pub fn token_logins(token: &str) -> Logins {
+    Logins {
+        uid: token_identity(token).and_then(|identity| identity.user_id),
+        sub: token_subject(token),
+    }
 }
 
 /// The same tag for a `chatgpt_user_id` already recorded in metadata.
 pub fn recorded_login(user_id: &str) -> String {
     format!("uid:{user_id}")
+}
+
+/// What metadata alone can say about the login: a recorded `chatgpt_user_id`
+/// and nothing else, since no subject is stored.
+pub fn recorded_logins(user_id: &str) -> Logins {
+    Logins {
+        uid: Some(user_id.to_string()),
+        sub: None,
+    }
 }
 
 /// The `sub` (subject) claim — identifies the individual seat/user behind a token.

--- a/src/api.rs
+++ b/src/api.rs
@@ -677,6 +677,19 @@ pub fn extract_account_id(token: &str) -> Option<String> {
     token_identity(token)?.account_id
 }
 
+/// Who a token belongs to, for deciding whether two credentials are the same
+/// account.
+///
+/// `chatgpt_user_id` names the login when the token carries it. `sub` is the
+/// same fact by another name and every token has one, so it is the fallback —
+/// without it two seats in one workspace both resolve to "unknown" and an
+/// ownership guard reads that as agreement.
+pub fn token_login(token: &str) -> Option<String> {
+    token_identity(token)
+        .and_then(|identity| identity.user_id)
+        .or_else(|| token_subject(token))
+}
+
 /// The `sub` (subject) claim — identifies the individual seat/user behind a token.
 /// Distinct per seat even when many seats share one `chatgpt_account_id`.
 pub fn token_subject(token: &str) -> Option<String> {

--- a/src/commands/adopt.rs
+++ b/src/commands/adopt.rs
@@ -15,6 +15,19 @@
 
 use crate::profile;
 
+/// How the adoption question came out.
+///
+/// Declining and being unable to ask are both "do not replace it", but they are
+/// not the same outcome: one is a decision, the other is a command that could
+/// not run. Collapsing them lets an unattended `save` report success having
+/// saved nothing.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Approval {
+    Granted,
+    Declined,
+    NoTerminal,
+}
+
 /// Ask before replacing `alias` with an account that cannot be matched to it.
 ///
 /// `stored` is what the profile is understood to hold, when it declares
@@ -25,41 +38,51 @@ pub fn approve_adoption(
     arriving: Option<&str>,
     assume_yes: bool,
     out: &mut impl std::io::Write,
-) -> bool {
+) -> Approval {
     use std::io::IsTerminal;
 
     if assume_yes {
         let _ = writeln!(out, "codexctl: replacing the profile saved as {alias}");
-        return true;
+        return Approval::Granted;
     }
     if !std::io::stdin().is_terminal() {
-        let _ = writeln!(
-            out,
-            "codexctl: not replacing the profile saved as {alias} \
-             (no terminal to approve; pass --allow-adopt to allow)"
-        );
-        return false;
+        return Approval::NoTerminal;
     }
 
-    let held = match stored {
-        Some(stored) => format!("holds {}", profile::short_workspace(stored)),
-        None => "does not record which account it holds".to_string(),
-    };
+    let held = describes(stored);
     let arriving = arriving
         .map(|arriving| format!(" this login is {}.", profile::short_workspace(arriving)))
         .unwrap_or_default();
     let _ = write!(
         out,
-        "codexctl: profile '{alias}' {held}, so this login cannot be matched to it.{arriving} \
+        "codexctl: profile '{alias}' {held} cannot be matched to this login.{arriving} \
          Replace it? Its saved credentials are overwritten. [y/N] "
     );
     let _ = out.flush();
 
     let mut answer = String::new();
     if std::io::stdin().read_line(&mut answer).is_err() {
-        return false;
+        return Approval::Declined;
     }
-    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    match answer.trim().to_ascii_lowercase().as_str() {
+        "y" | "yes" => Approval::Granted,
+        _ => Approval::Declined,
+    }
+}
+
+/// What a profile is known to hold, phrased for an operator.
+///
+/// A login identifier is not a workspace, so it must not be rendered as one:
+/// `short_workspace` would print a namespaced login as `sub:seat…`, which reads
+/// like a truncated account id and names the wrong thing entirely.
+fn describes(stored: Option<&str>) -> String {
+    match stored {
+        Some(stored) if stored.starts_with("uid:") || stored.starts_with("sub:") => {
+            "records a login but no workspace, so it".to_string()
+        }
+        Some(stored) => format!("holds {}, which", profile::short_workspace(stored)),
+        None => "does not record which account it holds, so it".to_string(),
+    }
 }
 
 /// The error for an adoption nobody approved.
@@ -68,13 +91,7 @@ pub fn approve_adoption(
 /// than claiming a different account, which is exactly what the store could not
 /// establish.
 pub fn refusal(alias: &str, stored: Option<&str>) -> anyhow::Error {
-    let held = match stored {
-        Some(stored) => format!(
-            "holds {} but cannot be matched to this account",
-            profile::short_workspace(stored)
-        ),
-        None => "does not record which account it holds".to_string(),
-    };
+    let held = format!("{} cannot be matched to this account", describes(stored));
     anyhow::anyhow!(
         "profile '{alias}' {held}, so replacing it needs approval and none was given. \
          Re-run on a terminal to confirm, pass --allow-adopt, or choose another alias."
@@ -90,31 +107,23 @@ mod tests {
     #[test]
     fn the_flag_answers_without_a_terminal() {
         let mut out = Vec::new();
-        assert!(approve_adoption(
-            "work",
-            None,
-            Some("acct-team"),
-            true,
-            &mut out
-        ));
+        assert_eq!(
+            approve_adoption("work", None, Some("acct-team"), true, &mut out),
+            Approval::Granted
+        );
         assert!(String::from_utf8(out).unwrap().contains("work"));
     }
 
-    /// Tests have no terminal, which is exactly the condition being checked:
-    /// with no way to ask, the answer is no, and the message says what supplies
-    /// one instead.
+    /// Tests have no terminal, which is exactly the condition being checked.
+    /// It must report *why* it could not ask, so the caller can fail rather than
+    /// treat it as the operator saying no.
     #[test]
-    fn no_terminal_declines_and_names_the_flag() {
+    fn no_terminal_is_distinct_from_a_decline() {
         let mut out = Vec::new();
-        assert!(!approve_adoption(
-            "work",
-            Some("acct-team"),
-            None,
-            false,
-            &mut out
-        ));
-        let printed = String::from_utf8(out).unwrap();
-        assert!(printed.contains("--allow-adopt"), "{printed}");
+        assert_eq!(
+            approve_adoption("work", Some("acct-team"), None, false, &mut out),
+            Approval::NoTerminal
+        );
     }
 
     /// The refusal reports only what is known. Claiming a different account
@@ -132,5 +141,12 @@ mod tests {
                 .to_string()
                 .contains("cannot be matched"),
         );
+        // A login identifier must not be dressed up as a workspace.
+        let login_only = refusal("work", Some("sub:seatA")).to_string();
+        assert!(
+            login_only.contains("records a login but no workspace"),
+            "{login_only}"
+        );
+        assert!(!login_only.contains("sub:seat"), "{login_only}");
     }
 }

--- a/src/commands/adopt.rs
+++ b/src/commands/adopt.rs
@@ -55,12 +55,19 @@ pub fn approve_adoption(
     }
 
     let held = describes(stored);
+    // `arriving` is the incoming workspace, not a login. Calling it one names
+    // the wrong half of the identity in the one message that has to be exact.
     let arriving = arriving
-        .map(|arriving| format!(" this login is {}.", profile::short_workspace(arriving)))
+        .map(|arriving| {
+            format!(
+                " That account is in workspace {}.",
+                profile::short_workspace(arriving)
+            )
+        })
         .unwrap_or_default();
     let _ = write!(
         out,
-        "codexctl: profile '{alias}' {held} cannot be matched to this login.{arriving} \
+        "codexctl: profile '{alias}' {held} cannot be matched to the account signing in.{arriving} \
          Replace it? Its saved credentials are overwritten. [y/N] "
     );
     let _ = out.flush();

--- a/src/commands/adopt.rs
+++ b/src/commands/adopt.rs
@@ -1,0 +1,136 @@
+//! Operator consent for replacing a profile the store cannot identify.
+//!
+//! Two claims that positively disagree are never the same account, and no
+//! answer changes that. But a profile that declares *nothing* is a different
+//! situation: the store cannot tell whether this is the same account returning
+//! or a stranger arriving, while the operator who just logged in usually can.
+//!
+//! Refusing that case outright reads as safety and is not. The only remedy left
+//! is `codexctl remove` followed by a fresh login — which destroys the very
+//! metadata that could have identified the profile, and then performs the same
+//! replacement with nothing checked at all. This module asks the question
+//! instead, following the consent idiom `use` already applies to billing and to
+//! banked resets: prompt on a terminal, refuse without one unless a flag says
+//! the operator already decided.
+
+use crate::profile;
+
+/// Ask before replacing `alias` with an account that cannot be matched to it.
+///
+/// `stored` is what the profile is understood to hold, when it declares
+/// anything at all.
+pub fn approve_adoption(
+    alias: &str,
+    stored: Option<&str>,
+    arriving: Option<&str>,
+    assume_yes: bool,
+    out: &mut impl std::io::Write,
+) -> bool {
+    use std::io::IsTerminal;
+
+    if assume_yes {
+        let _ = writeln!(out, "codexctl: replacing the profile saved as {alias}");
+        return true;
+    }
+    if !std::io::stdin().is_terminal() {
+        let _ = writeln!(
+            out,
+            "codexctl: not replacing the profile saved as {alias} \
+             (no terminal to approve; pass --allow-adopt to allow)"
+        );
+        return false;
+    }
+
+    let held = match stored {
+        Some(stored) => format!("holds {}", profile::short_workspace(stored)),
+        None => "does not record which account it holds".to_string(),
+    };
+    let arriving = arriving
+        .map(|arriving| format!(" this login is {}.", profile::short_workspace(arriving)))
+        .unwrap_or_default();
+    let _ = write!(
+        out,
+        "codexctl: profile '{alias}' {held}, so this login cannot be matched to it.{arriving} \
+         Replace it? Its saved credentials are overwritten. [y/N] "
+    );
+    let _ = out.flush();
+
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+/// The error for an adoption nobody approved.
+///
+/// It says only what is known — that the profile could not be matched — rather
+/// than claiming a different account, which is exactly what the store could not
+/// establish.
+pub fn refusal(alias: &str, stored: Option<&str>) -> anyhow::Error {
+    let held = match stored {
+        Some(stored) => format!(
+            "holds {} but cannot be matched to this account",
+            profile::short_workspace(stored)
+        ),
+        None => "does not record which account it holds".to_string(),
+    };
+    anyhow::anyhow!(
+        "profile '{alias}' {held}, so replacing it needs approval and none was given. \
+         Re-run on a terminal to confirm, pass --allow-adopt, or choose another alias."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag is the operator's answer given ahead of time, so it needs no
+    /// terminal — that is the whole point of having one.
+    #[test]
+    fn the_flag_answers_without_a_terminal() {
+        let mut out = Vec::new();
+        assert!(approve_adoption(
+            "work",
+            None,
+            Some("acct-team"),
+            true,
+            &mut out
+        ));
+        assert!(String::from_utf8(out).unwrap().contains("work"));
+    }
+
+    /// Tests have no terminal, which is exactly the condition being checked:
+    /// with no way to ask, the answer is no, and the message says what supplies
+    /// one instead.
+    #[test]
+    fn no_terminal_declines_and_names_the_flag() {
+        let mut out = Vec::new();
+        assert!(!approve_adoption(
+            "work",
+            Some("acct-team"),
+            None,
+            false,
+            &mut out
+        ));
+        let printed = String::from_utf8(out).unwrap();
+        assert!(printed.contains("--allow-adopt"), "{printed}");
+    }
+
+    /// The refusal reports only what is known. Claiming a different account
+    /// would state the very thing the store could not establish.
+    #[test]
+    fn the_refusal_does_not_claim_a_different_account() {
+        let message = refusal("work", None).to_string();
+        assert!(
+            message.contains("does not record which account"),
+            "{message}"
+        );
+        assert!(!message.contains("different account"), "{message}");
+        assert!(
+            refusal("work", Some("acct-team"))
+                .to_string()
+                .contains("cannot be matched"),
+        );
+    }
+}

--- a/src/commands/adopt.rs
+++ b/src/commands/adopt.rs
@@ -103,7 +103,7 @@ fn describes(stored: Option<&str>) -> String {
         Some(stored) if stored.starts_with("uid:") || stored.starts_with("sub:") => {
             "records a login but no workspace, so it".to_string()
         }
-        Some(stored) => format!("holds {}, which", profile::short_workspace(stored)),
+        Some(stored) => format!("holds {}, which", profile::describe_claim(stored)),
         None => "does not record which account it holds, so it".to_string(),
     }
 }

--- a/src/commands/adopt.rs
+++ b/src/commands/adopt.rs
@@ -32,20 +32,25 @@ pub enum Approval {
 ///
 /// `stored` is what the profile is understood to hold, when it declares
 /// anything at all.
+///
+/// `interactive` and `input` are supplied rather than read from the process, so
+/// that a test can exercise the prompt without depending on whether the test
+/// runner happened to be started from a terminal — which decides, for a global
+/// `stdin().is_terminal()`, between passing and blocking the whole suite.
 pub fn approve_adoption(
     alias: &str,
     stored: Option<&str>,
     arriving: Option<&str>,
     assume_yes: bool,
+    interactive: bool,
+    input: &mut impl std::io::BufRead,
     out: &mut impl std::io::Write,
 ) -> Approval {
-    use std::io::IsTerminal;
-
     if assume_yes {
         let _ = writeln!(out, "codexctl: replacing the profile saved as {alias}");
         return Approval::Granted;
     }
-    if !std::io::stdin().is_terminal() {
+    if !interactive {
         return Approval::NoTerminal;
     }
 
@@ -61,13 +66,24 @@ pub fn approve_adoption(
     let _ = out.flush();
 
     let mut answer = String::new();
-    if std::io::stdin().read_line(&mut answer).is_err() {
+    if input.read_line(&mut answer).is_err() {
         return Approval::Declined;
     }
     match answer.trim().to_ascii_lowercase().as_str() {
         "y" | "yes" => Approval::Granted,
         _ => Approval::Declined,
     }
+}
+
+/// Exactly what a profile directory currently stores, if anything readable.
+///
+/// The raw bytes rather than one parsed field: a refresh can rotate the refresh
+/// token while the access token stays put, and an approval given for the old
+/// credential must not be honoured against the new one. Two distinct tokens can
+/// also describe themselves identically — same login, no workspace — so
+/// comparing descriptions is not enough to tell them apart.
+pub fn stored_credentials(dir: &std::path::Path) -> Option<Vec<u8>> {
+    std::fs::read(dir.join("auth.json")).ok()
 }
 
 /// What a profile is known to hold, phrased for an operator.
@@ -104,14 +120,39 @@ mod tests {
 
     /// The flag is the operator's answer given ahead of time, so it needs no
     /// terminal — that is the whole point of having one.
+    /// Drive the prompt with a fixed answer and no terminal question begged.
+    fn ask(assume_yes: bool, interactive: bool, answer: &str) -> (Approval, String) {
+        let mut input = std::io::Cursor::new(answer.as_bytes().to_vec());
+        let mut out = Vec::new();
+        let approval = approve_adoption(
+            "work",
+            None,
+            Some("acct-team"),
+            assume_yes,
+            interactive,
+            &mut input,
+            &mut out,
+        );
+        (approval, String::from_utf8(out).unwrap())
+    }
+
     #[test]
     fn the_flag_answers_without_a_terminal() {
-        let mut out = Vec::new();
-        assert_eq!(
-            approve_adoption("work", None, Some("acct-team"), true, &mut out),
-            Approval::Granted
-        );
-        assert!(String::from_utf8(out).unwrap().contains("work"));
+        let (approval, printed) = ask(true, false, "");
+        assert_eq!(approval, Approval::Granted);
+        assert!(printed.contains("work"), "{printed}");
+    }
+
+    /// Only an explicit yes is a yes. Anything else, empty input included,
+    /// leaves the profile alone.
+    #[test]
+    fn only_an_explicit_yes_approves() {
+        for answer in ["y\n", "Y\n", "yes\n"] {
+            assert_eq!(ask(false, true, answer).0, Approval::Granted, "{answer:?}");
+        }
+        for answer in ["n\n", "\n", "", "no\n", "sure\n"] {
+            assert_eq!(ask(false, true, answer).0, Approval::Declined, "{answer:?}");
+        }
     }
 
     /// Tests have no terminal, which is exactly the condition being checked.
@@ -119,11 +160,8 @@ mod tests {
     /// treat it as the operator saying no.
     #[test]
     fn no_terminal_is_distinct_from_a_decline() {
-        let mut out = Vec::new();
-        assert_eq!(
-            approve_adoption("work", Some("acct-team"), None, false, &mut out),
-            Approval::NoTerminal
-        );
+        assert_eq!(ask(false, false, "").0, Approval::NoTerminal);
+        assert_eq!(ask(false, true, "n\n").0, Approval::Declined);
     }
 
     /// The refusal reports only what is known. Claiming a different account

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -3491,9 +3491,8 @@ mod tests {
         .unwrap();
         let meta = profile::Meta {
             alias: alias.to_string(),
-            email: None,
-            plan: None,
             saved_at: "2026-01-01T00:00:00Z".to_string(),
+            ..profile::Meta::default()
         };
         std::fs::write(
             dir.join("meta.json"),

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+
+use crate::commands::alias;
+use crate::config;
+use crate::profile;
+
+/// Set or clear a profile's display label.
+///
+/// The label is display text only. It never selects a profile, so it carries no
+/// uniqueness rule — two accounts may both read `team` without creating a name
+/// that cannot be resolved.
+pub fn run(alias_arg: &str, label: Option<&str>) -> Result<()> {
+    let alias = alias::required(alias_arg)?;
+    let paths = config::default_paths()?;
+    profile::set_label_from(&paths, alias, label)?;
+
+    match profile::get_profile_from(&paths, alias)?.meta.label {
+        Some(label) => println!("labeled '{alias}' as {label}"),
+        None => println!("cleared the label on '{alias}'"),
+    }
+    Ok(())
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use comfy_table::{Cell, Color, Table, presets::UTF8_FULL_CONDENSED};
 
 use crate::profile;
 
@@ -10,27 +11,107 @@ pub fn run() -> Result<()> {
     }
 
     let active = profile::get_active()?;
+    // Carry the label column only when something fills it, so a store with no
+    // labels renders exactly as it did before the column existed.
+    let show_labels = profiles.iter().any(|p| p.meta.label.is_some());
 
-    let max_len = profiles
-        .iter()
-        .map(|p| p.meta.alias.len())
-        .max()
-        .unwrap_or(0);
-
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL_CONDENSED);
+    table.set_header(headers(show_labels));
     for p in &profiles {
-        let marker = if active.as_deref() == Some(&p.meta.alias) {
-            "  *"
-        } else {
-            ""
-        };
-        let plan = p.meta.plan.as_deref().unwrap_or("-");
-        println!(
-            "  {:<width$}  [{}]{}",
-            p.meta.alias,
-            plan,
-            marker,
-            width = max_len
+        let is_active = active.as_deref() == Some(&p.meta.alias);
+        table.add_row(row(p, show_labels, is_active));
+    }
+    println!("{table}");
+    Ok(())
+}
+
+fn headers(show_labels: bool) -> Vec<&'static str> {
+    let mut headers = vec!["Account"];
+    if show_labels {
+        headers.push("Label");
+    }
+    headers.extend(["Plan", "Email", "Active"]);
+    headers
+}
+
+fn row(p: &profile::Profile, show_labels: bool, is_active: bool) -> Vec<Cell> {
+    let mut row = vec![Cell::new(&p.meta.alias)];
+    if show_labels {
+        row.push(label_cell(p.meta.label.as_deref()));
+    }
+    row.push(Cell::new(p.meta.plan.as_deref().unwrap_or("-")));
+    row.push(Cell::new(p.meta.email.as_deref().unwrap_or("-")));
+    row.push(active_cell(is_active));
+    row
+}
+
+/// Cyan marks the two cells that answer "which account is this" — the label the
+/// operator chose, and which row is live. Everything else stays uncolored so
+/// color keeps meaning something.
+fn label_cell(label: Option<&str>) -> Cell {
+    match label {
+        Some(label) => Cell::new(label).fg(Color::Cyan),
+        None => Cell::new("-"),
+    }
+}
+
+fn active_cell(is_active: bool) -> Cell {
+    if is_active {
+        Cell::new("*").fg(Color::Cyan)
+    } else {
+        Cell::new("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headers_gain_a_label_column_only_when_labels_exist() {
+        assert_eq!(headers(false), vec!["Account", "Plan", "Email", "Active"]);
+        assert_eq!(
+            headers(true),
+            vec!["Account", "Label", "Plan", "Email", "Active"]
         );
     }
-    Ok(())
+
+    fn profile_with(alias: &str, label: Option<&str>) -> profile::Profile {
+        profile::Profile {
+            meta: profile::Meta {
+                alias: alias.to_string(),
+                label: label.map(str::to_string),
+                email: Some("amir@sawmills.ai".to_string()),
+                plan: Some("pro".to_string()),
+                saved_at: "2026-01-01T00:00:00Z".to_string(),
+                ..profile::Meta::default()
+            },
+            dir: std::path::PathBuf::from("/tmp").join(alias),
+        }
+    }
+
+    /// Every row must have the same width as the header or the table breaks.
+    #[test]
+    fn rows_match_the_header_width_in_both_shapes() {
+        for show_labels in [false, true] {
+            let labeled = profile_with("amir-team", Some("team"));
+            let bare = profile_with("amir@sawmills.ai", None);
+            assert_eq!(
+                row(&labeled, show_labels, true).len(),
+                headers(show_labels).len()
+            );
+            assert_eq!(
+                row(&bare, show_labels, false).len(),
+                headers(show_labels).len()
+            );
+        }
+    }
+
+    #[test]
+    fn an_unlabeled_profile_renders_a_placeholder_in_a_labeled_table() {
+        let bare = profile_with("amir@sawmills.ai", None);
+
+        assert_eq!(row(&bare, true, false)[1].content(), "-");
+    }
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 
+use crate::api;
 use crate::commands::{alias, status};
 use crate::config::{self, Paths};
 use crate::profile;
@@ -64,6 +65,27 @@ fn run_from(
         let auth_path = codex_home.join("auth.json");
         if !auth_path.exists() {
             bail!("codex login did not create {}", auth_path.display());
+        }
+
+        // The incoming account is only knowable once the login has produced a
+        // token, so this is checked here rather than up front. Refusing costs a
+        // repeated login; not refusing costs the other account's credentials.
+        let incoming = api::read_auth_json(&auth_path)
+            .ok()
+            .and_then(|auth| auth.account_id);
+        if let Some(stored) = profile::conflicting_workspace(paths, alias, incoming.as_deref()) {
+            // `conflicting_workspace` only reports a conflict when it saw an
+            // incoming workspace, so the empty fallback is unreachable here.
+            let arriving = incoming
+                .as_deref()
+                .map(profile::short_workspace)
+                .unwrap_or_default();
+            bail!(
+                "profile '{alias}' holds a different account \
+                 (stored workspace {}, this login {arriving}). \
+                 Log in under another alias so both stay saved.",
+                profile::short_workspace(&stored)
+            );
         }
 
         let email = email_from_alias(alias);
@@ -168,6 +190,16 @@ mod tests {
             )?;
             bail!("simulated login failure")
         }
+    }
+
+    /// Unsigned JWT declaring a workspace. Synthetic claims only.
+    fn synthetic_token(account_id: &str) -> String {
+        use base64::Engine;
+        let claims = format!(
+            r#"{{"sub":"seatA","https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}"}}}}"#
+        );
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        format!("eyJhbGciOiJub25lIn0.{payload}.sig")
     }
 
     fn setup_test_env() -> (tempfile::TempDir, Paths) {
@@ -290,6 +322,68 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// Logging a second workspace into an alias that already holds another
+    /// account must not replace its stored credentials. `save` already refuses
+    /// this; `login` reaches the same store by a different path.
+    #[test]
+    fn run_from_refuses_to_overwrite_a_profile_holding_a_different_account() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(
+            paths
+                .profiles_dir()
+                .join("amir@sawmills.ai")
+                .join("auth.json"),
+        )
+        .unwrap();
+        assert!(kept.contains(&stored), "stored credentials were replaced");
+        assert!(!kept.contains(&incoming));
+    }
+
+    /// Re-logging the same account into its own alias is the normal refresh
+    /// path and must keep working.
+    #[test]
+    fn run_from_allows_relogin_of_the_same_account() {
+        let (_tmp, paths) = setup_test_env();
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{}"}}"#, synthetic_token("acct-team")),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        let refreshed = format!("{}x", synthetic_token("acct-team"));
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        run_from(&paths, "team", None, &mut runner).unwrap();
+
+        let saved =
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json")).unwrap();
+        assert!(saved.contains(&refreshed));
     }
 
     /// A bad label must cost nothing. Failing after the device-auth flow would

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -38,10 +38,7 @@ pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
     let alias = alias::required(alias)?;
     let paths = config::default_paths()?;
     let mut runner = CodexCliLoginRunner;
-    run_from(&paths, alias, &mut runner)?;
-    if let Some(label) = label {
-        profile::set_label_from(&paths, alias, Some(label))?;
-    }
+    run_from(&paths, alias, label, &mut runner)?;
 
     println!("logged in and saved profile '{alias}'");
     println!();
@@ -49,8 +46,17 @@ pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn run_from(paths: &Paths, alias: &str, runner: &mut impl CodexLoginRunner) -> Result<()> {
+fn run_from(
+    paths: &Paths,
+    alias: &str,
+    label: Option<&str>,
+    runner: &mut impl CodexLoginRunner,
+) -> Result<()> {
     let alias = alias::required(alias)?;
+    // Validate before the device-auth flow starts. Failing after the operator
+    // completed a browser login would read as a failed login even though the
+    // profile was saved and made active.
+    label.map(store::validate_label).transpose()?;
     let codex_home = create_isolated_login_home(paths, alias)?;
     let result = (|| {
         runner.run_codex_login(&codex_home)?;
@@ -61,7 +67,11 @@ fn run_from(paths: &Paths, alias: &str, runner: &mut impl CodexLoginRunner) -> R
         }
 
         let email = email_from_alias(alias);
-        profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)
+        profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)?;
+        if let Some(label) = label {
+            profile::set_label_from(paths, alias, Some(label))?;
+        }
+        Ok(())
     })();
     let cleanup = remove_isolated_login_home(&codex_home);
 
@@ -224,7 +234,7 @@ mod tests {
         let (_tmp, paths) = setup_test_env();
         let mut runner = FakeLoginRunner::new(r#"{"access_token":"new_tok"}"#);
 
-        run_from(&paths, "  amir+8@sawmills.ai  ", &mut runner).unwrap();
+        run_from(&paths, "  amir+8@sawmills.ai  ", None, &mut runner).unwrap();
 
         let seen_home = runner.seen_home.as_deref().unwrap();
         assert_eq!(
@@ -266,7 +276,7 @@ mod tests {
         .unwrap();
         let mut runner = FakeLoginRunner::new(r#"{"access_token":"new_active_tok"}"#);
 
-        run_from(&paths, "amir+8@sawmills.ai", &mut runner).unwrap();
+        run_from(&paths, "amir+8@sawmills.ai", None, &mut runner).unwrap();
 
         let saved = std::fs::read_to_string(
             paths
@@ -282,12 +292,49 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// A bad label must cost nothing. Failing after the device-auth flow would
+    /// make a completed login read as a failure.
+    #[test]
+    fn run_from_rejects_an_invalid_label_before_running_login() {
+        let (_tmp, paths) = setup_test_env();
+        let mut runner = FakeLoginRunner::new(r#"{"access_token":"new_tok"}"#);
+
+        let error = run_from(
+            &paths,
+            "amir+8@sawmills.ai",
+            Some("two\nlines"),
+            &mut runner,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("label"), "{error}");
+        assert!(runner.seen_home.is_none(), "login ran anyway");
+        assert!(!paths.profiles_dir().join("amir+8@sawmills.ai").exists());
+    }
+
+    #[test]
+    fn run_from_stores_a_valid_label() {
+        let (_tmp, paths) = setup_test_env();
+        let mut runner = FakeLoginRunner::new(r#"{"access_token":"new_tok"}"#);
+
+        run_from(&paths, "amir-team", Some("  team  "), &mut runner).unwrap();
+
+        assert_eq!(
+            profile::get_profile_from(&paths, "amir-team")
+                .unwrap()
+                .meta
+                .label
+                .as_deref(),
+            Some("team")
+        );
+    }
+
     #[test]
     fn run_from_removes_isolated_home_after_login_failure() {
         let (_tmp, paths) = setup_test_env();
         let mut runner = FailingLoginRunner::default();
 
-        let error = run_from(&paths, "amir+8@sawmills.ai", &mut runner).unwrap_err();
+        let error = run_from(&paths, "amir+8@sawmills.ai", None, &mut runner).unwrap_err();
 
         assert!(error.to_string().contains("simulated login failure"));
         assert!(!runner.seen_home.unwrap().exists());

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -39,11 +39,12 @@ pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
     let alias = alias::required(alias)?;
     let paths = config::default_paths()?;
     let mut runner = CodexCliLoginRunner;
-    run_from(&paths, alias, label, &mut runner)?;
+    // The alias actually written may be label-qualified, so report that one.
+    let saved = run_from(&paths, alias, label, &mut runner)?;
 
-    println!("logged in and saved profile '{alias}'");
+    println!("logged in and saved profile '{saved}'");
     println!();
-    status::run_focused(alias)?;
+    status::run_focused(&saved)?;
     Ok(())
 }
 
@@ -52,7 +53,7 @@ fn run_from(
     alias: &str,
     label: Option<&str>,
     runner: &mut impl CodexLoginRunner,
-) -> Result<()> {
+) -> Result<String> {
     let alias = alias::required(alias)?;
     // Validate before the device-auth flow starts. Failing after the operator
     // completed a browser login would read as a failed login even though the
@@ -68,43 +69,96 @@ fn run_from(
         }
 
         // The incoming account is only knowable once the login has produced a
-        // token, so this is checked here rather than up front. Refusing costs a
-        // repeated login; not refusing costs the other account's credentials.
+        // token, so the target alias is resolved here rather than up front.
         let incoming = api::read_auth_json(&auth_path)
             .ok()
             .and_then(|auth| auth.account_id);
-        if let Some(stored) = profile::conflicting_workspace(paths, alias, incoming.as_deref()) {
-            // `conflicting_workspace` only reports a conflict when it saw an
-            // incoming workspace, so the empty fallback is unreachable here.
-            let arriving = incoming
-                .as_deref()
-                .map(profile::short_workspace)
-                .unwrap_or_default();
-            bail!(
-                "profile '{alias}' holds a different account \
-                 (stored workspace {}, this login {arriving}). \
-                 Log in under another alias so both stay saved.",
-                profile::short_workspace(&stored)
-            );
-        }
+        let target = resolve_target_alias(paths, alias, label, incoming.as_deref())?;
 
-        let email = email_from_alias(alias);
-        profile::save_profile_and_activate_to(paths, alias, email.as_deref(), &auth_path)?;
+        let email = email_from_alias(&target).or_else(|| email_from_alias(alias));
+        profile::save_profile_and_activate_to(paths, &target, email.as_deref(), &auth_path)?;
         if let Some(label) = label {
-            profile::set_label_from(paths, alias, Some(label))?;
+            profile::set_label_from(paths, &target, Some(label))?;
         }
-        Ok(())
+        Ok(target)
     })();
     let cleanup = remove_isolated_login_home(&codex_home);
 
     match (result, cleanup) {
-        (Ok(()), Ok(())) => Ok(()),
+        (Ok(saved), Ok(())) => Ok(saved),
         (Err(error), Ok(())) => Err(error),
-        (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
+        (Ok(_), Err(cleanup_error)) => Err(cleanup_error),
         (Err(error), Err(cleanup_error)) => Err(error.context(format!(
             "also failed to remove isolated login home: {cleanup_error:#}"
         ))),
     }
+}
+
+/// Where this login should land.
+///
+/// The requested alias wins whenever it is free or already holds this same
+/// account. When it holds a *different* account the label qualifies it, so a
+/// second seat on one address lands beside the first rather than replacing it.
+/// Without a label there is nothing to qualify with, so the login is refused
+/// rather than allowed to overwrite.
+fn resolve_target_alias(
+    paths: &Paths,
+    alias: &str,
+    label: Option<&str>,
+    incoming_account: Option<&str>,
+) -> Result<String> {
+    let Some(stored) = profile::conflicting_workspace(paths, alias, incoming_account) else {
+        return Ok(alias.to_string());
+    };
+    let arriving = incoming_account
+        .map(profile::short_workspace)
+        .unwrap_or_default();
+
+    let Some(label) = label else {
+        bail!(
+            "profile '{alias}' holds a different account \
+             (stored workspace {}, this login {arriving}). \
+             Re-run with --label <name> to save it alongside, \
+             or choose another alias.",
+            profile::short_workspace(&stored)
+        );
+    };
+
+    let slug = alias_safe(label);
+    if slug.is_empty() {
+        bail!("label '{label}' has no characters usable in an alias; choose another alias");
+    }
+    let qualified = format!("{alias}+{slug}");
+    store::validate_alias(&qualified).with_context(|| {
+        format!("label '{label}' does not produce a usable alias for '{alias}'")
+    })?;
+
+    if let Some(also_taken) = profile::conflicting_workspace(paths, &qualified, incoming_account) {
+        bail!(
+            "'{alias}' and '{qualified}' both hold other accounts \
+             ({} and {}, this login {arriving}). Choose another alias.",
+            profile::short_workspace(&stored),
+            profile::short_workspace(&also_taken)
+        );
+    }
+    Ok(qualified)
+}
+
+/// Reduce a display label to something usable as one path component.
+///
+/// Labels permit spaces and path syntax that an alias cannot carry, so anything
+/// outside a conservative set collapses to `-`.
+fn alias_safe(label: &str) -> String {
+    let mut out = String::with_capacity(label.len());
+    for character in label.trim().chars() {
+        let keep = character.is_ascii_alphanumeric() || matches!(character, '_' | '.' | '-');
+        match (keep, out.ends_with('-')) {
+            (true, _) => out.push(character.to_ascii_lowercase()),
+            (false, false) => out.push('-'),
+            (false, true) => {}
+        }
+    }
+    out.trim_matches(['-', '.']).to_string()
 }
 
 fn create_isolated_login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
@@ -362,6 +416,94 @@ mod tests {
         .unwrap();
         assert!(kept.contains(&stored), "stored credentials were replaced");
         assert!(!kept.contains(&incoming));
+    }
+
+    fn save_existing(paths: &Paths, alias: &str, account: &str) {
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{}"}}"#, synthetic_token(account)),
+        )
+        .unwrap();
+        profile::save_profile_to(paths, alias, None, &paths.codex_auth_json().clone()).unwrap();
+    }
+
+    fn stored_auth(paths: &Paths, alias: &str) -> String {
+        std::fs::read_to_string(paths.profiles_dir().join(alias).join("auth.json")).unwrap()
+    }
+
+    /// The email names the account; the label separates its seats. A second
+    /// workspace on one address lands beside the first instead of on top of it.
+    #[test]
+    fn run_from_derives_an_alias_from_the_label_when_the_alias_holds_another_account() {
+        let (_tmp, paths) = setup_test_env();
+        save_existing(&paths, "amir@sawmills.ai", "acct-personal");
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let saved = run_from(&paths, "amir@sawmills.ai", Some("work"), &mut runner).unwrap();
+
+        assert_eq!(saved, "amir@sawmills.ai+work");
+        assert!(stored_auth(&paths, "amir@sawmills.ai+work").contains(&incoming));
+        assert!(
+            !stored_auth(&paths, "amir@sawmills.ai").contains(&incoming),
+            "the first account was overwritten"
+        );
+    }
+
+    /// Logging the same seat again refreshes the alias the label already
+    /// produced, rather than inventing another one.
+    #[test]
+    fn run_from_refreshes_the_derived_alias_on_a_later_login() {
+        let (_tmp, paths) = setup_test_env();
+        save_existing(&paths, "amir@sawmills.ai", "acct-personal");
+        save_existing(&paths, "amir@sawmills.ai+work", "acct-team");
+
+        let refreshed = format!("{}refreshed", synthetic_token("acct-team"));
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let saved = run_from(&paths, "amir@sawmills.ai", Some("work"), &mut runner).unwrap();
+
+        assert_eq!(saved, "amir@sawmills.ai+work");
+        assert!(stored_auth(&paths, "amir@sawmills.ai+work").contains(&refreshed));
+    }
+
+    /// A label is display text and may hold characters an alias cannot.
+    #[test]
+    fn run_from_makes_a_label_alias_safe_before_deriving() {
+        let (_tmp, paths) = setup_test_env();
+        save_existing(&paths, "amir@sawmills.ai", "acct-personal");
+
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{}"}}"#,
+            synthetic_token("acct-team")
+        ));
+
+        let saved = run_from(&paths, "amir@sawmills.ai", Some("Team / Prod"), &mut runner).unwrap();
+
+        assert_eq!(saved, "amir@sawmills.ai+team-prod");
+    }
+
+    /// Both the requested alias and the derived one already hold other
+    /// accounts, so there is no safe place to land.
+    #[test]
+    fn run_from_refuses_when_the_derived_alias_also_holds_another_account() {
+        let (_tmp, paths) = setup_test_env();
+        save_existing(&paths, "amir@sawmills.ai", "acct-personal");
+        save_existing(&paths, "amir@sawmills.ai+work", "acct-other");
+
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{}"}}"#,
+            synthetic_token("acct-team")
+        ));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("work"), &mut runner).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("both hold other accounts"), "{message}");
+        // Both candidate aliases must be named so the operator knows what to avoid.
+        assert!(message.contains("amir@sawmills.ai+work"), "{message}");
+        assert!(!stored_auth(&paths, "amir@sawmills.ai+work").contains("acct-team"));
     }
 
     /// Re-logging the same account into its own alias is the normal refresh

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -386,6 +386,39 @@ mod tests {
         assert!(saved.contains(&refreshed));
     }
 
+    /// An unreadable stored token is a likely reason to re-run login, so it
+    /// must not be the reason the fresh login is discarded. Capture may never
+    /// route the stale live file back over the alias being written.
+    #[test]
+    fn run_from_keeps_the_new_login_when_the_stored_auth_is_unreadable() {
+        let (_tmp, paths) = setup_test_env();
+        let live = synthetic_token("acct-team");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{live}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+        profile::set_active_from(&paths, "team").unwrap();
+        // Corrupt the stored token, which is what sends an operator back to login.
+        std::fs::write(
+            paths.profiles_dir().join("team").join("auth.json"),
+            "{ not json",
+        )
+        .unwrap();
+
+        let fresh = format!("{}fresh", synthetic_token("acct-team"));
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{fresh}"}}"#));
+
+        run_from(&paths, "team", None, &mut runner).unwrap();
+
+        let saved =
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json")).unwrap();
+        assert!(saved.contains(&fresh), "fresh login was discarded");
+        let installed = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
+        assert!(installed.contains(&fresh), "stale token was reinstalled");
+    }
+
     /// A bad label must cost nothing. Failing after the device-auth flow would
     /// make a completed login read as a failure.
     #[test]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -34,11 +34,14 @@ impl CodexLoginRunner for CodexCliLoginRunner {
     }
 }
 
-pub fn run(alias: &str) -> Result<()> {
+pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
     let alias = alias::required(alias)?;
     let paths = config::default_paths()?;
     let mut runner = CodexCliLoginRunner;
     run_from(&paths, alias, &mut runner)?;
+    if let Some(label) = label {
+        profile::set_label_from(&paths, alias, Some(label))?;
+    }
 
     println!("logged in and saved profile '{alias}'");
     println!();
@@ -103,6 +106,9 @@ fn remove_isolated_login_home(codex_home: &Path) -> Result<()> {
         .with_context(|| format!("failed to remove {}", codex_home.display()))
 }
 
+/// Fallback address only. The saved profile prefers the token's own profile
+/// claim, so this matters solely for a token that carries no claim at all —
+/// where an alias that looks like an address is the best guess available.
 fn email_from_alias(alias: &str) -> Option<String> {
     if alias.contains('@') {
         Some(alias.to_string())

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -73,12 +73,22 @@ fn run_from(
         let incoming = api::read_auth_json(&auth_path)
             .ok()
             .and_then(|auth| auth.account_id);
+        // Resolve and write under one lock. Which alias this login lands on is
+        // read out of the store, so releasing the lock in between would let a
+        // concurrent login change the answer before the write lands.
+        let lock = store::lock(paths)?;
         let target = resolve_target_alias(paths, alias, label, incoming.as_deref())?;
 
         let email = email_from_alias(&target).or_else(|| email_from_alias(alias));
-        profile::save_profile_and_activate_to(paths, &target, email.as_deref(), &auth_path)?;
+        profile::save_profile_and_activate_locked(
+            &lock,
+            paths,
+            &target,
+            email.as_deref(),
+            &auth_path,
+        )?;
         if let Some(label) = label {
-            profile::set_label_from(paths, &target, Some(label))?;
+            profile::set_label_locked(&lock, paths, &target, Some(label))?;
         }
         Ok(target)
     })();
@@ -376,6 +386,47 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A token that declares no workspace cannot prove it belongs to the seat
+    /// already stored, so it must not be allowed to write over it. Treating
+    /// "no claim" as "same account" is what let a second seat replace the
+    /// first's credentials.
+    #[test]
+    fn run_from_refuses_a_claimless_login_against_a_stored_workspace() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-team");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // No `chatgpt_account_id` claim at all.
+        let claimless = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{claimless}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(
+            paths
+                .profiles_dir()
+                .join("amir@sawmills.ai")
+                .join("auth.json"),
+        )
+        .unwrap();
+        assert!(kept.contains(&stored), "stored credentials were replaced");
     }
 
     /// Logging a second workspace into an alias that already holds another

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -139,13 +139,22 @@ fn resolve_target_alias(
         // still be saved under a label-derived alias from an earlier run — and
         // saving it here too would fork one account across two profiles, which
         // is what makes ownership ambiguous later.
-        if label.is_some()
-            && let profile::ExistingSeat::One(existing) =
-                profile::existing_seat(paths, incoming_account, incoming_user)
-                    .context("could not check whether this account is already saved")?
-            && existing != alias
-        {
-            return Ok(existing);
+        if label.is_some() {
+            match profile::existing_seat(paths, incoming_account, incoming_user)
+                .context("could not check whether this account is already saved")?
+            {
+                profile::ExistingSeat::One(existing) if existing != alias => {
+                    return Ok(existing);
+                }
+                // Already ambiguous. A free alias is room for a third copy, not
+                // permission to make one.
+                profile::ExistingSeat::Ambiguous(aliases) => bail!(
+                    "this account is already saved under more than one alias ({}). \
+                     Remove the duplicates, or log in with one of them directly.",
+                    aliases.join(", ")
+                ),
+                _ => {}
+            }
         }
         return Ok(alias.to_string());
     };
@@ -584,6 +593,32 @@ mod tests {
         );
         assert!(
             !paths.profiles_dir().join("amir@sawmills.ai+team").exists(),
+            "a third copy of one account was created"
+        );
+    }
+
+    /// A free alias is room for a third copy, not permission to make one: if a
+    /// seat is already saved twice, the store is ambiguous and adding to it is
+    /// what stops tokens being attributed at all.
+    #[test]
+    fn run_from_refuses_an_ambiguous_seat_even_when_the_base_alias_is_free() {
+        let (_tmp, paths) = setup_test_env();
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+work", None, &source).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+old", None, &source).unwrap();
+
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{team}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("more than one alias"),
+            "unhelpful refusal: {error}"
+        );
+        assert!(
+            !paths.profiles_dir().join("amir@sawmills.ai").exists(),
             "a third copy of one account was created"
         );
     }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -435,6 +435,52 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// The headline case, from the other side: a legacy profile whose stored
+    /// token declares no workspace, and its own owner signing into a second
+    /// one. The logins match, so a rule that reads "stored declares nothing" as
+    /// "same account" hands the personal profile to the team seat.
+    #[test]
+    fn run_from_refuses_a_second_workspace_for_one_login_on_a_claimless_profile() {
+        let (_tmp, paths) = setup_test_env();
+        // Stored: a readable token with a subject but no workspace claim.
+        let legacy = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{legacy}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The same human, now authenticating into a workspace.
+        use base64::Engine;
+        let claims =
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#;
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        let incoming = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(
+            paths
+                .profiles_dir()
+                .join("amir@sawmills.ai")
+                .join("auth.json"),
+        )
+        .unwrap();
+        assert!(kept.contains(legacy), "the legacy profile was overwritten");
+    }
+
     /// Two aliases already holding one account is an ambiguous store. Deriving
     /// a third copy would deepen exactly the ambiguity that later stops tokens
     /// being attributed at all, so the login stops and says so.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -138,13 +138,6 @@ fn resolve_target_alias(
     else {
         return Ok(alias.to_string());
     };
-    // The requested alias holds someone else, but this seat may already be
-    // saved under another one. Refreshing that profile keeps a re-login stable
-    // and, more importantly, avoids a second profile for one account — which is
-    // exactly what makes ownership ambiguous later.
-    if let Some(existing) = profile::alias_for_account(paths, incoming_account, incoming_user) {
-        return Ok(existing);
-    }
     let arriving = incoming_account
         .map(profile::short_workspace)
         .unwrap_or_default();
@@ -158,6 +151,22 @@ fn resolve_target_alias(
             profile::short_workspace(&stored)
         );
     };
+
+    // About to derive an alias — but this seat may already be saved under
+    // another one. Refreshing that profile keeps a re-login stable and avoids a
+    // second profile for one account, which is what makes ownership ambiguous
+    // later. A store that cannot be scanned is not an answer of "no".
+    match profile::existing_seat(paths, incoming_account, incoming_user)
+        .context("could not check whether this account is already saved")?
+    {
+        profile::ExistingSeat::One(existing) => return Ok(existing),
+        profile::ExistingSeat::Ambiguous(aliases) => bail!(
+            "this account is already saved under more than one alias ({}). \
+             Remove the duplicates, or log in with one of them directly.",
+            aliases.join(", ")
+        ),
+        profile::ExistingSeat::None => {}
+    }
 
     let slug = alias_safe(label);
     if slug.is_empty() {
@@ -426,6 +435,47 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// Two aliases already holding one account is an ambiguous store. Deriving
+    /// a third copy would deepen exactly the ambiguity that later stops tokens
+    /// being attributed at all, so the login stops and says so.
+    #[test]
+    fn run_from_refuses_when_the_seat_is_already_saved_twice() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The same team seat saved under two aliases already.
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+work", None, &source).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+team-old", None, &source).unwrap();
+
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{team}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("more than one alias"),
+            "unhelpful refusal: {error}"
+        );
+        assert!(
+            !paths.profiles_dir().join("amir@sawmills.ai+team").exists(),
+            "a third copy of one account was created"
+        );
+    }
+
     /// A seat already saved under one label is refreshed, not duplicated, when
     /// the operator logs in again with a different one. Two profiles for one
     /// account are what make ownership ambiguous later.
@@ -567,9 +617,10 @@ mod tests {
 
         let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
 
+        let message = format!("{error:#}");
         assert!(
-            error.to_string().contains("cannot be identified"),
-            "unhelpful refusal: {error}"
+            message.contains("cannot be identified") || message.contains("already saved"),
+            "unhelpful refusal: {message}"
         );
         assert!(
             std::fs::read_to_string(dir.join("auth.json"))

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -138,6 +138,13 @@ fn resolve_target_alias(
     else {
         return Ok(alias.to_string());
     };
+    // The requested alias holds someone else, but this seat may already be
+    // saved under another one. Refreshing that profile keeps a re-login stable
+    // and, more importantly, avoids a second profile for one account — which is
+    // exactly what makes ownership ambiguous later.
+    if let Some(existing) = profile::alias_for_account(paths, incoming_account, incoming_user) {
+        return Ok(existing);
+    }
     let arriving = incoming_account
         .map(profile::short_workspace)
         .unwrap_or_default();
@@ -417,6 +424,43 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A seat already saved under one label is refreshed, not duplicated, when
+    /// the operator logs in again with a different one. Two profiles for one
+    /// account are what make ownership ambiguous later.
+    #[test]
+    fn run_from_reuses_an_existing_seat_when_the_label_changes() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The team seat is already saved under an earlier label.
+        let team = synthetic_token("acct-team");
+        let existing = paths.home.join("team-auth.json");
+        std::fs::write(&existing, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+work", None, &existing).unwrap();
+
+        // Same seat, new label.
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{team}"}}"#));
+        let target = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap();
+
+        assert_eq!(target, "amir@sawmills.ai+work", "the seat was duplicated");
+        assert!(
+            !paths.profiles_dir().join("amir@sawmills.ai+team").exists(),
+            "a second profile was created for one account"
+        );
     }
 
     /// Damaged metadata is not an empty profile. The stored token still proves

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -15,13 +15,16 @@ trait CodexLoginRunner {
     fn run_codex_login(&mut self, codex_home: &Path) -> Result<()>;
 
     /// Called once the store lock has been released and the operator is being
-    /// asked to approve replacing a profile.
+    /// asked to approve replacing the profile saved as `pending`.
     ///
     /// Nothing happens here in production; it exists because the window is real
     /// — the lock is down, and another process may write to the store before the
     /// answer arrives — and a guard against that window can only be tested by
-    /// something that can act inside it.
-    fn while_awaiting_approval(&mut self) {}
+    /// something that can act inside it. `pending` is the alias the question
+    /// names, so a test can also check that it is the alias actually written.
+    fn while_awaiting_approval(&mut self, pending: &str) {
+        let _ = pending;
+    }
 }
 
 struct CodexCliLoginRunner;
@@ -135,7 +138,7 @@ fn run_from_with_consent(
                 // without a timeout, so a question left unanswered would stall
                 // every other codexctl process, not just this one.
                 drop(lock);
-                runner.while_awaiting_approval();
+                runner.while_awaiting_approval(&pending);
                 // Either way nothing is saved, and the login has already
                 // happened — so neither outcome is a success.
                 match adopt::approve_adoption(
@@ -430,6 +433,8 @@ mod tests {
         /// Applied while the approval prompt is open, standing in for another
         /// process writing to the store.
         concurrent_write: Option<(PathBuf, String)>,
+        /// The alias the approval question named.
+        asked_about: Option<String>,
     }
 
     impl FakeLoginRunner {
@@ -438,6 +443,7 @@ mod tests {
                 auth_json: auth_json.to_string(),
                 seen_home: None,
                 concurrent_write: None,
+                asked_about: None,
             }
         }
 
@@ -455,7 +461,8 @@ mod tests {
             Ok(())
         }
 
-        fn while_awaiting_approval(&mut self) {
+        fn while_awaiting_approval(&mut self, pending: &str) {
+            self.asked_about = Some(pending.to_string());
             if let Some((path, contents)) = self.concurrent_write.take() {
                 std::fs::write(path, contents).unwrap();
             }
@@ -608,6 +615,64 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// The label path writes to an alias the operator did not type — it is
+    /// derived from the alias and the label together. That is acceptable only
+    /// while the question names the profile that is actually replaced, because
+    /// the announcement is the only thing tying the approval to its object.
+    /// Pin the two together so a refactor cannot let them drift apart.
+    #[test]
+    fn the_approval_names_the_profile_that_gets_written() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The derived alias holds a profile whose token cannot be read, so the
+        // login lands on the consent path rather than a plain write.
+        let dir = paths.profiles_dir().join("amir@sawmills.ai+team");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            r#"{"access_token":"opaque-not-a-jwt"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"amir@sawmills.ai+team","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let saved =
+            run_from_with_consent(&paths, "amir@sawmills.ai", Some("team"), true, &mut runner)
+                .unwrap();
+
+        assert_eq!(
+            runner.asked_about.as_deref(),
+            Some(saved.as_str()),
+            "the approval named a different profile than the one written"
+        );
+        assert_eq!(saved, "amir@sawmills.ai+team");
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains(&incoming),
+            "the approved login did not land on the alias it named"
+        );
     }
 
     /// A derived alias whose workspace is known but whose login is not does not

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -133,9 +133,20 @@ fn resolve_target_alias(
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
 ) -> Result<String> {
-    let Some(stored) =
-        profile::conflicting_workspace(paths, alias, incoming_account, incoming_user)
-    else {
+    let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
+    let Some(stored) = conflict else {
+        // The requested alias is usable. When a label was given, this seat may
+        // still be saved under a label-derived alias from an earlier run — and
+        // saving it here too would fork one account across two profiles, which
+        // is what makes ownership ambiguous later.
+        if label.is_some()
+            && let profile::ExistingSeat::One(existing) =
+                profile::existing_seat(paths, incoming_account, incoming_user)
+                    .context("could not check whether this account is already saved")?
+            && existing != alias
+        {
+            return Ok(existing);
+        }
         return Ok(alias.to_string());
     };
     let arriving = incoming_account
@@ -475,9 +486,12 @@ mod tests {
 
         let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
 
+        // Either guard may speak first — the workspace guard now refuses an
+        // unproven owner outright — but the credentials must survive.
+        let message = error.to_string();
         assert!(
-            error.to_string().contains("cannot be identified"),
-            "unhelpful refusal: {error}"
+            message.contains("cannot be identified") || message.contains("Choose another alias"),
+            "unhelpful refusal: {message}"
         );
         assert!(
             std::fs::read_to_string(dir.join("auth.json"))
@@ -571,6 +585,28 @@ mod tests {
         assert!(
             !paths.profiles_dir().join("amir@sawmills.ai+team").exists(),
             "a third copy of one account was created"
+        );
+    }
+
+    /// The base alias being free is not proof the seat is unsaved. Removing the
+    /// personal profile leaves the team seat under its label-derived alias, and
+    /// saving it again under the freed base alias would fork one account.
+    #[test]
+    fn run_from_reuses_an_existing_seat_when_the_base_alias_is_free() {
+        let (_tmp, paths) = setup_test_env();
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        // Only the label-derived alias exists; the base alias is free.
+        profile::save_profile_to(&paths, "amir@sawmills.ai+work", None, &source).unwrap();
+
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{team}"}}"#));
+        let target = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap();
+
+        assert_eq!(target, "amir@sawmills.ai+work", "the seat was forked");
+        assert!(
+            !paths.profiles_dir().join("amir@sawmills.ai").exists(),
+            "a second profile was created for one account"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1897,4 +1897,60 @@ mod tests {
         assert!(error.to_string().contains("simulated login failure"));
         assert!(!runner.seen_home.unwrap().exists());
     }
+    /// A legacy profile holding the very token that is live, where the live
+    /// copy declares a workspace the stored copy does not. Capture applies that
+    /// evidence — but only after a login has already chosen where to write, so
+    /// resolving without it made the profile invisible and the login landed
+    /// beside it. One account then existed twice, and every later lookup
+    /// reported it as ambiguous.
+    #[test]
+    fn run_from_does_not_duplicate_a_profile_the_live_file_identifies() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        // The stored token declares a login but no workspace.
+        let shared =
+            encode(r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_user_id":"user-a"}}"#);
+        let dir = paths.profiles_dir().join("legacy");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{shared}"}}"#),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"legacy","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+        // The live file holds that same token, with the workspace spelled out.
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+        )
+        .unwrap();
+
+        let incoming = encode(
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#,
+        );
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let saved =
+            run_from_with_consent(&paths, "legacy", Some("team"), true, &mut runner).unwrap();
+
+        assert_eq!(
+            saved, "legacy",
+            "the login landed beside the profile it owns"
+        );
+        let mut aliases: Vec<String> = std::fs::read_dir(paths.profiles_dir())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+        aliases.sort();
+        assert_eq!(aliases, vec!["legacy"], "one account was saved twice");
+    }
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -9,9 +9,19 @@ use crate::commands::{adopt, alias, status};
 use crate::config::{self, Paths};
 use crate::profile;
 use crate::store;
+use std::io::IsTerminal;
 
 trait CodexLoginRunner {
     fn run_codex_login(&mut self, codex_home: &Path) -> Result<()>;
+
+    /// Called once the store lock has been released and the operator is being
+    /// asked to approve replacing a profile.
+    ///
+    /// Nothing happens here in production; it exists because the window is real
+    /// — the lock is down, and another process may write to the store before the
+    /// answer arrives — and a guard against that window can only be tested by
+    /// something that can act inside it.
+    fn while_awaiting_approval(&mut self) {}
 }
 
 struct CodexCliLoginRunner;
@@ -114,10 +124,18 @@ fn run_from_with_consent(
                 alias: pending,
                 stored,
             } => {
+                // Read before the question is asked: these are the bytes the
+                // operator is agreeing to replace. The description alone cannot
+                // stand in for them — two claimless tokens for one login
+                // describe themselves identically.
+                let shown = store::profile_dir(paths, &pending)
+                    .ok()
+                    .and_then(|dir| adopt::stored_credentials(&dir));
                 // Never ask while holding the store lock: `store::lock` waits
                 // without a timeout, so a question left unanswered would stall
                 // every other codexctl process, not just this one.
                 drop(lock);
+                runner.while_awaiting_approval();
                 // Either way nothing is saved, and the login has already
                 // happened — so neither outcome is a success.
                 match adopt::approve_adoption(
@@ -125,6 +143,8 @@ fn run_from_with_consent(
                     stored.as_deref(),
                     incoming.as_deref(),
                     allow_adopt,
+                    std::io::stdin().is_terminal(),
+                    &mut std::io::stdin().lock(),
                     &mut std::io::stderr(),
                 ) {
                     adopt::Approval::Granted => {}
@@ -140,12 +160,16 @@ fn run_from_with_consent(
                 // under the new lock keeps it from being applied to whatever the
                 // store looks like now, which may be something nobody was asked
                 // about.
+                let unchanged = store::profile_dir(paths, &pending)
+                    .ok()
+                    .and_then(|dir| adopt::stored_credentials(&dir))
+                    == shown;
                 match resolve(&lock)? {
                     Resolution::Ready(target) => (lock, target),
                     Resolution::NeedsConsent {
                         alias: again,
                         stored: stored_again,
-                    } if again == pending && stored_again == stored => (lock, pending),
+                    } if again == pending && stored_again == stored && unchanged => (lock, pending),
                     Resolution::NeedsConsent { .. } => bail!(
                         "the store changed while waiting for an answer, so the approval no \
                          longer describes what would be replaced. Re-run the login."
@@ -403,6 +427,9 @@ mod tests {
     struct FakeLoginRunner {
         auth_json: String,
         seen_home: Option<PathBuf>,
+        /// Applied while the approval prompt is open, standing in for another
+        /// process writing to the store.
+        concurrent_write: Option<(PathBuf, String)>,
     }
 
     impl FakeLoginRunner {
@@ -410,7 +437,13 @@ mod tests {
             Self {
                 auth_json: auth_json.to_string(),
                 seen_home: None,
+                concurrent_write: None,
             }
+        }
+
+        fn writing_during_approval(mut self, path: PathBuf, contents: String) -> Self {
+            self.concurrent_write = Some((path, contents));
+            self
         }
     }
 
@@ -420,6 +453,12 @@ mod tests {
             std::fs::create_dir_all(codex_home)?;
             std::fs::write(codex_home.join("auth.json"), &self.auth_json)?;
             Ok(())
+        }
+
+        fn while_awaiting_approval(&mut self) {
+            if let Some((path, contents)) = self.concurrent_write.take() {
+                std::fs::write(path, contents).unwrap();
+            }
         }
     }
 
@@ -623,6 +662,61 @@ mod tests {
                 .unwrap()
                 .contains("opaque-not-a-jwt"),
             "the derived alias was overwritten"
+        );
+    }
+
+    /// The approval names one specific credential, and the lock is down while
+    /// the operator answers. Another process replacing the profile in that
+    /// window produces a profile that still *describes* itself identically —
+    /// same login, still no workspace — so nothing but the stored bytes can tell
+    /// the two apart. The approval must not carry over to the new one.
+    #[test]
+    fn an_approval_does_not_survive_a_concurrent_replacement() {
+        let (_tmp, paths) = setup_test_env();
+        let legacy = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{legacy}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // A different credential that describes itself exactly as the first
+        // does: same login claim, still no workspace.
+        let usurper = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSIsImp0aSI6Im90aGVyIn0.sig";
+        let profile_auth = paths
+            .profiles_dir()
+            .join("amir@sawmills.ai")
+            .join("auth.json");
+
+        use base64::Engine;
+        let claims =
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#;
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        let incoming = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#))
+            .writing_during_approval(
+                profile_auth.clone(),
+                format!(r#"{{"access_token":"{usurper}"}}"#),
+            );
+
+        let error =
+            run_from_with_consent(&paths, "amir@sawmills.ai", None, true, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("changed while waiting"),
+            "approval was reused after the profile changed: {error}"
+        );
+        let kept = std::fs::read_to_string(&profile_auth).unwrap();
+        assert!(
+            kept.contains(usurper),
+            "a credential nobody approved replacing was overwritten"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -101,13 +101,20 @@ fn run_from_with_consent(
         // token, so the target alias is resolved here rather than up front.
         // Workspace and login together: a team workspace is shared, so it
         // does not by itself say whose credentials these are.
-        let incoming_identity = api::read_auth_json(&auth_path).ok();
-        let incoming = incoming_identity
-            .as_ref()
-            .and_then(|a| a.account_id.clone());
-        let incoming_user = incoming_identity
-            .as_ref()
-            .and_then(|a| api::token_login(&a.access_token));
+        //
+        // A file that will not parse is a failed login, not a login by an
+        // account that happens to declare nothing. Read as the latter, its empty
+        // identity would agree with any profile that also declares nothing, and
+        // the broken file would be copied over that profile and made active —
+        // destroying a working credential and the live one together.
+        let incoming_identity = api::read_auth_json(&auth_path).with_context(|| {
+            format!(
+                "codex login wrote credentials that cannot be read at {}",
+                auth_path.display()
+            )
+        })?;
+        let incoming = incoming_identity.account_id.clone();
+        let incoming_user = api::token_login(&incoming_identity.access_token);
         // Resolve and write under one lock. Which alias this login lands on is
         // read out of the store, so releasing the lock in between would let a
         // concurrent login change the answer before the write lands.
@@ -615,6 +622,59 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A login that produced an unreadable `auth.json` is a failed login, not a
+    /// login by an account that declares nothing. Read as the latter, its empty
+    /// identity agrees with any profile that also declares nothing — so the
+    /// broken file would be copied over a working legacy profile and made the
+    /// active credential, destroying both.
+    #[test]
+    fn run_from_refuses_a_login_whose_auth_file_cannot_be_read() {
+        let (_tmp, paths) = setup_test_env();
+        // A readable legacy credential: a subject, no workspace.
+        let legacy = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{legacy}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The login writes a file that cannot be parsed.
+        let mut runner = FakeLoginRunner::new("{ not json");
+
+        let error =
+            run_from_with_consent(&paths, "amir@sawmills.ai", None, true, &mut runner).unwrap_err();
+
+        let reported = format!("{error:#}");
+        assert!(
+            reported.contains("cannot be read") && reported.contains("failed to parse"),
+            "the unreadable login was not reported: {reported}"
+        );
+        assert!(
+            std::fs::read_to_string(
+                paths
+                    .profiles_dir()
+                    .join("amir@sawmills.ai")
+                    .join("auth.json"),
+            )
+            .unwrap()
+            .contains(legacy),
+            "a working profile was replaced with an unreadable credential"
+        );
+        assert!(
+            std::fs::read_to_string(paths.codex_auth_json())
+                .unwrap()
+                .contains(legacy),
+            "the live credential was replaced with an unreadable one"
+        );
     }
 
     /// The label path writes to an alias the operator did not type — it is

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -79,7 +79,10 @@ fn run_from(
         let lock = store::lock(paths)?;
         let target = resolve_target_alias(paths, alias, label, incoming.as_deref())?;
 
-        let email = email_from_alias(&target).or_else(|| email_from_alias(alias));
+        // The address is the alias the operator asked for; a label-qualified
+        // target like `a@b.com+work` is a store key, not an email. This is only
+        // a fallback — a token carrying an email claim still wins.
+        let email = email_from_alias(alias).or_else(|| email_from_alias(&target));
         profile::save_profile_and_activate_locked(
             &lock,
             paths,
@@ -386,6 +389,59 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// Every profile written before this release has no `account_id` in its
+    /// metadata, so a guard reading metadata alone is inert for exactly the
+    /// profiles an upgrade brings with it. The stored token still carries the
+    /// claim, so the guard has to read that.
+    #[test]
+    fn run_from_refuses_a_second_workspace_against_a_legacy_profile() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+        // Rewrite meta.json the way an older codexctl left it: no workspace.
+        let meta_path = paths
+            .profiles_dir()
+            .join("amir@sawmills.ai")
+            .join("meta.json");
+        std::fs::write(
+            &meta_path,
+            r#"{"alias":"amir@sawmills.ai","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(
+            paths
+                .profiles_dir()
+                .join("amir@sawmills.ai")
+                .join("auth.json"),
+        )
+        .unwrap();
+        assert!(
+            kept.contains(&stored),
+            "a legacy profile's credentials were replaced"
+        );
     }
 
     /// A token that declares no workspace cannot prove it belongs to the seat

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -715,6 +715,34 @@ mod tests {
         );
     }
 
+    /// A token that names no login at all cannot prove ownership by agreeing on
+    /// the workspace: workspaces are shared, and the profile does name someone.
+    #[test]
+    fn run_from_refuses_a_login_with_no_identity_against_a_named_profile() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-team");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // Same workspace declared in the file, but the token names nobody.
+        let mut runner =
+            FakeLoginRunner::new(r#"{"access_token":"opaque-not-a-jwt","account_id":"acct-team"}"#);
+
+        let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept =
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json")).unwrap();
+        assert!(kept.contains(&stored), "stored credentials were replaced");
+    }
+
     /// A team workspace holds many people. Two colleagues therefore agree on
     /// `chatgpt_account_id` and are still different accounts, so the workspace
     /// alone cannot say whose credentials an alias holds.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -435,6 +435,58 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// A derived alias whose workspace is known but whose login is not does not
+    /// identify an account: workspaces hold many people. The operator never
+    /// named this alias, so "not proven different" is not enough to replace it.
+    #[test]
+    fn run_from_refuses_a_derived_alias_with_a_workspace_but_no_login() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The derived alias declares the workspace in metadata only, with a
+        // token that yields no login identity at all.
+        let dir = paths.profiles_dir().join("amir@sawmills.ai+team");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            r#"{"access_token":"opaque-not-a-jwt"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"amir@sawmills.ai+team","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("cannot be identified"),
+            "unhelpful refusal: {error}"
+        );
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains("opaque-not-a-jwt"),
+            "the derived alias was overwritten"
+        );
+    }
+
     /// The headline case, from the other side: a legacy profile whose stored
     /// token declares no workspace, and its own owner signing into a second
     /// one. The logins match, so a rule that reads "stored declares nothing" as

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -707,6 +707,41 @@ mod tests {
         );
     }
 
+    /// A profile whose credentials will not read, but whose metadata still
+    /// records a workspace. An incoming token that names that workspace and no
+    /// login at all must not simply replace it: the stored side is silent
+    /// because nothing could be read, not because it is an old token, and a
+    /// workspace is shared — so anyone holding a seat in it could otherwise
+    /// overwrite a damaged profile by naming its alias.
+    #[test]
+    fn run_from_asks_before_replacing_a_damaged_profile_on_a_claimless_token() {
+        let (_tmp, paths) = setup_test_env();
+        let dir = paths.profiles_dir().join("team");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), "{ not json").unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"team","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        // Readable, names the same workspace, and carries no login claim at all.
+        let mut runner =
+            FakeLoginRunner::new(r#"{"access_token":"opaque-not-a-jwt","account_id":"acct-team"}"#);
+
+        let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("--allow-adopt"),
+            "a damaged profile was replaced without consent: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join("auth.json")).unwrap(),
+            "{ not json",
+            "the damaged profile's credentials were overwritten"
+        );
+    }
+
     /// A login that produced an unreadable `auth.json` is a failed login, not a
     /// login by an account that declares nothing. Read as the latter, its empty
     /// identity agrees with any profile that also declares nothing — so the

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -298,10 +298,10 @@ fn resolve_target_alias(
         };
         bail!(
             "profile '{alias}' holds a different account \
-             (stored workspace {}, this login {arriving}). \
+             (stored {}, this login {arriving}). \
              Re-run with --label <name> to save it alongside, choose another \
              alias, or remove it first: codexctl remove {alias}",
-            profile::short_workspace(different)
+            profile::describe_claim(different)
         );
     };
 
@@ -345,9 +345,9 @@ fn resolve_target_alias(
                  ({} and {}, this login {arriving}). Choose another alias.",
                 stored
                     .as_deref()
-                    .map(profile::short_workspace)
+                    .map(profile::describe_claim)
                     .unwrap_or_default(),
-                profile::short_workspace(also_taken)
+                profile::describe_claim(also_taken)
             );
         }
         return Ok(Resolution::NeedsConsent {
@@ -622,6 +622,51 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A legacy profile identified only by the JWT subject, meeting its own
+    /// refreshed token that now also carries `chatgpt_user_id`. The two
+    /// identifiers sit in different namespaces, so nothing proves they differ —
+    /// and treating them as proven different would make the refusal absolute,
+    /// leaving the exact population this design migrates with no way through:
+    /// `--allow-adopt` cannot override a proven conflict, by design.
+    #[test]
+    fn a_refreshed_login_claim_is_not_proof_of_a_different_person() {
+        let (_tmp, paths) = setup_test_env();
+        // Stored: subject only, and a workspace, so the workspace half agrees.
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let stored = encode(
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+        );
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // The same seat, refreshed: same subject, now also a user id.
+        let refreshed = encode(
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#,
+        );
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        // It must not be refused outright. Whether it lands silently or asks,
+        // the operator has a way through — which a proven conflict would deny.
+        let saved = run_from_with_consent(&paths, "team", None, true, &mut runner)
+            .expect("a refreshed login was refused as a different account");
+
+        assert_eq!(saved, "team");
+        assert!(
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json"))
+                .unwrap()
+                .contains(&refreshed),
+            "the refreshed token did not land"
+        );
     }
 
     /// A login that produced an unreadable `auth.json` is a failed login, not a

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -91,10 +91,12 @@ fn run_from(
             incoming_user.as_deref(),
         )?;
 
-        // The address is the alias the operator asked for; a label-qualified
-        // target like `a@b.com+work` is a store key, not an email. This is only
-        // a fallback — a token carrying an email claim still wins.
-        let email = email_from_alias(alias).or_else(|| email_from_alias(&target));
+        // The address is the alias the operator asked for. A resolved target —
+        // label-qualified, or an existing alias this seat was matched to — is a
+        // store key, and `email_from_alias` would happily read `a@b.com+work`
+        // as an address. This is only a fallback either way: a token carrying an
+        // email claim still wins.
+        let email = email_from_alias(alias);
         profile::save_profile_and_activate_locked(
             &lock,
             paths,

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1623,30 +1623,61 @@ mod tests {
 
     /// A profile with nothing left to identify it — no readable token and no
     /// recorded account — is the one an operator is sent back to `login` to
-    /// repair, and that still works.
+    /// repair. It is still repairable, but it is asked about rather than
+    /// silently replaced: "nothing identifiable" is a conclusion drawn from the
+    /// token failing to parse, and a parser regression must widen the questions
+    /// rather than the permissions.
     #[test]
-    fn run_from_repairs_a_profile_with_no_identity_at_all() {
-        let (_tmp, paths) = setup_test_env();
-        let dir = paths.profiles_dir().join("broken");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("auth.json"), "{ not json").unwrap();
-        std::fs::write(
-            dir.join("meta.json"),
-            r#"{"alias":"broken","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
-        )
-        .unwrap();
-
+    fn run_from_repairs_a_profile_with_no_identity_at_all_once_approved() {
+        let broken = |paths: &Paths| {
+            let dir = paths.profiles_dir().join("broken");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("auth.json"), "{ not json").unwrap();
+            std::fs::write(
+                dir.join("meta.json"),
+                r#"{"alias":"broken","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+            )
+            .unwrap();
+            dir
+        };
         let fresh = synthetic_token("acct-team");
-        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{fresh}"}}"#));
+        let auth = format!(r#"{{"access_token":"{fresh}"}}"#);
 
-        run_from(&paths, "broken", None, &mut runner).unwrap();
+        let (_tmp, paths) = setup_test_env();
+        let dir = broken(&paths);
+        let mut runner = FakeLoginRunner::new(&auth);
+        let error = run_from(&paths, "broken", None, &mut runner).unwrap_err();
+        assert!(error.to_string().contains("--allow-adopt"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("auth.json")).unwrap(),
+            "{ not json",
+            "a profile was replaced without approval"
+        );
 
+        let (_tmp, paths) = setup_test_env();
+        let dir = broken(&paths);
+        let mut runner = FakeLoginRunner::new(&auth);
+        run_from_with_consent(&paths, "broken", None, true, &mut runner).unwrap();
         assert!(
             std::fs::read_to_string(dir.join("auth.json"))
                 .unwrap()
                 .contains(&fresh),
             "an unidentifiable profile could not be repaired"
         );
+    }
+
+    /// The exception above must not swallow the ordinary case: an alias with no
+    /// profile directory has no occupant to ask about, so a first login to a
+    /// free alias is never a question.
+    #[test]
+    fn run_from_does_not_ask_about_an_alias_with_no_profile() {
+        let (_tmp, paths) = setup_test_env();
+        let fresh = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{fresh}"}}"#));
+
+        let saved = run_from(&paths, "brand-new", None, &mut runner).unwrap();
+
+        assert_eq!(saved, "brand-new");
     }
 
     /// A bad label must cost nothing. Failing after the device-auth flow would

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -180,8 +180,8 @@ fn resolve_target_alias(
         bail!(
             "profile '{alias}' holds a different account \
              (stored workspace {}, this login {arriving}). \
-             Re-run with --label <name> to save it alongside, \
-             or choose another alias.",
+             Re-run with --label <name> to save it alongside, choose another \
+             alias, or remove it first: codexctl remove {alias}",
             profile::short_workspace(&stored)
         );
     };
@@ -1302,11 +1302,12 @@ mod tests {
         assert!(saved.contains(&refreshed));
     }
 
-    /// An unreadable stored token is a likely reason to re-run login, so it
-    /// must not be the reason the fresh login is discarded. Capture may never
-    /// route the stale live file back over the alias being written.
+    /// A damaged profile that still records *which account* it holds is not
+    /// open to anyone who names a login. Its own login cannot be recovered from
+    /// the broken token, so a colleague in the same workspace would otherwise
+    /// replace it. Repair means removing it first, which the error says.
     #[test]
-    fn run_from_keeps_the_new_login_when_the_stored_auth_is_unreadable() {
+    fn run_from_refuses_to_replace_an_identified_profile_with_unreadable_auth() {
         let (_tmp, paths) = setup_test_env();
         let live = synthetic_token("acct-team");
         std::fs::write(
@@ -1316,7 +1317,7 @@ mod tests {
         .unwrap();
         profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
         profile::set_active_from(&paths, "team").unwrap();
-        // Corrupt the stored token, which is what sends an operator back to login.
+        // Metadata still records the workspace; only the token is corrupt.
         std::fs::write(
             paths.profiles_dir().join("team").join("auth.json"),
             "{ not json",
@@ -1326,13 +1327,43 @@ mod tests {
         let fresh = format!("{}fresh", synthetic_token("acct-team"));
         let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{fresh}"}}"#));
 
-        run_from(&paths, "team", None, &mut runner).unwrap();
+        let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
 
+        assert!(
+            error.to_string().contains("codexctl remove team"),
+            "the refusal does not name the remedy: {error}"
+        );
         let saved =
             std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json")).unwrap();
-        assert!(saved.contains(&fresh), "fresh login was discarded");
-        let installed = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
-        assert!(installed.contains(&fresh), "stale token was reinstalled");
+        assert!(!saved.contains(&fresh), "the damaged profile was replaced");
+    }
+
+    /// A profile with nothing left to identify it — no readable token and no
+    /// recorded account — is the one an operator is sent back to `login` to
+    /// repair, and that still works.
+    #[test]
+    fn run_from_repairs_a_profile_with_no_identity_at_all() {
+        let (_tmp, paths) = setup_test_env();
+        let dir = paths.profiles_dir().join("broken");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), "{ not json").unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"broken","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let fresh = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{fresh}"}}"#));
+
+        run_from(&paths, "broken", None, &mut runner).unwrap();
+
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains(&fresh),
+            "an unidentifiable profile could not be repaired"
+        );
     }
 
     /// A bad label must cost nothing. Failing after the device-auth flow would

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -419,6 +419,39 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// Damaged metadata is not an empty profile. The stored token still proves
+    /// which account these credentials belong to, so an alias the operator did
+    /// name is still protected from a different login.
+    #[test]
+    fn run_from_refuses_a_different_account_behind_unreadable_metadata() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-personal");
+        let dir = paths.profiles_dir().join("amir@sawmills.ai");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        // A valid token behind metadata that will not parse.
+        std::fs::write(dir.join("meta.json"), "{ truncated").unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
+        assert!(
+            kept.contains(&stored),
+            "credentials behind damaged metadata were destroyed"
+        );
+    }
+
     /// A team workspace holds many people. Two colleagues therefore agree on
     /// `chatgpt_account_id` and are still different accounts, so the workspace
     /// alone cannot say whose credentials an alias holds.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -98,13 +98,10 @@ fn run_from(
         // the address is whatever that profile already recorded — deriving one
         // from the requested alias would overwrite an established email with an
         // unrelated string, or with nothing at all.
-        let email = if target == alias {
-            email_from_alias(alias)
-        } else {
-            profile::get_profile_from(paths, &target)
-                .ok()
-                .and_then(|existing| existing.meta.email)
-        };
+        let email = profile::get_profile_from(paths, &target)
+            .ok()
+            .and_then(|existing| existing.meta.email)
+            .or_else(|| email_from_alias(alias));
         profile::save_profile_and_activate_locked(
             &lock,
             paths,
@@ -230,13 +227,14 @@ fn resolve_target_alias(
             profile::short_workspace(&also_taken)
         );
     }
-    // No conflict can also mean no evidence: a profile with no workspace in its
-    // metadata or its stored token is unprovable, not proven safe. The operator
-    // never named this alias — it was derived from the label — so overwriting
-    // its occupant on that basis is not theirs to have approved.
-    if profile::unidentifiable_profile(paths, &qualified) {
+    // The agreement rule above has vouched for this pair, including two sides
+    // that both declare nothing — which is a claimless profile being refreshed
+    // by the command that created it. What it cannot vouch for is a profile
+    // whose credentials will not read at all: the operator never named this
+    // alias, so replacing its occupant on no evidence is not theirs to approve.
+    if profile::credentials_unreadable(paths, &qualified) {
         bail!(
-            "'{qualified}' already holds a profile whose account cannot be identified, \
+            "'{qualified}' already holds a profile whose credentials cannot be read, \
              so this login would overwrite it. Save or re-login that profile first, \
              or choose another label."
         );
@@ -847,6 +845,78 @@ mod tests {
         assert!(
             meta.contains("amir@sawmills.ai"),
             "the established email was discarded: {meta}"
+        );
+    }
+
+    /// Re-logging the same alias keeps its recorded address when the new token
+    /// carries no email claim — `list` and `whoami` should not lose established
+    /// identity to a token that simply says less than the last one.
+    #[test]
+    fn run_from_keeps_the_stored_email_on_a_same_alias_relogin() {
+        let (_tmp, paths) = setup_test_env();
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir-team", Some("amir@sawmills.ai"), &source).unwrap();
+
+        let refreshed = format!("{}refreshed", synthetic_token("acct-team"));
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        run_from(&paths, "amir-team", None, &mut runner).unwrap();
+
+        let meta =
+            std::fs::read_to_string(paths.profiles_dir().join("amir-team").join("meta.json"))
+                .unwrap();
+        assert!(
+            meta.contains("amir@sawmills.ai"),
+            "a re-login erased the stored email: {meta}"
+        );
+    }
+
+    /// A labelled profile for an account that declares no workspace must be
+    /// refreshable by the same command that created it. Both sides declaring
+    /// nothing is agreement, not missing evidence.
+    #[test]
+    fn run_from_refreshes_a_claimless_derived_profile() {
+        let (_tmp, paths) = setup_test_env();
+        // The base alias holds another account.
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // A claimless account already saved under the derived alias.
+        let claimless = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0WiJ9.first";
+        let source = paths.home.join("claimless.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{claimless}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir@sawmills.ai+team", None, &source).unwrap();
+
+        // The same claimless account logging in again.
+        let refreshed = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0WiJ9.second";
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let target = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap();
+
+        assert_eq!(target, "amir@sawmills.ai+team");
+        assert!(
+            std::fs::read_to_string(
+                paths
+                    .profiles_dir()
+                    .join("amir@sawmills.ai+team")
+                    .join("auth.json")
+            )
+            .unwrap()
+            .contains(refreshed),
+            "the claimless profile was not refreshed"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -78,8 +78,7 @@ fn run_from(
             .and_then(|a| a.account_id.clone());
         let incoming_user = incoming_identity
             .as_ref()
-            .and_then(|a| api::token_identity(&a.access_token))
-            .and_then(|identity| identity.user_id);
+            .and_then(|a| api::token_login(&a.access_token));
         // Resolve and write under one lock. Which alias this login lands on is
         // read out of the store, so releasing the lock in between would let a
         // concurrent login change the answer before the write lands.
@@ -504,8 +503,9 @@ mod tests {
     }
 
     /// The operator names the base alias; codexctl derives the qualified one.
-    /// Overwriting a profile nobody named, on the strength of an identity that
-    /// could not be read, is not an approval anyone gave.
+    /// Whichever guard fires — a positively different login, or an identity
+    /// that cannot be read at all — overwriting a profile nobody named is not
+    /// an approval anyone gave.
     #[test]
     fn run_from_refuses_a_derived_alias_holding_an_unidentifiable_profile() {
         let (_tmp, paths) = setup_test_env();
@@ -544,9 +544,10 @@ mod tests {
 
         let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
 
+        let message = error.to_string();
         assert!(
-            error.to_string().contains("cannot be identified"),
-            "unhelpful refusal: {error}"
+            message.contains("Choose another alias") || message.contains("cannot be identified"),
+            "unhelpful refusal: {message}"
         );
         let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
         assert!(kept.contains(opaque), "the derived alias was overwritten");

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -118,14 +118,22 @@ fn run_from_with_consent(
                 // without a timeout, so a question left unanswered would stall
                 // every other codexctl process, not just this one.
                 drop(lock);
-                if !adopt::approve_adoption(
+                // Either way nothing is saved, and the login has already
+                // happened — so neither outcome is a success.
+                match adopt::approve_adoption(
                     &pending,
                     stored.as_deref(),
                     incoming.as_deref(),
                     allow_adopt,
                     &mut std::io::stderr(),
                 ) {
-                    return Err(adopt::refusal(&pending, stored.as_deref()));
+                    adopt::Approval::Granted => {}
+                    adopt::Approval::Declined => {
+                        bail!("not replacing profile '{pending}', so this login was not saved")
+                    }
+                    adopt::Approval::NoTerminal => {
+                        return Err(adopt::refusal(&pending, stored.as_deref()));
+                    }
                 }
                 let lock = store::lock(paths)?;
                 // The answer approved one specific replacement. Resolving again

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail};
 
 use crate::api;
-use crate::commands::{alias, status};
+use crate::commands::{adopt, alias, status};
 use crate::config::{self, Paths};
 use crate::profile;
 use crate::store;
@@ -35,12 +35,12 @@ impl CodexLoginRunner for CodexCliLoginRunner {
     }
 }
 
-pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
+pub fn run(alias: &str, label: Option<&str>, allow_adopt: bool) -> Result<()> {
     let alias = alias::required(alias)?;
     let paths = config::default_paths()?;
     let mut runner = CodexCliLoginRunner;
     // The alias actually written may be label-qualified, so report that one.
-    let saved = run_from(&paths, alias, label, &mut runner)?;
+    let saved = run_from_with_consent(&paths, alias, label, allow_adopt, &mut runner)?;
 
     println!("logged in and saved profile '{saved}'");
     println!();
@@ -48,10 +48,26 @@ pub fn run(alias: &str, label: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// `run_from` with adoption never pre-approved.
+///
+/// Every caller is a test, and tests have no terminal, so the consent prompt
+/// declines on its own — this only spares them an argument that is always the
+/// same.
+#[cfg(test)]
 fn run_from(
     paths: &Paths,
     alias: &str,
     label: Option<&str>,
+    runner: &mut impl CodexLoginRunner,
+) -> Result<String> {
+    run_from_with_consent(paths, alias, label, false, runner)
+}
+
+fn run_from_with_consent(
+    paths: &Paths,
+    alias: &str,
+    label: Option<&str>,
+    allow_adopt: bool,
     runner: &mut impl CodexLoginRunner,
 ) -> Result<String> {
     let alias = alias::required(alias)?;
@@ -83,13 +99,52 @@ fn run_from(
         // read out of the store, so releasing the lock in between would let a
         // concurrent login change the answer before the write lands.
         let lock = store::lock(paths)?;
-        let target = resolve_target_alias(
-            paths,
-            alias,
-            label,
-            incoming.as_deref(),
-            incoming_user.as_deref(),
-        )?;
+        let resolve = |_: &store::StoreLock| {
+            resolve_target_alias(
+                paths,
+                alias,
+                label,
+                incoming.as_deref(),
+                incoming_user.as_deref(),
+            )
+        };
+        let (lock, target) = match resolve(&lock)? {
+            Resolution::Ready(target) => (lock, target),
+            Resolution::NeedsConsent {
+                alias: pending,
+                stored,
+            } => {
+                // Never ask while holding the store lock: `store::lock` waits
+                // without a timeout, so a question left unanswered would stall
+                // every other codexctl process, not just this one.
+                drop(lock);
+                if !adopt::approve_adoption(
+                    &pending,
+                    stored.as_deref(),
+                    incoming.as_deref(),
+                    allow_adopt,
+                    &mut std::io::stderr(),
+                ) {
+                    return Err(adopt::refusal(&pending, stored.as_deref()));
+                }
+                let lock = store::lock(paths)?;
+                // The answer approved one specific replacement. Resolving again
+                // under the new lock keeps it from being applied to whatever the
+                // store looks like now, which may be something nobody was asked
+                // about.
+                match resolve(&lock)? {
+                    Resolution::Ready(target) => (lock, target),
+                    Resolution::NeedsConsent {
+                        alias: again,
+                        stored: stored_again,
+                    } if again == pending && stored_again == stored => (lock, pending),
+                    Resolution::NeedsConsent { .. } => bail!(
+                        "the store changed while waiting for an answer, so the approval no \
+                         longer describes what would be replaced. Re-run the login."
+                    ),
+                }
+            }
+        };
 
         // Only a fallback either way: a token carrying an email claim wins.
         //
@@ -126,22 +181,34 @@ fn run_from(
     }
 }
 
+/// Where a login should land, once the store has said everything it can.
+enum Resolution {
+    /// Settled. Write here.
+    Ready(String),
+    /// This alias holds something the store can neither match to this account
+    /// nor rule out, so only the operator can settle it. See `commands::adopt`.
+    NeedsConsent {
+        alias: String,
+        stored: Option<String>,
+    },
+}
+
 /// Where this login should land.
 ///
 /// The requested alias wins whenever it is free or already holds this same
 /// account. When it holds a *different* account the label qualifies it, so a
 /// second seat on one address lands beside the first rather than replacing it.
-/// Without a label there is nothing to qualify with, so the login is refused
-/// rather than allowed to overwrite.
+/// Without a label there is nothing to qualify with — and nothing the store can
+/// decide either, so the operator is asked rather than refused.
 fn resolve_target_alias(
     paths: &Paths,
     alias: &str,
     label: Option<&str>,
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
-) -> Result<String> {
+) -> Result<Resolution> {
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
-    let Some(stored) = conflict else {
+    let Some(conflict) = conflict else {
         // The requested alias is usable. When a label was given, this seat may
         // still be saved under a label-derived alias from an earlier run — and
         // saving it here too would fork one account across two profiles, which
@@ -151,7 +218,7 @@ fn resolve_target_alias(
                 .context("could not check whether this account is already saved")?
             {
                 profile::ExistingSeat::One(existing) if existing != alias => {
-                    return Ok(existing);
+                    return Ok(Resolution::Ready(existing));
                 }
                 // Already ambiguous. A free alias is room for a third copy,
                 // not permission to make one — unless the operator named one of
@@ -159,7 +226,7 @@ fn resolve_target_alias(
                 // the very remedy this error recommends.
                 profile::ExistingSeat::Ambiguous(aliases) => {
                     if aliases.iter().any(|existing| existing == alias) {
-                        return Ok(alias.to_string());
+                        return Ok(Resolution::Ready(alias.to_string()));
                     }
                     bail!(
                         "this account is already saved under more than one alias ({}). \
@@ -170,19 +237,29 @@ fn resolve_target_alias(
                 _ => {}
             }
         }
-        return Ok(alias.to_string());
+        return Ok(Resolution::Ready(alias.to_string()));
     };
     let arriving = incoming_account
         .map(profile::short_workspace)
         .unwrap_or_default();
+    let stored = conflict.stored().map(str::to_string);
 
     let Some(label) = label else {
+        // A claim that positively disagrees is never this account, so no answer
+        // could make replacing it right. One that simply cannot be compared is a
+        // question, and the operator is the only one who can answer it.
+        let profile::AccountConflict::Different(different) = &conflict else {
+            return Ok(Resolution::NeedsConsent {
+                alias: alias.to_string(),
+                stored,
+            });
+        };
         bail!(
             "profile '{alias}' holds a different account \
              (stored workspace {}, this login {arriving}). \
              Re-run with --label <name> to save it alongside, choose another \
              alias, or remove it first: codexctl remove {alias}",
-            profile::short_workspace(&stored)
+            profile::short_workspace(different)
         );
     };
 
@@ -193,11 +270,11 @@ fn resolve_target_alias(
     match profile::existing_seat(paths, incoming_account, incoming_user)
         .context("could not check whether this account is already saved")?
     {
-        profile::ExistingSeat::One(existing) => return Ok(existing),
+        profile::ExistingSeat::One(existing) => return Ok(Resolution::Ready(existing)),
         profile::ExistingSeat::Ambiguous(aliases) => {
             // Naming one of the duplicates is refreshing it, not adding to them.
             if aliases.iter().any(|existing| existing == alias) {
-                return Ok(alias.to_string());
+                return Ok(Resolution::Ready(alias.to_string()));
             }
             bail!(
                 "this account is already saved under more than one alias ({}). \
@@ -220,26 +297,36 @@ fn resolve_target_alias(
     if let Some(also_taken) =
         profile::conflicting_workspace(paths, &qualified, incoming_account, incoming_user)
     {
-        bail!(
-            "'{alias}' and '{qualified}' both hold other accounts \
-             ({} and {}, this login {arriving}). Choose another alias.",
-            profile::short_workspace(&stored),
-            profile::short_workspace(&also_taken)
-        );
+        if let profile::AccountConflict::Different(also_taken) = &also_taken {
+            bail!(
+                "'{alias}' and '{qualified}' both hold other accounts \
+                 ({} and {}, this login {arriving}). Choose another alias.",
+                stored
+                    .as_deref()
+                    .map(profile::short_workspace)
+                    .unwrap_or_default(),
+                profile::short_workspace(also_taken)
+            );
+        }
+        return Ok(Resolution::NeedsConsent {
+            stored: also_taken.stored().map(str::to_string),
+            alias: qualified,
+        });
     }
     // The agreement rule above has vouched for this pair, including two sides
     // that both declare nothing — which is a claimless profile being refreshed
     // by the command that created it. What it cannot vouch for is a profile
-    // whose credentials will not read at all: the operator never named this
-    // alias, so replacing its occupant on no evidence is not theirs to approve.
+    // whose credentials will not read at all. The operator never named this
+    // alias, so replacing its occupant is not something the store may decide on
+    // its own — but the only remedy left otherwise is `remove`, which destroys
+    // the metadata that identifies it and then replaces it anyway. Ask instead.
     if profile::credentials_unreadable(paths, &qualified) {
-        bail!(
-            "'{qualified}' already holds a profile whose credentials cannot be read, \
-             so this login would overwrite it. Save or re-login that profile first, \
-             or choose another label."
-        );
+        return Ok(Resolution::NeedsConsent {
+            stored: profile::workspace_of_profile(paths, &qualified),
+            alias: qualified,
+        });
     }
-    Ok(qualified)
+    Ok(Resolution::Ready(qualified))
 }
 
 /// Reduce a display label to something usable as one path component.
@@ -520,7 +607,7 @@ mod tests {
         // unproven owner outright — but the credentials must survive.
         let message = error.to_string();
         assert!(
-            message.contains("cannot be identified") || message.contains("Choose another alias"),
+            message.contains("--allow-adopt"),
             "unhelpful refusal: {message}"
         );
         assert!(
@@ -528,6 +615,100 @@ mod tests {
                 .unwrap()
                 .contains("opaque-not-a-jwt"),
             "the derived alias was overwritten"
+        );
+    }
+
+    /// The other half of the headline case: the refusal above is a default, not
+    /// a wall. A legacy profile that declares no workspace is exactly what an
+    /// upgrade leaves behind, and the operator is the one who knows whether the
+    /// account arriving is the one it held. With that answer given, the login
+    /// lands and the profile stops being claimless — which is what makes a
+    /// re-login the documented way to bring an old profile forward.
+    #[test]
+    fn run_from_adopts_a_claimless_profile_when_approved() {
+        let (_tmp, paths) = setup_test_env();
+        let legacy = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{legacy}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        use base64::Engine;
+        let claims =
+            r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#;
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        let incoming = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let saved =
+            run_from_with_consent(&paths, "amir@sawmills.ai", None, true, &mut runner).unwrap();
+
+        assert_eq!(saved, "amir@sawmills.ai");
+        let dir = paths.profiles_dir().join("amir@sawmills.ai");
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains(&incoming),
+            "the approved login did not land"
+        );
+        // The profile can now answer for itself, so the next login needs no
+        // approval at all. Without this the adoption would have to be repeated
+        // forever, which is the circularity the refusal alone created.
+        assert_eq!(
+            profile::workspace_of_profile(&paths, "amir@sawmills.ai").as_deref(),
+            Some("acct-team"),
+            "the adopted profile still records no workspace"
+        );
+    }
+
+    /// Approval settles what the store could not work out. It does not overrule
+    /// what the store worked out and got a negative answer to: two workspaces
+    /// that positively disagree are not one account, and no flag makes them one.
+    #[test]
+    fn allow_adopt_does_not_override_a_proven_different_account() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error =
+            run_from_with_consent(&paths, "amir@sawmills.ai", None, true, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "--allow-adopt bypassed a proven conflict: {error}"
+        );
+        assert!(
+            std::fs::read_to_string(
+                paths
+                    .profiles_dir()
+                    .join("amir@sawmills.ai")
+                    .join("auth.json"),
+            )
+            .unwrap()
+            .contains(&stored),
+            "a proven different account was overwritten"
         );
     }
 
@@ -564,7 +745,7 @@ mod tests {
         let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
 
         assert!(
-            error.to_string().contains("different account"),
+            error.to_string().contains("--allow-adopt"),
             "unhelpful refusal: {error}"
         );
         let kept = std::fs::read_to_string(
@@ -756,7 +937,7 @@ mod tests {
         let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
 
         assert!(
-            error.to_string().contains("different account"),
+            error.to_string().contains("--allow-adopt"),
             "unhelpful refusal: {error}"
         );
         let kept =
@@ -790,7 +971,7 @@ mod tests {
         let error = run_from(&paths, "work", None, &mut runner).unwrap_err();
 
         assert!(
-            error.to_string().contains("different account"),
+            error.to_string().contains("--allow-adopt"),
             "unhelpful refusal: {error}"
         );
         assert!(
@@ -1139,7 +1320,7 @@ mod tests {
         let error = run_from(&paths, "amir@sawmills.ai", None, &mut runner).unwrap_err();
 
         assert!(
-            error.to_string().contains("different account"),
+            error.to_string().contains("--allow-adopt"),
             "unhelpful refusal: {error}"
         );
         let kept = std::fs::read_to_string(
@@ -1330,7 +1511,7 @@ mod tests {
         let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
 
         assert!(
-            error.to_string().contains("codexctl remove team"),
+            error.to_string().contains("--allow-adopt"),
             "the refusal does not name the remedy: {error}"
         );
         let saved =

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -154,6 +154,17 @@ fn resolve_target_alias(
             profile::short_workspace(&also_taken)
         );
     }
+    // No conflict can also mean no evidence: a profile with no workspace in its
+    // metadata or its stored token is unprovable, not proven safe. The operator
+    // never named this alias — it was derived from the label — so overwriting
+    // its occupant on that basis is not theirs to have approved.
+    if profile::unidentifiable_profile(paths, &qualified) {
+        bail!(
+            "'{qualified}' already holds a profile whose account cannot be identified, \
+             so this login would overwrite it. Save or re-login that profile first, \
+             or choose another label."
+        );
+    }
     Ok(qualified)
 }
 
@@ -389,6 +400,55 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// The operator names the base alias; codexctl derives the qualified one.
+    /// Overwriting a profile nobody named, on the strength of an identity that
+    /// could not be read, is not an approval anyone gave.
+    #[test]
+    fn run_from_refuses_a_derived_alias_holding_an_unidentifiable_profile() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // `amir@sawmills.ai+team` exists but declares no workspace anywhere:
+        // no metadata claim, and a stored token that carries none either.
+        let dir = paths.profiles_dir().join("amir@sawmills.ai+team");
+        std::fs::create_dir_all(&dir).unwrap();
+        let opaque = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0WiJ9.sig";
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{opaque}"}}"#),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"amir@sawmills.ai+team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("cannot be identified"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
+        assert!(kept.contains(opaque), "the derived alias was overwritten");
     }
 
     /// Every profile written before this release has no `account_id` in its

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -114,19 +114,13 @@ fn run_from_with_consent(
             )
         })?;
         let incoming = incoming_identity.account_id.clone();
-        let incoming_user = api::token_login(&incoming_identity.access_token);
+        let incoming_user = api::token_logins(&incoming_identity.access_token);
         // Resolve and write under one lock. Which alias this login lands on is
         // read out of the store, so releasing the lock in between would let a
         // concurrent login change the answer before the write lands.
         let lock = store::lock(paths)?;
         let resolve = |_: &store::StoreLock| {
-            resolve_target_alias(
-                paths,
-                alias,
-                label,
-                incoming.as_deref(),
-                incoming_user.as_deref(),
-            )
+            resolve_target_alias(paths, alias, label, incoming.as_deref(), &incoming_user)
         };
         let (lock, target) = match resolve(&lock)? {
             Resolution::Ready(target) => (lock, target),
@@ -247,7 +241,7 @@ fn resolve_target_alias(
     alias: &str,
     label: Option<&str>,
     incoming_account: Option<&str>,
-    incoming_user: Option<&str>,
+    incoming_user: &api::Logins,
 ) -> Result<Resolution> {
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
     let Some(conflict) = conflict else {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -91,12 +91,20 @@ fn run_from(
             incoming_user.as_deref(),
         )?;
 
-        // The address is the alias the operator asked for. A resolved target —
-        // label-qualified, or an existing alias this seat was matched to — is a
-        // store key, and `email_from_alias` would happily read `a@b.com+work`
-        // as an address. This is only a fallback either way: a token carrying an
-        // email claim still wins.
-        let email = email_from_alias(alias);
+        // Only a fallback either way: a token carrying an email claim wins.
+        //
+        // When the login lands on the alias that was asked for, that alias is
+        // the address. When it is redirected to a profile that already exists,
+        // the address is whatever that profile already recorded — deriving one
+        // from the requested alias would overwrite an established email with an
+        // unrelated string, or with nothing at all.
+        let email = if target == alias {
+            email_from_alias(alias)
+        } else {
+            profile::get_profile_from(paths, &target)
+                .ok()
+                .and_then(|existing| existing.meta.email)
+        };
         profile::save_profile_and_activate_locked(
             &lock,
             paths,
@@ -148,13 +156,20 @@ fn resolve_target_alias(
                 profile::ExistingSeat::One(existing) if existing != alias => {
                     return Ok(existing);
                 }
-                // Already ambiguous. A free alias is room for a third copy, not
-                // permission to make one.
-                profile::ExistingSeat::Ambiguous(aliases) => bail!(
-                    "this account is already saved under more than one alias ({}). \
-                     Remove the duplicates, or log in with one of them directly.",
-                    aliases.join(", ")
-                ),
+                // Already ambiguous. A free alias is room for a third copy,
+                // not permission to make one — unless the operator named one of
+                // the duplicates, which is refreshing an existing profile and
+                // the very remedy this error recommends.
+                profile::ExistingSeat::Ambiguous(aliases) => {
+                    if aliases.iter().any(|existing| existing == alias) {
+                        return Ok(alias.to_string());
+                    }
+                    bail!(
+                        "this account is already saved under more than one alias ({}). \
+                         Remove the duplicates, or log in with one of them directly.",
+                        aliases.join(", ")
+                    )
+                }
                 _ => {}
             }
         }
@@ -182,11 +197,17 @@ fn resolve_target_alias(
         .context("could not check whether this account is already saved")?
     {
         profile::ExistingSeat::One(existing) => return Ok(existing),
-        profile::ExistingSeat::Ambiguous(aliases) => bail!(
-            "this account is already saved under more than one alias ({}). \
-             Remove the duplicates, or log in with one of them directly.",
-            aliases.join(", ")
-        ),
+        profile::ExistingSeat::Ambiguous(aliases) => {
+            // Naming one of the duplicates is refreshing it, not adding to them.
+            if aliases.iter().any(|existing| existing == alias) {
+                return Ok(alias.to_string());
+            }
+            bail!(
+                "this account is already saved under more than one alias ({}). \
+                 Remove the duplicates, or log in with one of them directly.",
+                aliases.join(", ")
+            )
+        }
         profile::ExistingSeat::None => {}
     }
 
@@ -779,6 +800,53 @@ mod tests {
                 .unwrap()
                 .contains("opaque-not-a-jwt"),
             "an intact profile was overwritten"
+        );
+    }
+
+    /// Naming one of the duplicates is refreshing it, not adding a third — and
+    /// it is the remedy the ambiguity error itself recommends.
+    #[test]
+    fn run_from_refreshes_a_named_alias_from_an_ambiguous_set() {
+        let (_tmp, paths) = setup_test_env();
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "work", None, &source).unwrap();
+        profile::save_profile_to(&paths, "work-copy", None, &source).unwrap();
+
+        let refreshed = format!("{}refreshed", synthetic_token("acct-team"));
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let target = run_from(&paths, "work", Some("team"), &mut runner).unwrap();
+
+        assert_eq!(target, "work", "a named duplicate could not be refreshed");
+        assert!(
+            !paths.profiles_dir().join("work+team").exists(),
+            "a third copy was created"
+        );
+    }
+
+    /// A login redirected to an existing profile keeps the address that profile
+    /// already recorded, rather than replacing it from an unrelated alias.
+    #[test]
+    fn run_from_keeps_the_existing_email_when_redirected_to_a_seat() {
+        let (_tmp, paths) = setup_test_env();
+        let team = synthetic_token("acct-team");
+        let source = paths.home.join("team-auth.json");
+        std::fs::write(&source, format!(r#"{{"access_token":"{team}"}}"#)).unwrap();
+        profile::save_profile_to(&paths, "amir-team", Some("amir@sawmills.ai"), &source).unwrap();
+
+        // Requested under an unrelated alias; the token carries no email claim.
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{team}"}}"#));
+        let target = run_from(&paths, "temporary", Some("team"), &mut runner).unwrap();
+
+        assert_eq!(target, "amir-team", "the existing seat was not reused");
+        let meta =
+            std::fs::read_to_string(paths.profiles_dir().join("amir-team").join("meta.json"))
+                .unwrap();
+        assert!(
+            meta.contains("amir@sawmills.ai"),
+            "the established email was discarded: {meta}"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -87,7 +87,13 @@ fn run_from_with_consent(
     // Validate before the device-auth flow starts. Failing after the operator
     // completed a browser login would read as a failed login even though the
     // profile was saved and made active.
-    label.map(store::validate_label).transpose()?;
+    //
+    // Keep what validation returns rather than only its verdict: it trims, and
+    // reports a blank label as no label at all. Carrying the raw text on would
+    // send a whitespace-only label down the qualifying path, where it produces
+    // an empty slug and fails — after the browser login, which is precisely
+    // what checking here is meant to prevent.
+    let label = label.map(store::validate_label).transpose()?.flatten();
     let codex_home = create_isolated_login_home(paths, alias)?;
     let result = (|| {
         runner.run_codex_login(&codex_home)?;
@@ -616,6 +622,44 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A whitespace-only label is no label, and validation already says so.
+    /// Carrying the raw text on instead sent it down the qualifying path, where
+    /// it slugs to nothing and fails — after the browser login, which is the one
+    /// outcome validating up front exists to prevent.
+    #[test]
+    fn a_blank_label_behaves_as_no_label() {
+        let (_tmp, paths) = setup_test_env();
+        let stored = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("   "), &mut runner).unwrap_err();
+
+        // The unlabeled refusal, not the empty-slug failure.
+        let message = error.to_string();
+        assert!(
+            message.contains("different account"),
+            "a blank label took the qualifying path: {message}"
+        );
+        assert!(
+            !message.contains("no characters usable"),
+            "the failure came from slugging a blank label: {message}"
+        );
     }
 
     /// A legacy profile identified only by the JWT subject, meeting its own

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -70,14 +70,27 @@ fn run_from(
 
         // The incoming account is only knowable once the login has produced a
         // token, so the target alias is resolved here rather than up front.
-        let incoming = api::read_auth_json(&auth_path)
-            .ok()
-            .and_then(|auth| auth.account_id);
+        // Workspace and login together: a team workspace is shared, so it
+        // does not by itself say whose credentials these are.
+        let incoming_identity = api::read_auth_json(&auth_path).ok();
+        let incoming = incoming_identity
+            .as_ref()
+            .and_then(|a| a.account_id.clone());
+        let incoming_user = incoming_identity
+            .as_ref()
+            .and_then(|a| api::token_identity(&a.access_token))
+            .and_then(|identity| identity.user_id);
         // Resolve and write under one lock. Which alias this login lands on is
         // read out of the store, so releasing the lock in between would let a
         // concurrent login change the answer before the write lands.
         let lock = store::lock(paths)?;
-        let target = resolve_target_alias(paths, alias, label, incoming.as_deref())?;
+        let target = resolve_target_alias(
+            paths,
+            alias,
+            label,
+            incoming.as_deref(),
+            incoming_user.as_deref(),
+        )?;
 
         // The address is the alias the operator asked for; a label-qualified
         // target like `a@b.com+work` is a store key, not an email. This is only
@@ -119,8 +132,11 @@ fn resolve_target_alias(
     alias: &str,
     label: Option<&str>,
     incoming_account: Option<&str>,
+    incoming_user: Option<&str>,
 ) -> Result<String> {
-    let Some(stored) = profile::conflicting_workspace(paths, alias, incoming_account) else {
+    let Some(stored) =
+        profile::conflicting_workspace(paths, alias, incoming_account, incoming_user)
+    else {
         return Ok(alias.to_string());
     };
     let arriving = incoming_account
@@ -146,7 +162,9 @@ fn resolve_target_alias(
         format!("label '{label}' does not produce a usable alias for '{alias}'")
     })?;
 
-    if let Some(also_taken) = profile::conflicting_workspace(paths, &qualified, incoming_account) {
+    if let Some(also_taken) =
+        profile::conflicting_workspace(paths, &qualified, incoming_account, incoming_user)
+    {
         bail!(
             "'{alias}' and '{qualified}' both hold other accounts \
              ({} and {}, this login {arriving}). Choose another alias.",
@@ -400,6 +418,46 @@ mod tests {
         let active = std::fs::read_to_string(paths.codex_auth_json()).unwrap();
         assert!(active.contains("new_active_tok"));
         assert!(!active.contains("old_active_tok"));
+    }
+
+    /// A team workspace holds many people. Two colleagues therefore agree on
+    /// `chatgpt_account_id` and are still different accounts, so the workspace
+    /// alone cannot say whose credentials an alias holds.
+    #[test]
+    fn run_from_refuses_a_different_login_in_the_same_workspace() {
+        let (_tmp, paths) = setup_test_env();
+        let colleague = |user: &str| {
+            use base64::Engine;
+            let claims = format!(
+                r#"{{"sub":"{user}","https://api.openai.com/auth":{{"chatgpt_account_id":"acct-team","chatgpt_user_id":"{user}"}}}}"#
+            );
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let stored = colleague("user-a");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // Same workspace, different person.
+        let incoming = colleague("user-b");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "team", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept =
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json")).unwrap();
+        assert!(
+            kept.contains(&stored),
+            "a colleague's login replaced these credentials"
+        );
     }
 
     /// An interrupted save or a damaged metadata file leaves a directory that

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -743,6 +743,43 @@ mod tests {
         assert!(kept.contains(&stored), "stored credentials were replaced");
     }
 
+    /// A readable token that simply names nobody is an intact profile, not a
+    /// broken one. Only credentials that cannot be read at all get the repair
+    /// exception; anything else needs the same proof as any other overwrite.
+    #[test]
+    fn run_from_refuses_a_known_login_over_a_readable_but_anonymous_profile() {
+        let (_tmp, paths) = setup_test_env();
+        // Readable auth whose token yields neither workspace nor login.
+        let dir = paths.profiles_dir().join("work");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            r#"{"access_token":"opaque-not-a-jwt"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"work","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "work", None, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains("opaque-not-a-jwt"),
+            "an intact profile was overwritten"
+        );
+    }
+
     /// A team workspace holds many people. Two colleagues therefore agree on
     /// `chatgpt_account_id` and are still different accounts, so the workspace
     /// alone cannot say whose credentials an alias holds.
@@ -814,10 +851,13 @@ mod tests {
 
         let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
 
-        let message = format!("{error:#}");
+        // Several guards can speak first here — an unprovable workspace, an
+        // unidentifiable occupant, an unreadable store. The invariant is that
+        // the login is refused and the credentials survive, not which one
+        // answers, so this pins that rather than one wording.
         assert!(
-            message.contains("cannot be identified") || message.contains("already saved"),
-            "unhelpful refusal: {message}"
+            !format!("{error:#}").is_empty(),
+            "refusal carried no explanation"
         );
         assert!(
             std::fs::read_to_string(dir.join("auth.json"))

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -402,6 +402,49 @@ mod tests {
         assert!(!active.contains("old_active_tok"));
     }
 
+    /// An interrupted save or a damaged metadata file leaves a directory that
+    /// cannot be read. That is the strongest reason to leave it alone, not a
+    /// reason to treat the alias as free.
+    #[test]
+    fn run_from_refuses_a_derived_alias_whose_profile_cannot_be_read() {
+        let (_tmp, paths) = setup_test_env();
+        let personal = synthetic_token("acct-personal");
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{personal}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The derived alias exists on disk but its metadata is unreadable.
+        let dir = paths.profiles_dir().join("amir@sawmills.ai+team");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), r#"{"access_token":"salvageable"}"#).unwrap();
+        std::fs::write(dir.join("meta.json"), "{ this is not json").unwrap();
+
+        let incoming = synthetic_token("acct-team");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{incoming}"}}"#));
+
+        let error = run_from(&paths, "amir@sawmills.ai", Some("team"), &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("cannot be identified"),
+            "unhelpful refusal: {error}"
+        );
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains("salvageable"),
+            "credentials behind unreadable metadata were destroyed"
+        );
+    }
+
     /// The operator names the base alias; codexctl derives the qualified one.
     /// Overwriting a profile nobody named, on the strength of an identity that
     /// could not be read, is not an approval anyone gave.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod alias;
 pub mod codex;
 pub mod completions;
+pub mod label;
 pub mod list;
 pub mod login;
 pub mod remove;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod adopt;
 mod alias;
 pub mod codex;
 pub mod completions;

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -6,8 +6,9 @@ use crate::config;
 use crate::profile;
 use crate::store;
 
-pub fn run(alias: Option<&str>) -> Result<()> {
-    let auth_path = config::codex_auth_json()?;
+pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
+    let paths = config::default_paths()?;
+    let auth_path = paths.codex_auth_json();
     if !auth_path.exists() {
         anyhow::bail!(
             "no auth.json found at {}. Log in with Codex CLI first.",
@@ -16,8 +17,14 @@ pub fn run(alias: Option<&str>) -> Result<()> {
     }
 
     let auth = api::read_auth_json(&auth_path)?;
+    let identity = api::token_identity(&auth.access_token).unwrap_or_default();
 
-    let email = fetch_email(&auth.access_token);
+    // The token's own claim is authoritative and costs no network call. Only
+    // ask the API when the token carries no profile claim at all.
+    let email = identity
+        .email
+        .clone()
+        .or_else(|| fetch_email(&auth.access_token));
     let resolved_alias = match alias::optional(alias)? {
         Some(a) => a.to_string(),
         None => match &email {
@@ -36,8 +43,9 @@ pub fn run(alias: Option<&str>) -> Result<()> {
         },
     };
 
-    let existing = store::profile_dir(&config::default_paths()?, &resolved_alias)?;
+    let existing = store::profile_dir(&paths, &resolved_alias)?;
     if existing.exists() {
+        refuse_a_different_account(&paths, &resolved_alias, identity.account_id.as_deref())?;
         eprint!(
             "profile '{}' already exists. Overwrite? [y/N] ",
             resolved_alias
@@ -51,9 +59,55 @@ pub fn run(alias: Option<&str>) -> Result<()> {
     }
 
     profile::save_profile_and_activate(&resolved_alias, email.as_deref(), &auth_path)?;
+    if let Some(label) = label {
+        profile::set_label_from(&paths, &resolved_alias, Some(label))?;
+    }
 
     println!("saved profile '{}'", resolved_alias);
     Ok(())
+}
+
+/// Stop before the overwrite prompt when the target profile holds a *different*
+/// workspace.
+///
+/// Without an explicit alias `save` defaults to the detected email, so a second
+/// account on one address lands on the first account's profile. There the
+/// destructive answer is a single keystroke, and the right action is always to
+/// pick another alias — so this is an error rather than another prompt.
+///
+/// A refusal needs positive evidence of a different account. When either side
+/// has no workspace identifier the command falls through to the usual prompt.
+fn refuse_a_different_account(
+    paths: &config::Paths,
+    alias: &str,
+    incoming_account: Option<&str>,
+) -> Result<()> {
+    let Some(incoming) = incoming_account else {
+        return Ok(());
+    };
+    let Ok(existing) = profile::get_profile_from(paths, alias) else {
+        return Ok(());
+    };
+    let Some(stored) = existing.meta.account_id.as_deref() else {
+        return Ok(());
+    };
+    if stored == incoming {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "profile '{alias}' holds a different account \
+         (stored workspace {}, incoming {}). \
+         Pass an explicit alias: codexctl save <alias>",
+        short_workspace(stored),
+        short_workspace(incoming)
+    )
+}
+
+fn short_workspace(account_id: &str) -> String {
+    match account_id.char_indices().nth(8) {
+        Some((index, _)) => format!("{}…", &account_id[..index]),
+        None => account_id.to_string(),
+    }
 }
 
 fn fetch_email(access_token: &str) -> Option<String> {

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -92,18 +92,9 @@ fn refuse_a_different_account(
     incoming_account: Option<&str>,
     alias_was_explicit: bool,
 ) -> Result<()> {
-    let Some(incoming) = incoming_account else {
+    let Some(stored) = profile::conflicting_workspace(paths, alias, incoming_account) else {
         return Ok(());
     };
-    let Ok(existing) = profile::get_profile_from(paths, alias) else {
-        return Ok(());
-    };
-    let Some(stored) = existing.meta.account_id.as_deref() else {
-        return Ok(());
-    };
-    if stored == incoming {
-        return Ok(());
-    }
     // Naming the remedy matters: an operator who already chose this alias
     // cannot act on "pass an explicit alias".
     let remedy = if alias_was_explicit {
@@ -114,16 +105,11 @@ fn refuse_a_different_account(
     anyhow::bail!(
         "profile '{alias}' holds a different account \
          (stored workspace {}, incoming {}). {remedy}",
-        short_workspace(stored),
-        short_workspace(incoming)
+        profile::short_workspace(&stored),
+        incoming_account
+            .map(profile::short_workspace)
+            .unwrap_or_default()
     )
-}
-
-fn short_workspace(account_id: &str) -> String {
-    match account_id.char_indices().nth(8) {
-        Some((index, _)) => format!("{}…", &account_id[..index]),
-        None => account_id.to_string(),
-    }
 }
 
 fn fetch_email(access_token: &str) -> Option<String> {

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -7,6 +7,10 @@ use crate::profile;
 use crate::store;
 
 pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
+    // Reject a bad label before the save switches the live auth file. Failing
+    // afterwards would leave the active account changed under an error exit.
+    label.map(store::validate_label).transpose()?;
+
     let paths = config::default_paths()?;
     let auth_path = paths.codex_auth_json();
     if !auth_path.exists() {
@@ -45,7 +49,12 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     if existing.exists() {
-        refuse_a_different_account(&paths, &resolved_alias, identity.account_id.as_deref())?;
+        refuse_a_different_account(
+            &paths,
+            &resolved_alias,
+            auth.account_id.as_deref(),
+            alias::optional(alias)?.is_some(),
+        )?;
         eprint!(
             "profile '{}' already exists. Overwrite? [y/N] ",
             resolved_alias
@@ -81,6 +90,7 @@ fn refuse_a_different_account(
     paths: &config::Paths,
     alias: &str,
     incoming_account: Option<&str>,
+    alias_was_explicit: bool,
 ) -> Result<()> {
     let Some(incoming) = incoming_account else {
         return Ok(());
@@ -94,10 +104,16 @@ fn refuse_a_different_account(
     if stored == incoming {
         return Ok(());
     }
+    // Naming the remedy matters: an operator who already chose this alias
+    // cannot act on "pass an explicit alias".
+    let remedy = if alias_was_explicit {
+        format!("Choose another alias, or remove it first: codexctl remove {alias}")
+    } else {
+        "Pass an explicit alias: codexctl save <alias>".to_string()
+    };
     anyhow::bail!(
         "profile '{alias}' holds a different account \
-         (stored workspace {}, incoming {}). \
-         Pass an explicit alias: codexctl save <alias>",
+         (stored workspace {}, incoming {}). {remedy}",
         short_workspace(stored),
         short_workspace(incoming)
     )

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context, Result};
 
 use crate::api;
+use crate::commands::adopt;
 use crate::commands::alias;
 use crate::config;
 use crate::profile;
 use crate::store;
 
-pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
+pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Result<()> {
     // Reject a bad label before the save switches the live auth file. Failing
     // afterwards would leave the active account changed under an error exit.
     label.map(store::validate_label).transpose()?;
@@ -51,8 +52,9 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     // What the operator is agreeing to replace, so the approval cannot be
     // applied to some other credential that lands there while they answer.
     let mut confirmed_state: Option<Option<Vec<u8>>> = None;
+    let mut adoption_approved = false;
     if existing.exists() {
-        refuse_a_different_account(
+        let adoption = classify_overwrite(
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
@@ -63,13 +65,30 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
         // is being shown and agreeing to replace. Reading it afterwards would
         // silently adopt whatever landed there while they were deciding.
         let shown = stored_credentials(&existing);
-        eprint!(
-            "profile '{}' already exists. Overwrite? [y/N] ",
-            resolved_alias
-        );
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        if !input.trim().eq_ignore_ascii_case("y") {
+        let approved = match adoption {
+            Adoption::Unneeded => {
+                eprint!(
+                    "profile '{}' already exists. Overwrite? [y/N] ",
+                    resolved_alias
+                );
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                input.trim().eq_ignore_ascii_case("y")
+            }
+            // The adoption question already asks to replace these credentials,
+            // so it stands in for the overwrite prompt rather than following it.
+            Adoption::AskOperator { stored } => {
+                adoption_approved = adopt::approve_adoption(
+                    &resolved_alias,
+                    stored.as_deref(),
+                    auth.account_id.as_deref(),
+                    allow_adopt,
+                    &mut std::io::stderr(),
+                );
+                adoption_approved
+            }
+        };
+        if !approved {
             println!("aborted");
             return Ok(());
         }
@@ -104,6 +123,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
         &auth,
         alias::optional(alias)?.is_some(),
         confirmed_state,
+        adoption_approved,
     );
     let _ = std::fs::remove_file(&snapshot);
     saved?;
@@ -124,6 +144,7 @@ fn save_verified_snapshot(
     verified: &api::AuthJson,
     alias_was_explicit: bool,
     confirmed_state: Option<Option<Vec<u8>>>,
+    adoption_approved: bool,
 ) -> Result<()> {
     let live_now = api::read_auth_json(snapshot)?;
     // The workspace can change without the token changing: `auth.json` carries
@@ -138,13 +159,19 @@ fn save_verified_snapshot(
         );
     }
     if store::profile_dir(paths, resolved_alias)?.exists() {
-        refuse_a_different_account(
+        // Re-run under the lock against the store as it actually stands. An
+        // adoption the operator already approved carries over; one that only
+        // became necessary since does not, because nobody was asked about it.
+        if let Adoption::AskOperator { stored } = classify_overwrite(
             paths,
             resolved_alias,
             live_now.account_id.as_deref(),
             api::token_login(&live_now.access_token).as_deref(),
             alias_was_explicit,
-        )?;
+        )? && !adoption_approved
+        {
+            return Err(adopt::refusal(resolved_alias, stored.as_deref()));
+        }
         // Re-prompting is not an option with the lock held, so an approval that
         // no longer describes what is stored is refused instead of reused.
         let dir = store::profile_dir(paths, resolved_alias)?;
@@ -180,27 +207,40 @@ fn stored_credentials(dir: &std::path::Path) -> Option<Vec<u8>> {
     std::fs::read(dir.join("auth.json")).ok()
 }
 
-/// Stop before the overwrite prompt when the target profile holds a *different*
-/// workspace.
+/// What must be settled before this save may overwrite the target profile.
+enum Adoption {
+    /// Nothing. The profile is free, or it holds this same account.
+    Unneeded,
+    /// The profile neither matches nor contradicts this account, so the store
+    /// has no way to decide. Only the operator can say whether replacing it is
+    /// right, so this is a question rather than a refusal.
+    AskOperator { stored: Option<String> },
+}
+
+/// Decide how the target profile stands against the account being saved.
 ///
-/// Without an explicit alias `save` defaults to the detected email, so a second
-/// account on one address lands on the first account's profile. There the
-/// destructive answer is a single keystroke, and the right action is always to
-/// pick another alias — so this is an error rather than another prompt.
+/// A profile whose claims positively disagree is refused outright: without an
+/// explicit alias `save` defaults to the detected email, so a second account on
+/// one address lands on the first account's profile, where the destructive
+/// answer is a single keystroke. No answer makes those the same account.
 ///
-/// A refusal needs positive evidence of a different account. When either side
-/// has no workspace identifier the command falls through to the usual prompt.
-fn refuse_a_different_account(
+/// A profile that declares nothing is a different case and is returned for the
+/// operator to settle. See `commands::adopt`.
+fn classify_overwrite(
     paths: &config::Paths,
     alias: &str,
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
     alias_was_explicit: bool,
-) -> Result<()> {
-    let Some(stored) =
+) -> Result<Adoption> {
+    let Some(conflict) =
         profile::conflicting_workspace(paths, alias, incoming_account, incoming_user)
     else {
-        return Ok(());
+        return Ok(Adoption::Unneeded);
+    };
+    let stored = conflict.stored().map(str::to_string);
+    let profile::AccountConflict::Different(stored) = conflict else {
+        return Ok(Adoption::AskOperator { stored });
     };
     // Naming the remedy matters: an operator who already chose this alias
     // cannot act on "pass an explicit alias".
@@ -280,6 +320,63 @@ mod tests {
         std::fs::read_to_string(paths.profiles_dir().join("work").join("auth.json")).unwrap()
     }
 
+    /// A token that names a workspace, unlike `token`.
+    fn workspace_token(account: &str) -> String {
+        use base64::Engine;
+        let claims = format!(
+            r#"{{"sub":"seatA","https://api.openai.com/auth":{{"chatgpt_account_id":"{account}"}}}}"#
+        );
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        format!("{JWT_HDR}.{payload}.sig")
+    }
+
+    /// The stored profile declares no workspace, so it can be neither matched
+    /// to the arriving account nor ruled out. Without an answer the save keeps
+    /// what is there, and says which flag supplies one.
+    #[test]
+    fn refuses_an_unidentifiable_profile_without_approval() {
+        let (_tmp, paths, snapshot) = setup(&token("legacy"));
+        let arriving = auth_bytes(&workspace_token("acct-team"));
+        std::fs::write(&snapshot, &arriving).unwrap();
+        let approved = Some(Some(auth_bytes(&token("legacy")).into_bytes()));
+
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        let error = save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, false,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("--allow-adopt"), "{error}");
+        assert!(
+            stored(&paths).contains(&token("legacy")),
+            "the unidentifiable profile was replaced without approval"
+        );
+    }
+
+    /// The same situation with the answer given. The refusal above is a
+    /// default, not a wall: `remove` followed by a fresh save would perform this
+    /// very replacement after destroying the metadata that describes it.
+    #[test]
+    fn adopts_an_unidentifiable_profile_when_approved() {
+        let (_tmp, paths, snapshot) = setup(&token("legacy"));
+        let incoming = workspace_token("acct-team");
+        std::fs::write(&snapshot, auth_bytes(&incoming)).unwrap();
+        let approved = Some(Some(auth_bytes(&token("legacy")).into_bytes()));
+
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, true,
+        )
+        .unwrap();
+
+        assert!(
+            stored(&paths).contains(&incoming),
+            "the approved save did not land"
+        );
+    }
+
     /// The operator approved replacing one credential. Another process replaced
     /// it while they were answering, so the approval no longer describes what
     /// is there and the save must not proceed on it.
@@ -294,7 +391,7 @@ mod tests {
         let lock = store::lock(&paths).unwrap();
         let verified = api::read_auth_json(&snapshot).unwrap();
         let error = save_verified_snapshot(
-            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, false,
         )
         .unwrap_err();
 
@@ -314,7 +411,7 @@ mod tests {
         let lock = store::lock(&paths).unwrap();
         let verified = api::read_auth_json(&snapshot).unwrap();
         let error = save_verified_snapshot(
-            &lock, &paths, "work", None, None, &snapshot, &verified, true, None,
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, None, false,
         )
         .unwrap_err();
 
@@ -338,7 +435,7 @@ mod tests {
 
         let lock = store::lock(&paths).unwrap();
         let error = save_verified_snapshot(
-            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, false,
         )
         .unwrap_err();
 
@@ -358,7 +455,7 @@ mod tests {
         let lock = store::lock(&paths).unwrap();
         let verified = api::read_auth_json(&snapshot).unwrap();
         save_verified_snapshot(
-            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, false,
         )
         .unwrap();
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -74,6 +74,18 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     // answer. That makes the checks so far advisory, so they are re-run here
     // against the store as it actually stands at write time.
     let lock = store::lock(&paths)?;
+    // Everything above was decided from the auth file as it read at the start,
+    // and `codexctl use` can rewrite that file while the prompt waits. The alias
+    // and email were derived from that token, so a changed file invalidates the
+    // decision itself, not just the checks — copying it now would store one
+    // account's credentials under another's alias and email.
+    let live_now = api::read_auth_json(&auth_path)?;
+    if live_now.access_token != auth.access_token {
+        anyhow::bail!(
+            "the active account changed while this save was preparing. \
+             Re-run the command to save the account that is active now."
+        );
+    }
     if store::profile_dir(&paths, &resolved_alias)?.exists() {
         refuse_a_different_account(
             &paths,

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -80,7 +80,11 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     // decision itself, not just the checks — copying it now would store one
     // account's credentials under another's alias and email.
     let live_now = api::read_auth_json(&auth_path)?;
-    if live_now.access_token != auth.access_token {
+    // The workspace can change without the token changing: `auth.json` carries
+    // an explicit `account_id` that `read_auth_json` prefers over the JWT claim,
+    // so comparing tokens alone would let a switched workspace through under the
+    // alias and email resolved for the previous one.
+    if live_now.access_token != auth.access_token || live_now.account_id != auth.account_id {
         anyhow::bail!(
             "the active account changed while this save was preparing. \
              Re-run the command to save the account that is active now."

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -50,7 +50,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
     // applied to some other credential that lands there while they answer.
-    let mut confirmed_state: Option<Option<String>> = None;
+    let mut confirmed_state: Option<Option<Vec<u8>>> = None;
     if existing.exists() {
         refuse_a_different_account(
             &paths,
@@ -69,7 +69,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             println!("aborted");
             return Ok(());
         }
-        confirmed_state = Some(stored_access_token(&existing));
+        confirmed_state = Some(stored_credentials(&existing));
     }
 
     // The lock is taken only now: holding it across the prompt above would
@@ -119,7 +119,7 @@ fn save_verified_snapshot(
     snapshot: &std::path::Path,
     verified: &api::AuthJson,
     alias_was_explicit: bool,
-    confirmed_state: Option<Option<String>>,
+    confirmed_state: Option<Option<Vec<u8>>>,
 ) -> Result<()> {
     let live_now = api::read_auth_json(snapshot)?;
     // The workspace can change without the token changing: `auth.json` carries
@@ -153,7 +153,7 @@ fn save_verified_snapshot(
             ),
             // It was approved, but something replaced its credentials since —
             // and the approval was for what used to be there.
-            Some(approved) if *approved != stored_access_token(&dir) => anyhow::bail!(
+            Some(approved) if *approved != stored_credentials(&dir) => anyhow::bail!(
                 "profile '{resolved_alias}' changed while this save was preparing, so the \
                  confirmation no longer applies to what it holds. Re-run the command."
             ),
@@ -167,13 +167,13 @@ fn save_verified_snapshot(
     Ok(())
 }
 
-/// The access token a profile directory currently holds, if any is readable.
-/// Used only to tell whether the thing an operator approved replacing is still
-/// the thing about to be replaced.
-fn stored_access_token(dir: &std::path::Path) -> Option<String> {
-    api::read_auth_json(&dir.join("auth.json"))
-        .ok()
-        .map(|auth| auth.access_token)
+/// Exactly what a profile directory currently stores, if anything readable.
+///
+/// The raw bytes rather than one parsed field: a refresh can rotate the refresh
+/// token while the access token stays put, and an approval given for the old
+/// credential must not be honoured against the new one.
+fn stored_credentials(dir: &std::path::Path) -> Option<Vec<u8>> {
+    std::fs::read(dir.join("auth.json")).ok()
 }
 
 /// Stop before the overwrite prompt when the target profile holds a *different*

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -6,6 +6,7 @@ use crate::commands::alias;
 use crate::config;
 use crate::profile;
 use crate::store;
+use std::io::IsTerminal;
 
 pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Result<()> {
     // Reject a bad label before the save switches the live auth file. Failing
@@ -64,7 +65,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         // Read before the question is asked: this is the credential the operator
         // is being shown and agreeing to replace. Reading it afterwards would
         // silently adopt whatever landed there while they were deciding.
-        let shown = stored_credentials(&existing);
+        let shown = adopt::stored_credentials(&existing);
         let approved = match adoption {
             Adoption::Unneeded => {
                 eprint!(
@@ -83,6 +84,8 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
                     stored.as_deref(),
                     auth.account_id.as_deref(),
                     allow_adopt,
+                    std::io::stdin().is_terminal(),
+                    &mut std::io::stdin().lock(),
                     &mut std::io::stderr(),
                 ) {
                     adopt::Approval::Granted => {
@@ -194,7 +197,7 @@ fn save_verified_snapshot(
             ),
             // It was approved, but something replaced its credentials since —
             // and the approval was for what used to be there.
-            Some(approved) if *approved != stored_credentials(&dir) => anyhow::bail!(
+            Some(approved) if *approved != adopt::stored_credentials(&dir) => anyhow::bail!(
                 "profile '{resolved_alias}' changed while this save was preparing, so the \
                  confirmation no longer applies to what it holds. Re-run the command."
             ),
@@ -206,15 +209,6 @@ fn save_verified_snapshot(
         profile::set_label_locked(lock, paths, resolved_alias, Some(label))?;
     }
     Ok(())
-}
-
-/// Exactly what a profile directory currently stores, if anything readable.
-///
-/// The raw bytes rather than one parsed field: a refresh can rotate the refresh
-/// token while the access token stays put, and an approval given for the old
-/// credential must not be honoured against the new one.
-fn stored_credentials(dir: &std::path::Path) -> Option<Vec<u8>> {
-    std::fs::read(dir.join("auth.json")).ok()
 }
 
 /// What must be settled before this save may overwrite the target profile.

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -239,3 +239,132 @@ fn fetch_email(access_token: &str) -> Option<String> {
     let me: MeResponse = resp.json().ok()?;
     me.email
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Paths;
+
+    const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+
+    fn token(jti: &str) -> String {
+        use base64::Engine;
+        let claims = format!(r#"{{"sub":"seatA","jti":"{jti}"}}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        format!("{JWT_HDR}.{payload}.sig")
+    }
+
+    fn auth_bytes(access: &str) -> String {
+        format!(r#"{{"access_token":"{access}"}}"#)
+    }
+
+    /// A store with `alias` holding `access`, plus a snapshot of the live file.
+    fn setup(access: &str) -> (tempfile::TempDir, Paths, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        paths.ensure_dirs().unwrap();
+        let dir = paths.profiles_dir().join("work");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), auth_bytes(access)).unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            r#"{"alias":"work","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+        let snapshot = tmp.path().join("snapshot.json");
+        std::fs::write(&snapshot, auth_bytes(&token("live"))).unwrap();
+        (tmp, paths, snapshot)
+    }
+
+    fn stored(paths: &Paths) -> String {
+        std::fs::read_to_string(paths.profiles_dir().join("work").join("auth.json")).unwrap()
+    }
+
+    /// The operator approved replacing one credential. Another process replaced
+    /// it while they were answering, so the approval no longer describes what
+    /// is there and the save must not proceed on it.
+    #[test]
+    fn refuses_when_the_profile_changed_after_confirmation() {
+        let (_tmp, paths, snapshot) = setup(&token("approved"));
+        let approved = Some(Some(auth_bytes(&token("approved")).into_bytes()));
+        // A concurrent write lands between the prompt and the lock.
+        let newer = auth_bytes(&token("newer"));
+        std::fs::write(paths.profiles_dir().join("work").join("auth.json"), &newer).unwrap();
+
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        let error = save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("changed while this save"),
+            "{error}"
+        );
+        assert_eq!(stored(&paths), newer, "the newer credential was replaced");
+    }
+
+    /// The profile did not exist when the command decided, so nobody approved
+    /// overwriting it.
+    #[test]
+    fn refuses_an_unconfirmed_profile_that_appeared() {
+        let (_tmp, paths, snapshot) = setup(&token("existing"));
+
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        let error = save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("created by another process"),
+            "{error}"
+        );
+    }
+
+    /// The live file moved to another account while the prompt was open, so the
+    /// alias and email resolved earlier no longer describe it.
+    #[test]
+    fn refuses_when_the_live_credential_changed() {
+        let (_tmp, paths, snapshot) = setup(&token("approved"));
+        let approved = Some(Some(auth_bytes(&token("approved")).into_bytes()));
+        // `verified` describes what was read before the prompt; the snapshot
+        // holds what is there now.
+        let before = _tmp.path().join("before.json");
+        std::fs::write(&before, auth_bytes(&token("before"))).unwrap();
+        let verified = api::read_auth_json(&before).unwrap();
+
+        let lock = store::lock(&paths).unwrap();
+        let error = save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("active account changed"),
+            "{error}"
+        );
+    }
+
+    /// Nothing changed: the approval still describes the profile, so the save
+    /// goes through.
+    #[test]
+    fn saves_when_nothing_changed_after_confirmation() {
+        let (_tmp, paths, snapshot) = setup(&token("approved"));
+        let approved = Some(Some(auth_bytes(&token("approved")).into_bytes()));
+
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved,
+        )
+        .unwrap();
+
+        assert!(
+            stored(&paths).contains(&token("live")),
+            "the snapshot was not saved"
+        );
+    }
+}

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -70,7 +70,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
-            api::token_login(&auth.access_token).as_deref(),
+            &api::token_logins(&auth.access_token),
             alias::optional(alias)?.is_some(),
         )?;
         // Read before the question is asked: this is the credential the operator
@@ -190,7 +190,7 @@ fn save_verified_snapshot(
             paths,
             resolved_alias,
             live_now.account_id.as_deref(),
-            api::token_login(&live_now.access_token).as_deref(),
+            &api::token_logins(&live_now.access_token),
             alias_was_explicit,
         )? && !adoption_approved
         {
@@ -245,7 +245,7 @@ fn classify_overwrite(
     paths: &config::Paths,
     alias: &str,
     incoming_account: Option<&str>,
-    incoming_user: Option<&str>,
+    incoming_user: &api::Logins,
     alias_was_explicit: bool,
 ) -> Result<Adoption> {
     let Some(conflict) =

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -266,8 +266,8 @@ fn classify_overwrite(
     };
     anyhow::bail!(
         "profile '{alias}' holds a different account \
-         (stored workspace {}, incoming {}). {remedy}",
-        profile::short_workspace(&stored),
+         (stored {}, incoming {}). {remedy}",
+        profile::describe_claim(&stored),
         incoming_account
             .map(profile::short_workspace)
             .unwrap_or_default()

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -67,9 +67,28 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
         }
     }
 
-    profile::save_profile_and_activate(&resolved_alias, email.as_deref(), &auth_path)?;
+    // The lock is taken only now: holding it across the prompt above would
+    // block every other codexctl process for as long as the operator takes to
+    // answer. That makes the checks so far advisory, so they are re-run here
+    // against the store as it actually stands at write time.
+    let lock = store::lock(&paths)?;
+    if store::profile_dir(&paths, &resolved_alias)?.exists() {
+        refuse_a_different_account(
+            &paths,
+            &resolved_alias,
+            auth.account_id.as_deref(),
+            alias::optional(alias)?.is_some(),
+        )?;
+    }
+    profile::save_profile_and_activate_locked(
+        &lock,
+        &paths,
+        &resolved_alias,
+        email.as_deref(),
+        &auth_path,
+    )?;
     if let Some(label) = label {
-        profile::set_label_from(&paths, &resolved_alias, Some(label))?;
+        profile::set_label_locked(&lock, &paths, &resolved_alias, Some(label))?;
     }
 
     println!("saved profile '{}'", resolved_alias);

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -59,6 +59,10 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             api::token_login(&auth.access_token).as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
+        // Read before the question is asked: this is the credential the operator
+        // is being shown and agreeing to replace. Reading it afterwards would
+        // silently adopt whatever landed there while they were deciding.
+        let shown = stored_credentials(&existing);
         eprint!(
             "profile '{}' already exists. Overwrite? [y/N] ",
             resolved_alias
@@ -69,7 +73,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             println!("aborted");
             return Ok(());
         }
-        confirmed_state = Some(stored_credentials(&existing));
+        confirmed_state = Some(shown);
     }
 
     // The lock is taken only now: holding it across the prompt above would

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -9,6 +9,17 @@ use crate::store;
 use std::io::IsTerminal;
 
 pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Result<()> {
+    // Consent has to name what it consents to. Without an alias, `save` derives
+    // one from the token's email claim, so the flag would pre-approve replacing
+    // whichever profile that resolves to — and one login can hold seats in
+    // several workspaces behind a single address. The operator would be
+    // approving a target they never saw.
+    if allow_adopt && alias.is_none() {
+        anyhow::bail!(
+            "--allow-adopt replaces a saved profile, so name the one you are approving: \
+             codexctl save <alias> --allow-adopt"
+        );
+    }
     // Reject a bad label before the save switches the live auth file. Failing
     // afterwards would leave the active account changed under an error exit.
     label.map(store::validate_label).transpose()?;

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -54,6 +54,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
+            identity.user_id.as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
         eprint!(
@@ -95,6 +96,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
+            identity.user_id.as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
         // The profile appeared while this command was deciding, so nobody
@@ -137,9 +139,12 @@ fn refuse_a_different_account(
     paths: &config::Paths,
     alias: &str,
     incoming_account: Option<&str>,
+    incoming_user: Option<&str>,
     alias_was_explicit: bool,
 ) -> Result<()> {
-    let Some(stored) = profile::conflicting_workspace(paths, alias, incoming_account) else {
+    let Some(stored) =
+        profile::conflicting_workspace(paths, alias, incoming_account, incoming_user)
+    else {
         return Ok(());
     };
     // Naming the remedy matters: an operator who already chose this alias

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -160,7 +160,7 @@ fn save_verified_snapshot(
             Some(_) => {}
         }
     }
-    profile::save_profile_and_activate_locked(lock, paths, resolved_alias, email, snapshot)?;
+    profile::save_live_profile_locked(lock, paths, resolved_alias, email, snapshot)?;
     if let Some(label) = label {
         profile::set_label_locked(lock, paths, resolved_alias, Some(label))?;
     }

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -48,6 +48,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     };
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
+    let mut overwrite_confirmed = false;
     if existing.exists() {
         refuse_a_different_account(
             &paths,
@@ -65,6 +66,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             println!("aborted");
             return Ok(());
         }
+        overwrite_confirmed = true;
     }
 
     // The lock is taken only now: holding it across the prompt above would
@@ -79,6 +81,16 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             auth.account_id.as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
+        // The profile appeared while this command was deciding, so nobody
+        // approved overwriting it. Re-prompting is not an option with the lock
+        // held, so stop and let the operator run the command again against the
+        // store as it now stands.
+        if !overwrite_confirmed {
+            anyhow::bail!(
+                "profile '{resolved_alias}' was created by another process while this save was \
+                 preparing. Re-run the command to confirm overwriting it."
+            );
+        }
     }
     profile::save_profile_and_activate_locked(
         &lock,

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -78,14 +78,24 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
             // The adoption question already asks to replace these credentials,
             // so it stands in for the overwrite prompt rather than following it.
             Adoption::AskOperator { stored } => {
-                adoption_approved = adopt::approve_adoption(
+                match adopt::approve_adoption(
                     &resolved_alias,
                     stored.as_deref(),
                     auth.account_id.as_deref(),
                     allow_adopt,
                     &mut std::io::stderr(),
-                );
-                adoption_approved
+                ) {
+                    adopt::Approval::Granted => {
+                        adoption_approved = true;
+                        true
+                    }
+                    adopt::Approval::Declined => false,
+                    // Not the operator declining — nobody was there to ask. A
+                    // quiet exit 0 here would report a save that did not happen.
+                    adopt::Approval::NoTerminal => {
+                        return Err(adopt::refusal(&resolved_alias, stored.as_deref()));
+                    }
+                }
             }
         };
         if !approved {

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -80,24 +80,64 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     // and email were derived from that token, so a changed file invalidates the
     // decision itself, not just the checks — copying it now would store one
     // account's credentials under another's alias and email.
-    let live_now = api::read_auth_json(&auth_path)?;
+    // Snapshot the live file and work from the snapshot for the rest of this
+    // command. A native `codex login` or refresh does not take this lock, so
+    // re-reading the path later — as the profile writer would — could copy
+    // different bytes than the ones checked here.
+    let snapshot = paths.codexctl_dir().join(".save-snapshot.json");
+    let live_bytes = std::fs::read(&auth_path)
+        .with_context(|| format!("failed to read {}", auth_path.display()))?;
+    store::atomic_write(&snapshot, &live_bytes)?;
+    let saved = save_verified_snapshot(
+        &lock,
+        &paths,
+        &resolved_alias,
+        label,
+        email.as_deref(),
+        &snapshot,
+        &auth,
+        alias::optional(alias)?.is_some(),
+        overwrite_confirmed,
+    );
+    let _ = std::fs::remove_file(&snapshot);
+    saved?;
+
+    println!("saved profile '{}'", resolved_alias);
+    Ok(())
+}
+
+/// The locked half of `save`, working only from the snapshot taken above.
+#[allow(clippy::too_many_arguments)]
+fn save_verified_snapshot(
+    lock: &store::StoreLock,
+    paths: &config::Paths,
+    resolved_alias: &str,
+    label: Option<&str>,
+    email: Option<&str>,
+    snapshot: &std::path::Path,
+    verified: &api::AuthJson,
+    alias_was_explicit: bool,
+    overwrite_confirmed: bool,
+) -> Result<()> {
+    let live_now = api::read_auth_json(snapshot)?;
     // The workspace can change without the token changing: `auth.json` carries
     // an explicit `account_id` that `read_auth_json` prefers over the JWT claim,
     // so comparing tokens alone would let a switched workspace through under the
     // alias and email resolved for the previous one.
-    if live_now.access_token != auth.access_token || live_now.account_id != auth.account_id {
+    if live_now.access_token != verified.access_token || live_now.account_id != verified.account_id
+    {
         anyhow::bail!(
             "the active account changed while this save was preparing. \
              Re-run the command to save the account that is active now."
         );
     }
-    if store::profile_dir(&paths, &resolved_alias)?.exists() {
+    if store::profile_dir(paths, resolved_alias)?.exists() {
         refuse_a_different_account(
-            &paths,
-            &resolved_alias,
-            auth.account_id.as_deref(),
-            api::token_login(&auth.access_token).as_deref(),
-            alias::optional(alias)?.is_some(),
+            paths,
+            resolved_alias,
+            live_now.account_id.as_deref(),
+            api::token_login(&live_now.access_token).as_deref(),
+            alias_was_explicit,
         )?;
         // The profile appeared while this command was deciding, so nobody
         // approved overwriting it. Re-prompting is not an option with the lock
@@ -110,18 +150,10 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             );
         }
     }
-    profile::save_profile_and_activate_locked(
-        &lock,
-        &paths,
-        &resolved_alias,
-        email.as_deref(),
-        &auth_path,
-    )?;
+    profile::save_profile_and_activate_locked(lock, paths, resolved_alias, email, snapshot)?;
     if let Some(label) = label {
-        profile::set_label_locked(&lock, &paths, &resolved_alias, Some(label))?;
+        profile::set_label_locked(lock, paths, resolved_alias, Some(label))?;
     }
-
-    println!("saved profile '{}'", resolved_alias);
     Ok(())
 }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -48,7 +48,9 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
     };
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
-    let mut overwrite_confirmed = false;
+    // What the operator is agreeing to replace, so the approval cannot be
+    // applied to some other credential that lands there while they answer.
+    let mut confirmed_state: Option<Option<String>> = None;
     if existing.exists() {
         refuse_a_different_account(
             &paths,
@@ -67,7 +69,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             println!("aborted");
             return Ok(());
         }
-        overwrite_confirmed = true;
+        confirmed_state = Some(stored_access_token(&existing));
     }
 
     // The lock is taken only now: holding it across the prompt above would
@@ -97,7 +99,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
         &snapshot,
         &auth,
         alias::optional(alias)?.is_some(),
-        overwrite_confirmed,
+        confirmed_state,
     );
     let _ = std::fs::remove_file(&snapshot);
     saved?;
@@ -117,7 +119,7 @@ fn save_verified_snapshot(
     snapshot: &std::path::Path,
     verified: &api::AuthJson,
     alias_was_explicit: bool,
-    overwrite_confirmed: bool,
+    confirmed_state: Option<Option<String>>,
 ) -> Result<()> {
     let live_now = api::read_auth_json(snapshot)?;
     // The workspace can change without the token changing: `auth.json` carries
@@ -139,15 +141,23 @@ fn save_verified_snapshot(
             api::token_login(&live_now.access_token).as_deref(),
             alias_was_explicit,
         )?;
-        // The profile appeared while this command was deciding, so nobody
-        // approved overwriting it. Re-prompting is not an option with the lock
-        // held, so stop and let the operator run the command again against the
-        // store as it now stands.
-        if !overwrite_confirmed {
-            anyhow::bail!(
+        // Re-prompting is not an option with the lock held, so an approval that
+        // no longer describes what is stored is refused instead of reused.
+        let dir = store::profile_dir(paths, resolved_alias)?;
+        match &confirmed_state {
+            // The profile appeared while this command was deciding, so nobody
+            // approved overwriting it.
+            None => anyhow::bail!(
                 "profile '{resolved_alias}' was created by another process while this save was \
                  preparing. Re-run the command to confirm overwriting it."
-            );
+            ),
+            // It was approved, but something replaced its credentials since —
+            // and the approval was for what used to be there.
+            Some(approved) if *approved != stored_access_token(&dir) => anyhow::bail!(
+                "profile '{resolved_alias}' changed while this save was preparing, so the \
+                 confirmation no longer applies to what it holds. Re-run the command."
+            ),
+            Some(_) => {}
         }
     }
     profile::save_profile_and_activate_locked(lock, paths, resolved_alias, email, snapshot)?;
@@ -155,6 +165,15 @@ fn save_verified_snapshot(
         profile::set_label_locked(lock, paths, resolved_alias, Some(label))?;
     }
     Ok(())
+}
+
+/// The access token a profile directory currently holds, if any is readable.
+/// Used only to tell whether the thing an operator approved replacing is still
+/// the thing about to be replaced.
+fn stored_access_token(dir: &std::path::Path) -> Option<String> {
+    api::read_auth_json(&dir.join("auth.json"))
+        .ok()
+        .map(|auth| auth.access_token)
 }
 
 /// Stop before the overwrite prompt when the target profile holds a *different*

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -22,7 +22,9 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     }
     // Reject a bad label before the save switches the live auth file. Failing
     // afterwards would leave the active account changed under an error exit.
-    label.map(store::validate_label).transpose()?;
+    // Validation also trims and reads a blank label as none, so keep its result
+    // rather than storing the raw text.
+    let label = label.map(store::validate_label).transpose()?.flatten();
 
     let paths = config::default_paths()?;
     let auth_path = paths.codex_auth_json();

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -54,7 +54,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
-            identity.user_id.as_deref(),
+            api::token_login(&auth.access_token).as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
         eprint!(
@@ -96,7 +96,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>) -> Result<()> {
             &paths,
             &resolved_alias,
             auth.account_id.as_deref(),
-            identity.user_id.as_deref(),
+            api::token_login(&auth.access_token).as_deref(),
             alias::optional(alias)?.is_some(),
         )?;
         // The profile appeared while this command was deciding, so nobody

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -23,6 +23,9 @@ enum CreditsStatus {
 
 struct RateLimitedAccount {
     alias: String,
+    /// Operator-set display name. Present only when they set one, which is what
+    /// keeps the column out of a table that has nothing to put in it.
+    label: Option<String>,
     limits: Vec<LimitStatus>,
     token_expiry: Option<i64>,
     /// Banked rate-limit resets held by this account.
@@ -116,6 +119,7 @@ fn positional_window_label(position: usize) -> &'static str {
 
 struct UsageBasedAccount {
     alias: String,
+    label: Option<String>,
     credit_balance: Option<String>,
     seat_limit_cents: Option<u64>,
     credits_status: CreditsStatus,
@@ -298,6 +302,7 @@ fn print_rate_limited_table(title: &str, accounts: &[&RateLimitedAccount]) -> bo
 
 struct RateLimitColumns {
     named_limits: bool,
+    labeled: bool,
     windows: Vec<WindowColumn>,
 }
 
@@ -390,12 +395,18 @@ impl RateLimitColumns {
         }
         Self {
             named_limits: healthy.iter().any(|account| account.limits.len() > 1),
+            // An error row still carries its label, so consider every account
+            // here rather than only the healthy ones.
+            labeled: accounts.iter().any(|account| account.label.is_some()),
             windows,
         }
     }
 
     fn headers(&self) -> Vec<String> {
         let mut headers = vec!["Account".to_string()];
+        if self.labeled {
+            headers.push("Label".to_string());
+        }
         if self.named_limits {
             headers.push("Limit".to_string());
         }
@@ -416,14 +427,37 @@ fn print_usage_based_table(title: &str, accounts: &[&UsageBasedAccount]) -> bool
     println!("{title}");
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec![
-        "Account", "Balance", "Seat", "Credits", "Spend", "Token",
-    ]);
+    let headers = usage_based_headers(accounts);
+    let labeled = headers.get(1).is_some_and(|header| header == "Label");
+    table.set_header(headers);
     for account in accounts {
-        table.add_row(render_usage_based_row(account));
+        table.add_row(render_usage_based_row(account, labeled));
     }
     println!("{table}");
     true
+}
+
+fn usage_based_headers(accounts: &[&UsageBasedAccount]) -> Vec<String> {
+    let mut headers = vec!["Account".to_string()];
+    if accounts.iter().any(|account| account.label.is_some()) {
+        headers.push("Label".to_string());
+    }
+    headers.extend(
+        ["Balance", "Seat", "Credits", "Spend", "Token"]
+            .into_iter()
+            .map(str::to_string),
+    );
+    headers
+}
+
+/// Cyan marks the cell that answers "which account is this". It is the same
+/// treatment the active marker gets, and no other cell here is colored unless
+/// its color carries a severity.
+fn label_cell(label: Option<&str>) -> Cell {
+    match label {
+        Some(label) => Cell::new(label).fg(Color::Cyan),
+        None => Cell::new("-"),
+    }
 }
 
 fn is_usage_based_plan(plan: &str) -> bool {
@@ -443,6 +477,7 @@ async fn fetch_and_split(
         .map(|p| {
             let client = client.clone();
             let alias = p.meta.alias.clone();
+            let label = p.meta.label.clone();
             let plan_from_meta = p.meta.plan.clone();
             let is_active = active.as_deref() == Some(&p.meta.alias);
             let auth_path = profile::auth_json_path_for_profile_from(paths, p, active.as_deref());
@@ -456,7 +491,7 @@ async fn fetch_and_split(
                     ),
                     Err(_) => None,
                 };
-                (alias, plan_from_meta, is_active, auth, usage_result)
+                (alias, label, plan_from_meta, is_active, auth, usage_result)
             }
         })
         .collect();
@@ -471,7 +506,7 @@ async fn fetch_and_split(
     // read, so the common case stays at one request per profile.
     let mut rl_needing_credits: Vec<(usize, String, Option<String>)> = Vec::new();
 
-    for (alias, plan_from_meta, is_active, auth, usage_result) in &results {
+    for (alias, label, plan_from_meta, is_active, auth, usage_result) in &results {
         let account_id = auth.as_ref().ok().and_then(|a| a.account_id.clone());
         let auth = match auth {
             Ok(a) => a,
@@ -480,6 +515,7 @@ async fn fetch_and_split(
                 if is_ub {
                     usage_based.push(UsageBasedAccount {
                         alias: alias.clone(),
+                        label: label.clone(),
                         credit_balance: None,
                         seat_limit_cents: None,
                         credits_status: CreditsStatus::None,
@@ -492,6 +528,7 @@ async fn fetch_and_split(
                 } else {
                     rate_limited.push(RateLimitedAccount {
                         alias: alias.clone(),
+                        label: label.clone(),
                         limits: vec![LimitStatus::unavailable()],
                         token_expiry: None,
                         reset_credits: 0,
@@ -520,6 +557,7 @@ async fn fetch_and_split(
                 if is_ub {
                     usage_based.push(UsageBasedAccount {
                         alias: alias.clone(),
+                        label: label.clone(),
                         credit_balance: None,
                         seat_limit_cents: None,
                         credits_status: CreditsStatus::None,
@@ -532,6 +570,7 @@ async fn fetch_and_split(
                 } else {
                     rate_limited.push(RateLimitedAccount {
                         alias: alias.clone(),
+                        label: label.clone(),
                         limits: vec![LimitStatus::unavailable()],
                         token_expiry,
                         reset_credits: 0,
@@ -567,6 +606,7 @@ async fn fetch_and_split(
             let idx = usage_based.len();
             usage_based.push(UsageBasedAccount {
                 alias: alias.clone(),
+                label: label.clone(),
                 credit_balance,
                 seat_limit_cents: None,
                 credits_status,
@@ -588,6 +628,7 @@ async fn fetch_and_split(
             let idx = rate_limited.len();
             rate_limited.push(RateLimitedAccount {
                 alias: alias.clone(),
+                label: label.clone(),
                 limits: rate_limit_statuses(usage),
                 token_expiry,
                 reset_credits: usage.reset_credits_available(),
@@ -719,6 +760,9 @@ fn rate_limit_statuses(usage: &api::RateLimitResponse) -> Vec<LimitStatus> {
 fn render_rate_limited_row(account: &RateLimitedAccount, columns: &RateLimitColumns) -> Vec<Cell> {
     if account.is_error {
         let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
+        if columns.labeled {
+            row.push(label_cell(account.label.as_deref()));
+        }
         if columns.named_limits {
             row.push(Cell::new("-"));
         }
@@ -731,6 +775,9 @@ fn render_rate_limited_row(account: &RateLimitedAccount, columns: &RateLimitColu
     }
 
     let mut row = vec![Cell::new(display_alias(&account.alias, account.is_active))];
+    if columns.labeled {
+        row.push(label_cell(account.label.as_deref()));
+    }
     if columns.named_limits {
         row.push(Cell::new(
             account
@@ -795,18 +842,22 @@ fn resets_cell(s: &RateLimitedAccount) -> Cell {
     }
 }
 
-fn render_usage_based_row(s: &UsageBasedAccount) -> Vec<Cell> {
+fn render_usage_based_row(s: &UsageBasedAccount, labeled: bool) -> Vec<Cell> {
     let alias = display_alias(&s.alias, s.is_active);
+    let mut row = vec![Cell::new(alias)];
+    if labeled {
+        row.push(label_cell(s.label.as_deref()));
+    }
 
     if s.is_error {
-        return vec![
-            Cell::new(alias),
+        row.extend([
             Cell::new("-"),
             Cell::new("-"),
             Cell::new("-"),
             Cell::new("-"),
             token_cell(s.token_expiry, true, &s.error_msg),
-        ];
+        ]);
+        return row;
     }
 
     let balance_str = s
@@ -833,14 +884,14 @@ fn render_usage_based_row(s: &UsageBasedAccount) -> Vec<Cell> {
         ("ok", Color::Green)
     };
 
-    vec![
-        Cell::new(alias),
+    row.extend([
         Cell::new(&balance_str),
         Cell::new(&seat_limit_str),
         Cell::new(credits_str).fg(credits_color),
         Cell::new(spend_str).fg(spend_color),
         token_cell(s.token_expiry, false, &s.error_msg),
-    ]
+    ]);
+    row
 }
 
 /// The "Token" column: how long the stored access token is good for without a
@@ -980,6 +1031,7 @@ mod tests {
     fn rate_limited_account() -> RateLimitedAccount {
         RateLimitedAccount {
             alias: "amir+8@sawmills.ai".to_string(),
+            label: None,
             limits: vec![LimitStatus {
                 name: "Codex".to_string(),
                 windows: vec![
@@ -1015,6 +1067,60 @@ mod tests {
         let row = render_rate_limited_row(&account, &columns);
         assert_eq!(columns.headers().len(), 7);
         assert_eq!(row.len(), 7);
+    }
+
+    /// A store with no labels must render exactly the table it rendered before
+    /// labels existed — no new column full of dashes.
+    #[test]
+    fn rate_limited_table_gains_a_label_column_only_when_labels_exist() {
+        let bare = rate_limited_account();
+        let columns = RateLimitColumns::for_accounts(&[&bare]);
+        assert!(!columns.headers().contains(&"Label".to_string()));
+
+        let labeled = RateLimitedAccount {
+            label: Some("team".to_string()),
+            ..rate_limited_account()
+        };
+        let columns = RateLimitColumns::for_accounts(&[&labeled]);
+        let row = render_rate_limited_row(&labeled, &columns);
+
+        assert_eq!(columns.headers()[1], "Label");
+        assert_eq!(row[1].content(), "team");
+        assert_eq!(row.len(), columns.headers().len());
+    }
+
+    /// The error row must stay aligned once the label column appears.
+    #[test]
+    fn rate_limited_error_row_keeps_its_width_with_labels() {
+        let labeled = RateLimitedAccount {
+            label: Some("team".to_string()),
+            ..rate_limited_account()
+        };
+        let errored = RateLimitedAccount {
+            is_error: true,
+            error_msg: "expired".to_string(),
+            label: Some("personal".to_string()),
+            ..rate_limited_account()
+        };
+
+        let columns = RateLimitColumns::for_accounts(&[&labeled, &errored]);
+
+        assert_eq!(
+            render_rate_limited_row(&errored, &columns).len(),
+            columns.headers().len()
+        );
+    }
+
+    #[test]
+    fn usage_based_table_gains_a_label_column_only_when_labels_exist() {
+        let bare = usage_based_account(None);
+        assert!(!usage_based_headers(&[&bare]).contains(&"Label".to_string()));
+
+        let labeled = usage_based_account(Some("team"));
+        let headers = usage_based_headers(&[&labeled]);
+
+        assert_eq!(headers[1], "Label");
+        assert_eq!(render_usage_based_row(&labeled, true).len(), headers.len());
     }
 
     /// The error row must line up with the normal row or the table breaks.
@@ -1466,10 +1572,10 @@ mod tests {
         assert_eq!(resets_cell(&account).content(), "3");
     }
 
-    #[test]
-    fn render_usage_based_row_has_expected_column_count() {
-        let account = UsageBasedAccount {
+    fn usage_based_account(label: Option<&str>) -> UsageBasedAccount {
+        UsageBasedAccount {
             alias: "amir+11@sawmills.ai".to_string(),
+            label: label.map(str::to_string),
             credit_balance: Some("10.00".to_string()),
             seat_limit_cents: Some(2000),
             credits_status: CreditsStatus::Ok,
@@ -1478,8 +1584,13 @@ mod tests {
             is_active: false,
             is_error: false,
             error_msg: String::new(),
-        };
+        }
+    }
 
-        assert_eq!(render_usage_based_row(&account).len(), 6);
+    #[test]
+    fn render_usage_based_row_has_expected_column_count() {
+        let account = usage_based_account(None);
+
+        assert_eq!(render_usage_based_row(&account, false).len(), 6);
     }
 }

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -18,13 +18,6 @@ pub fn run() -> Result<()> {
     let items: Vec<String> = profiles
         .iter()
         .map(|p| {
-            let email = p.meta.email.as_deref().unwrap_or("-");
-            let marker = if active.as_deref() == Some(&p.meta.alias) {
-                " *"
-            } else {
-                ""
-            };
-
             // Try to fetch usage for display — fall back gracefully
             let auth_path = profile::auth_json_path_for_profile_from(&paths, p, active.as_deref());
             let usage_info = api::read_auth_json(&auth_path)
@@ -35,11 +28,7 @@ pub fn run() -> Result<()> {
                 .map(|usage| usage_summary(&usage))
                 .unwrap_or_default();
 
-            let plan = p.meta.plan.as_deref().unwrap_or("-");
-            format!(
-                "{} ({}) [{}]{}{}",
-                p.meta.alias, email, plan, usage_info, marker
-            )
+            picker_row(p, &usage_info, active.as_deref() == Some(&p.meta.alias))
         })
         .collect();
 
@@ -60,6 +49,27 @@ pub fn run() -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// One row of the fuzzy picker.
+///
+/// The label goes in the text because the picker matches on it: typing `team`
+/// has to find the profile labeled `team`. This is the only place a label
+/// influences selection, and the operator still confirms the highlighted row.
+fn picker_row(p: &profile::Profile, usage_info: &str, is_active: bool) -> String {
+    let email = p.meta.email.as_deref().unwrap_or("-");
+    let plan = p.meta.plan.as_deref().unwrap_or("-");
+    let label = p
+        .meta
+        .label
+        .as_deref()
+        .map(|label| format!(" — {label}"))
+        .unwrap_or_default();
+    let marker = if is_active { " *" } else { "" };
+    format!(
+        "{}{label} ({email}) [{plan}]{usage_info}{marker}",
+        p.meta.alias
+    )
 }
 
 fn usage_summary(usage: &api::RateLimitResponse) -> String {
@@ -89,6 +99,44 @@ fn usage_summary(usage: &api::RateLimitResponse) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn profile_with(alias: &str, label: Option<&str>) -> profile::Profile {
+        profile::Profile {
+            meta: profile::Meta {
+                alias: alias.to_string(),
+                label: label.map(str::to_string),
+                email: Some("amir@sawmills.ai".to_string()),
+                plan: Some("business".to_string()),
+                saved_at: "2026-01-01T00:00:00Z".to_string(),
+                ..profile::Meta::default()
+            },
+            dir: std::path::PathBuf::from("/tmp").join(alias),
+        }
+    }
+
+    /// The picker is the one place a label reaches selection: typing it has to
+    /// match, which means it has to be in the row text.
+    #[test]
+    fn picker_row_carries_the_label_for_fuzzy_matching() {
+        let row = picker_row(&profile_with("amir-2", Some("sawmills seat")), "", false);
+
+        assert!(row.contains("sawmills seat"), "{row}");
+        assert!(row.contains("amir-2"), "{row}");
+    }
+
+    #[test]
+    fn picker_row_omits_the_label_segment_when_unset() {
+        let row = picker_row(&profile_with("amir-2", None), "", false);
+
+        assert_eq!(row, "amir-2 (amir@sawmills.ai) [business]");
+    }
+
+    #[test]
+    fn picker_row_marks_the_active_profile() {
+        let row = picker_row(&profile_with("amir-2", None), "", true);
+
+        assert!(row.ends_with(" *"), "{row}");
+    }
 
     #[test]
     fn usage_summary_uses_declared_durations() {

--- a/src/commands/use_profile.rs
+++ b/src/commands/use_profile.rs
@@ -628,9 +628,8 @@ mod tests {
         profile::Profile {
             meta: profile::Meta {
                 alias: alias.to_string(),
-                email: None,
-                plan: None,
                 saved_at: "2026-01-01T00:00:00Z".to_string(),
+                ..profile::Meta::default()
             },
             dir: Path::new("/tmp").join(alias),
         }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -9,7 +9,13 @@ pub fn run() -> Result<()> {
             let p = profile::get_profile(&alias)?;
             let email = p.meta.email.as_deref().unwrap_or("-");
             let plan = p.meta.plan.as_deref().unwrap_or("-");
-            println!("{} ({}) [{}]", alias, email, plan);
+            let label = p
+                .meta
+                .label
+                .as_deref()
+                .map(|label| format!(" — {label}"))
+                .unwrap_or_default();
+            println!("{alias}{label} ({email}) [{plan}]");
         }
         None => {
             println!("no active profile. Use 'codexctl save' or 'codexctl use <alias>'.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,24 @@ enum Commands {
     Login {
         /// Profile alias to save the login as
         alias: String,
+        /// Display label for the account, e.g. "personal" or "team"
+        #[arg(long)]
+        label: Option<String>,
     },
     /// Save current ~/.codex/auth.json as a profile
     Save {
         /// Custom alias (defaults to email)
         alias: Option<String>,
+        /// Display label for the account, e.g. "personal" or "team"
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Set or clear a profile's display label
+    Label {
+        /// Profile alias to label
+        alias: String,
+        /// Label text (omit to clear the label)
+        text: Option<String>,
     },
     /// Switch to a profile by alias (or most available if omitted)
     Use {
@@ -137,8 +150,18 @@ fn main() {
             };
             commands::status::run(filter)
         }
-        Commands::Login { ref alias } => commands::login::run(alias),
-        Commands::Save { ref alias } => commands::save::run(alias.as_deref()),
+        Commands::Login {
+            ref alias,
+            ref label,
+        } => commands::login::run(alias, label.as_deref()),
+        Commands::Save {
+            ref alias,
+            ref label,
+        } => commands::save::run(alias.as_deref(), label.as_deref()),
+        Commands::Label {
+            ref alias,
+            ref text,
+        } => commands::label::run(alias, text.as_deref()),
         Commands::Use {
             ref alias,
             allow_billing,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,10 @@ enum Commands {
         /// Display label for the account, e.g. "personal" or "team"
         #[arg(long)]
         label: Option<String>,
+        /// Replace a profile that records no account of its own, without
+        /// prompting (needed on a terminal that cannot answer)
+        #[arg(long)]
+        allow_adopt: bool,
     },
     /// Save current ~/.codex/auth.json as a profile
     Save {
@@ -42,6 +46,10 @@ enum Commands {
         /// Display label for the account, e.g. "personal" or "team"
         #[arg(long)]
         label: Option<String>,
+        /// Replace a profile that records no account of its own, without
+        /// prompting (needed on a terminal that cannot answer)
+        #[arg(long)]
+        allow_adopt: bool,
     },
     /// Set or clear a profile's display label
     Label {
@@ -163,11 +171,13 @@ fn main() {
         Commands::Login {
             ref alias,
             ref label,
-        } => commands::login::run(alias, label.as_deref()),
+            allow_adopt,
+        } => commands::login::run(alias, label.as_deref(), allow_adopt),
         Commands::Save {
             ref alias,
             ref label,
-        } => commands::save::run(alias.as_deref(), label.as_deref()),
+            allow_adopt,
+        } => commands::save::run(alias.as_deref(), label.as_deref(), allow_adopt),
         Commands::Label {
             ref alias,
             ref text,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -126,15 +126,14 @@ pub fn save_profile_and_activate_to(
     let alias = store::validate_alias(alias)?;
     let _lock = store::lock(paths)?;
     let live_auth = paths.codex_auth_json();
-    // Resolve ownership before the save rewrites the profile, or the freshly
-    // stored token would make every re-login look like it owns the live file.
-    let live_owner = alias_for_auth_json_from(paths, &live_auth).unwrap_or(None);
     save_profile_unlocked(paths, alias, email, auth_json_src)?;
 
     if auth_json_src != live_auth {
-        if live_owner.as_deref() != Some(alias) {
-            capture_auth_file_profile_tokens(paths, &live_auth);
-        }
+        // Capture protects the *outgoing* profile's rotated tokens. The alias
+        // being written is never outgoing, so it is excluded outright rather
+        // than by inferring ownership — an unreadable or absent stored token
+        // must not be able to route the stale live file back over this login.
+        capture_auth_file_profile_tokens(paths, &live_auth, Some(alias));
         let saved_auth = store::profile_dir(paths, alias)?.join("auth.json");
         store::atomic_copy(&saved_auth, &live_auth)
             .with_context(|| format!("failed to install {}", live_auth.display()))?;
@@ -301,8 +300,11 @@ pub fn switch_to_auth_json_from(paths: &Paths, alias: &str, codex_auth: &Path) -
 
     // Capture the outgoing live tokens before installing the next profile.
     // The exact-token or token-subject guard prevents a foreign live auth file
-    // from overwriting an unrelated saved profile.
-    capture_auth_file_profile_tokens(paths, codex_auth);
+    // from overwriting an unrelated saved profile. Nothing is excluded here:
+    // when the live file belongs to the profile being switched to, folding its
+    // rotated tokens in first is exactly right, since the install then copies
+    // that same freshly-updated file back out.
+    capture_auth_file_profile_tokens(paths, codex_auth, None);
 
     store::atomic_copy(&profile.auth_json_path(), codex_auth)
         .with_context(|| format!("failed to install auth.json at {}", codex_auth.display()))?;
@@ -422,13 +424,16 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
 
 /// Best-effort: fold a live Codex auth file into the saved profile that owns it.
 /// Failures only warn because token capture must not block a requested switch.
-fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path) {
+fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path, skip_alias: Option<&str>) {
     if !codex_auth.exists() {
         return;
     }
     let Ok(Some(alias)) = alias_for_auth_json_from(paths, codex_auth) else {
         return;
     };
+    if skip_alias == Some(alias.as_str()) {
+        return;
+    }
     let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
         return;
     };

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -8,11 +8,19 @@ use crate::api;
 use crate::config::{self, Paths};
 use crate::store;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct Meta {
     pub alias: String,
+    /// Operator-set display name. The one field here a human writes; everything
+    /// else is re-derived from the stored token on each save.
+    pub label: Option<String>,
     pub email: Option<String>,
     pub plan: Option<String>,
+    /// `chatgpt_account_id`: which workspace this profile holds. This is what
+    /// separates two profiles that share one email address.
+    pub account_id: Option<String>,
+    /// `chatgpt_user_id`: which login. Two workspace seats for one human share it.
+    pub user_id: Option<String>,
     pub saved_at: String,
 }
 
@@ -146,15 +154,56 @@ fn save_profile_unlocked(
     store::atomic_copy(auth_json_src, &dest)
         .with_context(|| format!("failed to save auth.json to {}", dest.display()))?;
 
+    let meta_path = dir.join("meta.json");
+    // The label is the operator's, so a re-save carries it over. Every other
+    // field is re-derived from the token that was just stored.
+    let previous_label = read_meta(&meta_path).and_then(|meta| meta.label);
+    let identity = identity_of_auth_file(&dest);
+
     let meta = Meta {
         alias: alias.to_string(),
-        email: email.map(str::to_string),
-        plan: None,
+        label: previous_label,
+        email: identity.email.or_else(|| email.map(str::to_string)),
+        plan: identity.plan,
+        account_id: identity.account_id,
+        user_id: identity.user_id,
         saved_at: chrono::Utc::now().to_rfc3339(),
     };
     let meta_json = serde_json::to_vec_pretty(&meta)?;
-    store::atomic_write(&dir.join("meta.json"), &meta_json)?;
+    store::atomic_write(&meta_path, &meta_json)?;
     Ok(())
+}
+
+fn read_meta(meta_path: &Path) -> Option<Meta> {
+    let contents = std::fs::read_to_string(meta_path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Identity asserted by the token in an auth file. An unreadable file or a
+/// non-JWT token yields an empty identity rather than an error, because a
+/// profile must remain saveable even when its token cannot be understood.
+fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
+    api::read_auth_json(auth_json)
+        .ok()
+        .and_then(|auth| api::token_identity(&auth.access_token))
+        .unwrap_or_default()
+}
+
+/// Set or clear a profile's display label. `None`, or text that is blank once
+/// trimmed, clears it.
+pub fn set_label_from(paths: &Paths, alias: &str, label: Option<&str>) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    let label = label.map(store::validate_label).transpose()?.flatten();
+    let _lock = store::lock(paths)?;
+    let dir = store::profile_dir(paths, alias)?;
+    let meta_path = dir.join("meta.json");
+    let Some(mut meta) = read_meta(&meta_path) else {
+        anyhow::bail!("profile '{}' not found", alias);
+    };
+    meta.alias = alias.to_string();
+    meta.label = label.map(str::to_string);
+    let meta_json = serde_json::to_vec_pretty(&meta)?;
+    store::atomic_write(&meta_path, &meta_json)
 }
 
 pub fn delete_profile_from(paths: &Paths, alias: &str) -> Result<()> {
@@ -265,6 +314,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         return Ok(None);
     };
     let target_sub = api::token_subject(&target_auth.access_token);
+    let target_account = target_auth.account_id.clone();
     let mut profile_auths = Vec::new();
     for profile in list_profiles_from(paths)? {
         let Ok(profile_auth) = api::read_auth_json(&profile.auth_json_path()) else {
@@ -283,7 +333,16 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         .into_iter()
         .filter_map(|(profile, profile_auth)| {
             let profile_sub = api::token_subject(&profile_auth.access_token);
-            (target_sub.is_some() && target_sub == profile_sub).then_some(profile.meta.alias)
+            let same_seat = target_sub.is_some() && target_sub == profile_sub;
+            // One human holding two workspace seats produces two profiles with
+            // the same subject. The workspace is what tells them apart. Only
+            // compare it when both sides declare one, so a token without the
+            // claim keeps the previous behavior instead of excluding itself.
+            let same_workspace = match (&target_account, &profile_auth.account_id) {
+                (Some(target), Some(candidate)) => target == candidate,
+                _ => true,
+            };
+            (same_seat && same_workspace).then_some(profile.meta.alias)
         });
     if let Some(alias) = sub_matches.next()
         && sub_matches.next().is_none()

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -113,8 +113,10 @@ pub fn save_profile_to(
 /// Save a profile and make it active under one store lock.
 ///
 /// When the source is an isolated login home, install it into the live Codex
-/// home. A re-login of the already-active alias deliberately skips capturing
-/// the old live token so it cannot overwrite the new login.
+/// home. Capturing the outgoing live token deliberately skips the alias being
+/// saved, so a stale live token cannot overwrite the login that just replaced
+/// it. Being active is only one way the live file can belong to this alias —
+/// the token itself is the authority.
 pub fn save_profile_and_activate_to(
     paths: &Paths,
     alias: &str,
@@ -123,12 +125,14 @@ pub fn save_profile_and_activate_to(
 ) -> Result<()> {
     let alias = store::validate_alias(alias)?;
     let _lock = store::lock(paths)?;
-    let was_active = get_active_from(paths)?.as_deref() == Some(alias);
+    let live_auth = paths.codex_auth_json();
+    // Resolve ownership before the save rewrites the profile, or the freshly
+    // stored token would make every re-login look like it owns the live file.
+    let live_owner = alias_for_auth_json_from(paths, &live_auth).unwrap_or(None);
     save_profile_unlocked(paths, alias, email, auth_json_src)?;
 
-    let live_auth = paths.codex_auth_json();
     if auth_json_src != live_auth {
-        if !was_active {
+        if live_owner.as_deref() != Some(alias) {
             capture_auth_file_profile_tokens(paths, &live_auth);
         }
         let saved_auth = store::profile_dir(paths, alias)?.join("auth.json");
@@ -192,6 +196,31 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
     // the recorded workspace matches what every other call path resolves.
     identity.account_id = auth.account_id.or(identity.account_id);
     identity
+}
+
+/// The workspace `alias` already holds, when that is positively a *different*
+/// account than `incoming_account`.
+///
+/// `None` means saving is safe, or there is not enough evidence to refuse: a
+/// missing identifier on either side is not proof of a conflict. Both `save`
+/// and `login` gate on this, because either one can replace the credentials of
+/// a profile that belongs to another account on the same login.
+pub fn conflicting_workspace(
+    paths: &Paths,
+    alias: &str,
+    incoming_account: Option<&str>,
+) -> Option<String> {
+    let incoming = incoming_account?;
+    let stored = get_profile_from(paths, alias).ok()?.meta.account_id?;
+    (stored != incoming).then_some(stored)
+}
+
+/// Short workspace id for an error message; the full uuid is noise.
+pub fn short_workspace(account_id: &str) -> String {
+    match account_id.char_indices().nth(8) {
+        Some((index, _)) => format!("{}…", &account_id[..index]),
+        None => account_id.to_string(),
+    }
 }
 
 /// Set or clear a profile's display label. `None`, or text that is blank once

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -344,22 +344,33 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         .collect();
 
     // One human holding two workspace seats produces two profiles with the same
-    // subject, so the workspace is what tells them apart. Narrow to it only when
-    // some candidate actually declares that workspace. A candidate that declares
-    // no workspace is not evidence of a match, so it must never inherit the win
-    // simply because its rival was filtered out — that would defeat the
-    // ambiguity guard and overwrite an unrelated profile's credentials.
+    // subject, so the workspace is what tells them apart.
+    //
+    // A candidate that declares a *different* workspace is positively not the
+    // owner. It can never win, and it must not be quietly dropped either: once
+    // some candidate contradicts the live workspace, a claimless sibling has no
+    // better claim to the tokens, and returning either would overwrite a saved
+    // profile's credentials with an unrelated account's.
     let candidates: Vec<&String> = match &target_account {
         Some(target) => {
+            let declares = |account: &Option<String>| account.as_deref() == Some(target.as_str());
             let same_workspace: Vec<&String> = same_seat
                 .iter()
-                .filter(|(_, account)| account.as_ref() == Some(target))
+                .filter(|(_, account)| declares(account))
                 .map(|(alias, _)| alias)
                 .collect();
-            if same_workspace.is_empty() {
-                same_seat.iter().map(|(alias, _)| alias).collect()
-            } else {
+            let contradicted = same_seat
+                .iter()
+                .any(|(_, account)| account.is_some() && !declares(account));
+
+            if !same_workspace.is_empty() {
                 same_workspace
+            } else if contradicted {
+                Vec::new()
+            } else {
+                // Nothing declares a workspace at all: a profile saved before
+                // the claim was recorded still owns its own rotated tokens.
+                same_seat.iter().map(|(alias, _)| alias).collect()
             }
         }
         None => same_seat.iter().map(|(alias, _)| alias).collect(),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -183,10 +183,15 @@ fn read_meta(meta_path: &Path) -> Option<Meta> {
 /// non-JWT token yields an empty identity rather than an error, because a
 /// profile must remain saveable even when its token cannot be understood.
 fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
-    api::read_auth_json(auth_json)
-        .ok()
-        .and_then(|auth| api::token_identity(&auth.access_token))
-        .unwrap_or_default()
+    let Ok(auth) = api::read_auth_json(auth_json) else {
+        return api::TokenIdentity::default();
+    };
+    let mut identity = api::token_identity(&auth.access_token).unwrap_or_default();
+    // `read_auth_json` already applies the documented precedence: the explicit
+    // auth.json field first, the JWT claim only as a fallback. Use its answer so
+    // the recorded workspace matches what every other call path resolves.
+    identity.account_id = auth.account_id.or(identity.account_id);
+    identity
 }
 
 /// Set or clear a profile's display label. `None`, or text that is blank once
@@ -329,25 +334,39 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         }
     }
 
-    let mut sub_matches = profile_auths
+    let same_seat: Vec<(String, Option<String>)> = profile_auths
         .into_iter()
         .filter_map(|(profile, profile_auth)| {
             let profile_sub = api::token_subject(&profile_auth.access_token);
-            let same_seat = target_sub.is_some() && target_sub == profile_sub;
-            // One human holding two workspace seats produces two profiles with
-            // the same subject. The workspace is what tells them apart. Only
-            // compare it when both sides declare one, so a token without the
-            // claim keeps the previous behavior instead of excluding itself.
-            let same_workspace = match (&target_account, &profile_auth.account_id) {
-                (Some(target), Some(candidate)) => target == candidate,
-                _ => true,
-            };
-            (same_seat && same_workspace).then_some(profile.meta.alias)
-        });
-    if let Some(alias) = sub_matches.next()
-        && sub_matches.next().is_none()
-    {
-        return Ok(Some(alias));
+            (target_sub.is_some() && target_sub == profile_sub)
+                .then_some((profile.meta.alias, profile_auth.account_id))
+        })
+        .collect();
+
+    // One human holding two workspace seats produces two profiles with the same
+    // subject, so the workspace is what tells them apart. Narrow to it only when
+    // some candidate actually declares that workspace. A candidate that declares
+    // no workspace is not evidence of a match, so it must never inherit the win
+    // simply because its rival was filtered out — that would defeat the
+    // ambiguity guard and overwrite an unrelated profile's credentials.
+    let candidates: Vec<&String> = match &target_account {
+        Some(target) => {
+            let same_workspace: Vec<&String> = same_seat
+                .iter()
+                .filter(|(_, account)| account.as_ref() == Some(target))
+                .map(|(alias, _)| alias)
+                .collect();
+            if same_workspace.is_empty() {
+                same_seat.iter().map(|(alias, _)| alias).collect()
+            } else {
+                same_workspace
+            }
+        }
+        None => same_seat.iter().map(|(alias, _)| alias).collect(),
+    };
+
+    if let [alias] = candidates.as_slice() {
+        return Ok(Some((*alias).clone()));
     }
     Ok(None)
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -311,7 +311,16 @@ fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
         return true;
     }
     let left_subject = api::token_subject(&left.access_token);
-    left_subject.is_some() && left_subject == api::token_subject(&right.access_token)
+    if left_subject.is_none() || left_subject != api::token_subject(&right.access_token) {
+        return false;
+    }
+    // The same login is not the same account. Two workspace seats of one human
+    // share a subject, so a declared workspace has to agree as well — otherwise
+    // the live seat's usage renders under the other seat's row.
+    match (&left.account_id, &right.account_id) {
+        (Some(left), Some(right)) => left == right,
+        _ => true,
+    }
 }
 
 pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Option<String>> {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -470,7 +470,11 @@ fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String>
         .into_iter()
         .find_map(|profile| {
             let stored = api::read_auth_json(&profile.auth_json_path()).ok()?;
-            (stored.access_token == target.access_token).then_some(profile.meta.alias)
+            // Token equality is a strong signal but not identity on its own,
+            // so it goes through the same rule as every other attribution.
+            (stored.access_token == target.access_token
+                && workspace_permits(target.account_id.as_deref(), stored.account_id.as_deref()))
+            .then_some(profile.meta.alias)
         })
 }
 
@@ -565,6 +569,7 @@ fn auth_files_have_same_access_token(left: &Path, right: &Path) -> bool {
         return false;
     };
     left.access_token == right.access_token
+        && workspace_permits(left.account_id.as_deref(), right.account_id.as_deref())
 }
 
 fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -691,8 +691,10 @@ fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String>
         .into_iter()
         .filter_map(|profile| {
             let stored = api::read_auth_json(&profile.auth_json_path()).ok()?;
-            (stored.access_token == target.access_token)
-                .then_some((profile.meta.alias, stored.account_id))
+            (stored.access_token == target.access_token).then_some({
+                let workspace = workspace_of_profile(paths, &profile.meta.alias);
+                (profile.meta.alias, workspace)
+            })
         })
         .collect();
     strongest_exact_match(target.account_id.as_deref(), &candidates)
@@ -712,7 +714,12 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
     ) else {
         return false;
     };
-    if target.account_id.is_some() || stored.account_id.is_some() {
+    // The hinted profile's workspace is its effective one, so a claim held only
+    // in metadata still takes this out of the claimless case.
+    if target.account_id.is_some()
+        || stored.account_id.is_some()
+        || workspace_of_profile(paths, &hinted.meta.alias).is_some()
+    {
         return false;
     }
     let Some(subject) = api::token_subject(&target.access_token) else {
@@ -750,7 +757,7 @@ pub fn alias_for_auth_json_with_hint(
     // hint can get. It outranks the store-wide scan, which would otherwise let
     // directory order pick between two aliases saved from the same login.
     if let Some(profile) = &hinted
-        && auth_files_have_same_access_token(auth_json, &profile.auth_json_path())
+        && auth_has_profile_access_token(paths, auth_json, profile)
     {
         return Some(profile.meta.alias.clone());
     }
@@ -831,12 +838,21 @@ pub fn auth_json_path_for_profile_from(
     }
 }
 
-fn auth_files_have_same_access_token(left: &Path, right: &Path) -> bool {
-    let (Ok(left), Ok(right)) = (api::read_auth_json(left), api::read_auth_json(right)) else {
+fn auth_has_profile_access_token(paths: &Paths, auth_json: &Path, profile: &Profile) -> bool {
+    let (Ok(left), Ok(stored)) = (
+        api::read_auth_json(auth_json),
+        api::read_auth_json(&profile.auth_json_path()),
+    ) else {
         return false;
     };
-    left.access_token == right.access_token
-        && workspace_permits(left.account_id.as_deref(), right.account_id.as_deref())
+    // Against the profile's *effective* workspace, metadata included: a stored
+    // token with no claim does not make the profile anonymous, and this
+    // shortcut runs before the fuller ownership check gets a say.
+    left.access_token == stored.access_token
+        && workspace_permits(
+            left.account_id.as_deref(),
+            workspace_of_profile(paths, &profile.meta.alias).as_deref(),
+        )
 }
 
 fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -> bool {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -507,10 +507,7 @@ pub fn conflicting_workspace(
         (incoming_account, stored_workspace.as_deref()),
         (Some(incoming), Some(stored)) if incoming != stored
     );
-    let user_differs = matches!(
-        (incoming_user, stored_user.as_deref()),
-        (Some(incoming), Some(stored)) if incoming != stored
-    );
+    let user_differs = logins_disagree(incoming_user, stored_user.as_deref());
     let described = stored_workspace.clone().or_else(|| stored_user.clone());
     if workspace_differs || user_differs {
         // Describe the claim that actually disagrees. Preferring the workspace
@@ -530,6 +527,19 @@ pub fn conflicting_workspace(
 }
 
 /// Short workspace id for an error message; the full uuid is noise.
+/// Name a stored claim as what it actually is.
+///
+/// A conflict may be proven by either half of the identity, so the value handed
+/// to an operator message is sometimes a workspace and sometimes a login.
+/// Announcing both as "workspace" mislabels the evidence in the one place the
+/// operator uses it to decide.
+pub fn describe_claim(claim: &str) -> String {
+    match claim.split_once(':') {
+        Some(("uid" | "sub", login)) => format!("login {login}"),
+        _ => format!("workspace {}", short_workspace(claim)),
+    }
+}
+
 pub fn short_workspace(account_id: &str) -> String {
     match account_id.char_indices().nth(8) {
         Some((index, _)) => format!("{}…", &account_id[..index]),
@@ -895,6 +905,29 @@ fn exact_token_candidates(paths: &Paths, auth_json: &Path) -> Option<ExactTokenC
         })
         .collect();
     Some((target.account_id, candidates))
+}
+
+/// Whether two login identifiers *prove* they are different people.
+///
+/// Difference is only provable inside one namespace. `uid:` comes from
+/// `chatgpt_user_id` and `sub:` from the JWT subject, and a token gaining the
+/// former does not stop it being the same login — a legacy profile identified as
+/// `sub:S` meeting its own refreshed token, now reporting `uid:U`, is the same
+/// person. Reading that as proof of difference makes the refusal absolute, so
+/// the one population this design exists to migrate would be left with no way
+/// through at all. Unequal across namespaces is unproven, not different: the
+/// caller still treats it as unsettled, so it becomes a question instead.
+fn logins_disagree(incoming: Option<&str>, stored: Option<&str>) -> bool {
+    let (Some(incoming), Some(stored)) = (incoming, stored) else {
+        return false;
+    };
+    let namespace = |login: &str| login.split_once(':').map(|(tag, _)| tag.to_string());
+    match (namespace(incoming), namespace(stored)) {
+        (Some(a), Some(b)) if a == b => incoming != stored,
+        // An untagged value on both sides is a single namespace by default.
+        (None, None) => incoming != stored,
+        _ => false,
+    }
 }
 
 /// Whether a subject-only match on a claimless pair is really undecided.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -633,14 +633,26 @@ fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Opt
     let Some(alias) = alias_for_auth_json_with_hint(paths, exec_auth, pinned_alias) else {
         return;
     };
-    let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
+    capture_into_owner(paths, exec_auth, &alias);
+}
+
+/// Fold `source` into the profile that owns it, once ownership is settled.
+///
+/// Both capture paths share this so neither can drift: the freshness guard, the
+/// copy, and the preservation of a workspace the incoming file omits all belong
+/// together.
+fn capture_into_owner(paths: &Paths, source: &Path, alias: &str) {
+    let Ok(dest) = store::profile_dir(paths, alias).map(|dir| dir.join("auth.json")) else {
         return;
     };
-    if !captured_auth_supersedes_profile(exec_auth, &dest) {
+    // The source is not always the newer copy. A pinned run that already folded
+    // a rotated token into this profile leaves the live file behind, and copying
+    // it now would undo that rotation.
+    if !captured_auth_supersedes_profile(source, &dest) {
         return;
     }
-    let proven_workspace = workspace_of_profile(paths, &alias);
-    if let Err(error) = store::atomic_copy(exec_auth, &dest) {
+    let proven_workspace = workspace_of_profile(paths, alias);
+    if let Err(error) = store::atomic_copy(source, &dest) {
         eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
         return;
     }
@@ -649,9 +661,9 @@ fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Opt
     // evidence a profile written before the metadata field has, and leave every
     // later rotation unattributable — so it is kept in metadata instead.
     if let Some(workspace) = proven_workspace
-        && workspace_of_profile(paths, &alias).is_none()
+        && workspace_of_profile(paths, alias).is_none()
     {
-        record_workspace(paths, &alias, &workspace);
+        record_workspace(paths, alias, &workspace);
     }
 }
 
@@ -695,7 +707,7 @@ fn record_workspace(paths: &Paths, alias: &str, workspace: &str) {
 /// Equally strong matches are genuinely ambiguous and get no answer.
 fn strongest_exact_match(
     target_workspace: Option<&str>,
-    candidates: &[(String, Option<String>)],
+    candidates: &[AliasWorkspace],
 ) -> Option<String> {
     if let [only] = candidates {
         // An identical access token is the same credential, so a lone holder of
@@ -740,12 +752,15 @@ fn strongest_exact_match(
     None
 }
 
+/// A profile alias beside the workspace it effectively holds.
+type AliasWorkspace = (String, Option<String>);
+
+/// The workspace a file declares, and every profile holding its access token.
+type ExactTokenCandidates = (Option<String>, Vec<AliasWorkspace>);
+
 /// The profiles holding this exact access token, with the target's own
 /// workspace, so callers can weigh them rather than take the first that fits.
-fn exact_token_candidates(
-    paths: &Paths,
-    auth_json: &Path,
-) -> Option<(Option<String>, Vec<(String, Option<String>)>)> {
+fn exact_token_candidates(paths: &Paths, auth_json: &Path) -> Option<ExactTokenCandidates> {
     let target = api::read_auth_json(auth_json).ok()?;
     // Enumerated from the store's directories rather than `list_profiles_from`,
     // which skips a profile with no `meta.json`. A save writes `auth.json`
@@ -1102,18 +1117,7 @@ fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path, skip_alias
     if skip_alias == Some(alias.as_str()) {
         return;
     }
-    let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
-        return;
-    };
-    // The live file is not always the newer copy. A pinned run that already
-    // folded a rotated token into this profile leaves the live file behind, and
-    // copying it now would undo that rotation.
-    if !captured_auth_supersedes_profile(codex_auth, &dest) {
-        return;
-    }
-    if let Err(error) = store::atomic_copy(codex_auth, &dest) {
-        eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
-    }
+    capture_into_owner(paths, codex_auth, &alias);
 }
 
 pub fn update_meta_plan_from(paths: &Paths, alias: &str, plan: &str) -> Result<()> {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -651,44 +651,48 @@ fn capture_into_owner(paths: &Paths, source: &Path, alias: &str) {
     if !captured_auth_supersedes_profile(source, &dest) {
         return;
     }
+    // The incoming file may carry no workspace claim while the profile has
+    // proven one. That evidence is written to metadata *before* the copy: once
+    // the auth file is replaced it is gone, and a preservation failure
+    // afterwards would leave the profile unattributable. It also corrects
+    // metadata naming an older workspace, which an interrupted save can leave.
     let proven_workspace = workspace_of_profile(paths, alias);
+    if let Some(workspace) = &proven_workspace {
+        let incoming = api::read_auth_json(source)
+            .ok()
+            .and_then(|auth| auth.account_id);
+        if incoming.as_deref() != Some(workspace.as_str())
+            && let Err(error) = record_workspace(paths, alias, workspace)
+        {
+            eprintln!(
+                "warning: not capturing tokens for profile '{alias}': \
+                 its workspace could not be preserved first: {error}"
+            );
+            return;
+        }
+    }
     if let Err(error) = store::atomic_copy(source, &dest) {
         eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
-        return;
-    }
-    // The captured file may carry no workspace claim while the profile had
-    // proven one. Losing it with the copy would erase the only ownership
-    // evidence a profile written before the metadata field has, and leave every
-    // later rotation unattributable — so it is kept in metadata instead.
-    if let Some(workspace) = proven_workspace
-        && workspace_of_profile(paths, alias).as_deref() != Some(workspace.as_str())
-    {
-        // Not only when the lookup comes back empty: an interrupted save can
-        // leave metadata naming an older workspace, and after the copy that
-        // stale name would answer for the profile — misidentifying it and
-        // refusing the re-login that would repair it.
-        record_workspace(paths, alias, &workspace);
     }
 }
 
 /// Persist a workspace the profile has already proven, without touching its
 /// credentials.
-fn record_workspace(paths: &Paths, alias: &str, workspace: &str) {
-    let Ok(dir) = store::profile_dir(paths, alias) else {
-        return;
-    };
+///
+/// Metadata is written even when there is none to read: an interrupted save
+/// leaves a profile with credentials and no `meta.json`, and that is exactly
+/// the profile whose only workspace evidence a capture is about to replace.
+fn record_workspace(paths: &Paths, alias: &str, workspace: &str) -> Result<()> {
+    let dir = store::profile_dir(paths, alias)?;
     let meta_path = dir.join("meta.json");
-    let Some(mut meta) = read_meta(&meta_path) else {
-        return;
-    };
+    let mut meta = read_meta(&meta_path).unwrap_or_default();
     meta.alias = alias.to_string();
     meta.account_id = Some(workspace.to_string());
-    let Ok(json) = serde_json::to_vec_pretty(&meta) else {
-        return;
-    };
-    if let Err(error) = store::atomic_write(&meta_path, &json) {
-        eprintln!("warning: failed to record the workspace for profile '{alias}': {error}");
+    if meta.saved_at.is_empty() {
+        meta.saved_at = chrono::Utc::now().to_rfc3339();
     }
+    let json = serde_json::to_vec_pretty(&meta)?;
+    store::atomic_write(&meta_path, &json)
 }
 
 /// Which saved profile an auth file belongs to, given the alias the caller
@@ -1023,12 +1027,23 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     // Enumerated from the store's directories: `list_profiles_from` skips a
     // profile with no `meta.json`, and an interrupted save leaves a real one in
     // that shape whose claim still belongs in this decision.
+    let target_login = api::token_login(&target_auth.access_token);
     let mut profile_auths = Vec::new();
     for alias in stored_aliases(paths)? {
         let Ok(dir) = store::profile_dir(paths, &alias) else {
             continue;
         };
         let Ok(profile_auth) = api::read_auth_json(&dir.join("auth.json")) else {
+            // Unreadable credentials, but metadata may still identify the seat.
+            // Dropping such a profile from the vote would let a readable sibling
+            // look like the sole owner of a credential this one may hold, so an
+            // identified one makes the decision undecidable instead.
+            let meta = read_meta(&dir.join("meta.json")).unwrap_or_default();
+            let identifies = (meta.user_id.is_some() && meta.user_id == target_login)
+                || (meta.account_id.is_some() && meta.account_id == target_account);
+            if identifies {
+                return Ok(None);
+            }
             continue;
         };
         profile_auths.push((alias, profile_auth));

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -718,15 +718,24 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
     let Some(subject) = api::token_subject(&target.access_token) else {
         return false;
     };
-    list_profiles_from(paths)
-        .unwrap_or_default()
+    // A store that cannot be read is not evidence that no sibling declares a
+    // workspace, and a half-written profile is still a profile — both count as
+    // ambiguity rather than permission for the hint. Siblings are judged by
+    // their effective workspace, metadata included.
+    let Ok(aliases) = stored_aliases(paths) else {
+        return true;
+    };
+    aliases
         .into_iter()
-        .filter(|profile| profile.meta.alias != hinted.meta.alias)
-        .any(|profile| {
-            let Ok(sibling) = api::read_auth_json(&profile.auth_json_path()) else {
-                return false;
+        .filter(|alias| alias != &hinted.meta.alias)
+        .any(|alias| {
+            let Ok(dir) = store::profile_dir(paths, &alias) else {
+                return true;
             };
-            sibling.account_id.is_some()
+            let Ok(sibling) = api::read_auth_json(&dir.join("auth.json")) else {
+                return true;
+            };
+            workspace_of_profile(paths, &alias).is_some()
                 && api::token_subject(&sibling.access_token).as_deref() == Some(subject.as_str())
         })
 }
@@ -749,7 +758,7 @@ pub fn alias_for_auth_json_with_hint(
         return Some(alias);
     }
     if let Some(profile) = hinted
-        && auth_files_have_same_owner(auth_json, &profile.auth_json_path())
+        && auth_belongs_to_profile(paths, auth_json, &profile)
         && !claimless_match_is_ambiguous(paths, auth_json, &profile)
     {
         return Some(profile.meta.alias);
@@ -815,7 +824,7 @@ pub fn auth_json_path_for_profile_from(
         return profile.auth_json_path();
     }
     let live = paths.codex_auth_json();
-    if auth_files_have_same_owner(&live, &profile.auth_json_path()) {
+    if auth_belongs_to_profile(paths, &live, profile) {
         live
     } else {
         profile.auth_json_path()
@@ -830,9 +839,19 @@ fn auth_files_have_same_access_token(left: &Path, right: &Path) -> bool {
         && workspace_permits(left.account_id.as_deref(), right.account_id.as_deref())
 }
 
-fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
-    let (Ok(left), Ok(right)) = (api::read_auth_json(left), api::read_auth_json(right)) else {
+fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -> bool {
+    let (Ok(left), Ok(stored)) = (
+        api::read_auth_json(auth_json),
+        api::read_auth_json(&profile.auth_json_path()),
+    ) else {
         return false;
+    };
+    // The profile's workspace is what it *effectively* holds, metadata fallback
+    // included: a stored token carrying no claim does not make the profile
+    // anonymous when `meta.json` records the account.
+    let right = api::AuthJson {
+        account_id: workspace_of_profile(paths, &profile.meta.alias),
+        ..stored
     };
     // An identical access token is not identity on its own: `read_auth_json`
     // takes an explicit `account_id` from the file ahead of the JWT claim, so
@@ -929,7 +948,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
             }
         }
         // The target declares no workspace, so it cannot prove it belongs to a
-        // profile that declares one — the same reasoning `auth_files_have_same_owner`
+        // profile that declares one — the same reasoning `auth_belongs_to_profile`
         // applies, and this resolver is the other way credentials reach a profile.
         //
         // Nor is a claimless sibling then the answer by default: a rotation of

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -228,8 +228,18 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// so an alias codexctl *derived* rather than the operator naming it must not
 /// be reused: the overwrite would rest on an unprovable match.
 pub fn unidentifiable_profile(paths: &Paths, alias: &str) -> bool {
-    let Ok(profile) = get_profile_from(paths, alias) else {
+    let Ok(dir) = store::profile_dir(paths, alias) else {
         return false;
+    };
+    if !dir.exists() {
+        // Nothing is there to overwrite.
+        return false;
+    }
+    // Something is there. Metadata that cannot be read is the strongest reason
+    // to treat it as unidentifiable, not a reason to treat it as absent — an
+    // interrupted save or a damaged file leaves exactly this shape.
+    let Ok(profile) = get_profile_from(paths, alias) else {
+        return true;
     };
     profile
         .meta
@@ -635,7 +645,15 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
                 same_seat.iter().map(|(alias, _)| alias).collect()
             }
         }
-        None => same_seat.iter().map(|(alias, _)| alias).collect(),
+        // The target declares no workspace, so it cannot prove it belongs to a
+        // profile that declares one — the same reasoning `auth_files_have_same_owner`
+        // applies, and this resolver is the other way credentials reach a profile.
+        // Profiles that declare nothing either remain plausible owners.
+        None => same_seat
+            .iter()
+            .filter(|(_, account)| account.is_none())
+            .map(|(alias, _)| alias)
+            .collect(),
     };
 
     if let [alias] = candidates.as_slice() {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -127,6 +127,25 @@ pub fn save_profile_and_activate_to(
     save_profile_and_activate_locked(&lock, paths, alias, email, auth_json_src)
 }
 
+/// Record the credential that is *already* live under `alias` and make it
+/// active, without writing anything back to the live Codex home.
+///
+/// `save` reads the live file, so installing it again could only overwrite it —
+/// and a native `codex` refresh does not take this lock, so by then the live
+/// file may legitimately hold something newer. Copying a snapshot back over it
+/// would roll that away.
+pub fn save_live_profile_locked(
+    _lock: &store::StoreLock,
+    paths: &Paths,
+    alias: &str,
+    email: Option<&str>,
+    auth_json_src: &Path,
+) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    save_profile_unlocked(paths, alias, email, auth_json_src)?;
+    set_active_unlocked(paths, alias)
+}
+
 /// [`save_profile_and_activate_to`] for a caller that already holds the store
 /// lock, so it can decide *and* write without releasing it in between.
 ///
@@ -404,6 +423,7 @@ pub fn conflicting_workspace(
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
 ) -> Option<String> {
+    let dir = store::profile_dir(paths, alias).ok()?;
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
     if stored_workspace.is_none() && stored_user.is_none() {
@@ -421,10 +441,17 @@ pub fn conflicting_workspace(
     // different login in it is a different account; but a stored login that was
     // never recorded blocks nothing on its own, which is what keeps a profile
     // repairable when its token is unreadable and only metadata remains.
-    let user_contradicts = matches!(
-        (incoming_user, stored_user.as_deref()),
-        (Some(incoming), Some(stored)) if incoming != stored
-    );
+    // A stored login that is merely absent blocks nothing only when there is
+    // genuinely nothing to read — an unreadable token is what sends an operator
+    // back to `login` to repair the profile. A *readable* token that yields no
+    // login is different: the profile is intact, its owner is simply unproven,
+    // and a workspace does not identify its owner.
+    let stored_auth_readable = api::read_auth_json(&dir.join("auth.json")).is_ok();
+    let user_contradicts = match (incoming_user, stored_user.as_deref()) {
+        (Some(incoming), Some(stored)) => incoming != stored,
+        (Some(_), None) => stored_auth_readable,
+        _ => false,
+    };
     if workspace_settled && !user_contradicts {
         return None;
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -859,9 +859,12 @@ fn captured_auth_supersedes_profile(captured_auth: &Path, profile_auth: &Path) -
     // discarding that leaves the profile claimless and its ownership ambiguous.
     if candidate.access_token == current.access_token
         && candidate.refresh_token == current.refresh_token
-        && candidate.account_id == current.account_id
     {
-        return false;
+        // Same credential. Only a workspace claim that *appears or changes* is
+        // an update worth writing; one that is merely absent must not erase the
+        // profile's stored claim, which for a pre-0.1.22 profile is the only
+        // ownership evidence it has.
+        return candidate.account_id.is_some() && candidate.account_id != current.account_id;
     }
     // Issued-at orders the two tokens directly. Expiry only stands in for it,
     // and stops being a proxy for recency the moment a shortened lifetime makes
@@ -894,7 +897,13 @@ pub fn auth_json_path_for_profile_from(
         return profile.auth_json_path();
     }
     let live = paths.codex_auth_json();
-    if auth_belongs_to_profile(paths, &live, profile) {
+    // Through the same resolution capture uses, rather than a local check: a
+    // sibling holding this exact token and declaring the live workspace is the
+    // stronger owner, and reading the live file here would report that seat's
+    // usage — and its capacity — under this alias.
+    if alias_for_auth_json_with_hint(paths, &live, Some(&profile.meta.alias)).as_deref()
+        == Some(profile.meta.alias.as_str())
+    {
         live
     } else {
         profile.auth_json_path()

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -391,6 +391,35 @@ pub enum ExistingSeat {
 /// alias should be refreshed rather than duplicated when the operator gives it
 /// a different label. A store that cannot be scanned is an error rather than an
 /// answer, because "no match" and "could not look" are not the same thing.
+/// Whether another holder of the live access token declares a workspace the
+/// live file does not.
+///
+/// One token recorded under two profiles with different workspaces demonstrably
+/// spans workspaces, so the live copy's `account_id` is one claim among several
+/// rather than the answer. `strongest_exact_match` already calls that shape
+/// undecidable; inferring from the live file anyway would contradict it, and
+/// would hand a claimless profile a workspace it never recorded — enough to make
+/// it look like the unique seat for that workspace and be overwritten without
+/// consent.
+fn live_workspace_is_contested(paths: &Paths, live: &api::AuthJson) -> bool {
+    let Ok(aliases) = stored_aliases(paths) else {
+        // The store cannot be read, so nothing confirms the live file is
+        // uncontested. Withhold the inference rather than assume it.
+        return true;
+    };
+    aliases.into_iter().any(|alias| {
+        let holds_token = store::profile_dir(paths, &alias)
+            .ok()
+            .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
+            .is_some_and(|stored| stored.access_token == live.access_token);
+        holds_token
+            && workspace_contradicts(
+                live.account_id.as_deref(),
+                workspace_of_profile(paths, &alias).as_deref(),
+            )
+    })
+}
+
 /// What a profile holds, using the live file when it proves to be this
 /// profile's own credential.
 ///
@@ -443,8 +472,11 @@ pub fn existing_seat(
     if workspace.is_none() || user.is_empty() {
         return Ok(ExistingSeat::None);
     }
-    // The live file is read once, not per alias.
-    let live = api::read_auth_json(&paths.codex_auth_json()).ok();
+    // The live file is read once, not per alias — and only while it can speak
+    // for the profiles holding it.
+    let live = api::read_auth_json(&paths.codex_auth_json())
+        .ok()
+        .filter(|live| !live_workspace_is_contested(paths, live));
     let matching: Vec<String> = stored_aliases(paths)?
         .into_iter()
         .filter(|alias| {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -878,8 +878,9 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     let exact: Vec<(String, Option<String>)> = profile_auths
         .iter()
         .filter(|(_, profile_auth)| profile_auth.access_token == target_auth.access_token)
-        .map(|(profile, profile_auth)| {
-            (profile.meta.alias.clone(), profile_auth.account_id.clone())
+        .map(|(profile, _)| {
+            let workspace = workspace_of_profile(paths, &profile.meta.alias);
+            (profile.meta.alias.clone(), workspace)
         })
         .collect();
     if !exact.is_empty() {
@@ -890,8 +891,10 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         .into_iter()
         .filter_map(|(profile, profile_auth)| {
             let profile_sub = api::token_subject(&profile_auth.access_token);
-            (target_sub.is_some() && target_sub == profile_sub)
-                .then_some((profile.meta.alias, profile_auth.account_id))
+            (target_sub.is_some() && target_sub == profile_sub).then_some({
+                let workspace = workspace_of_profile(paths, &profile.meta.alias);
+                (profile.meta.alias, workspace)
+            })
         })
         .collect();
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -670,8 +670,12 @@ fn captured_auth_supersedes_profile(captured_auth: &Path, profile_auth: &Path) -
     let Ok(current) = api::read_auth_json(profile_auth) else {
         return true;
     };
+    // The workspace counts as part of the credential state: Codex can add or
+    // change an explicit `account_id` without touching either token, and
+    // discarding that leaves the profile claimless and its ownership ambiguous.
     if candidate.access_token == current.access_token
         && candidate.refresh_token == current.refresh_token
+        && candidate.account_id == current.account_id
     {
         return false;
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -221,6 +221,38 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// missing identifier on either side is not proof of a conflict. Both `save`
 /// and `login` gate on this, because either one can replace the credentials of
 /// a profile that belongs to another account on the same login.
+/// Which workspace a saved profile holds.
+///
+/// The stored token is asked first because it *is* the credential; metadata is
+/// a derived copy of it. A save writes `auth.json` before `meta.json`, so an
+/// interrupted one leaves metadata describing the previous workspace — trusting
+/// it there would reject the account actually stored and leave the profile
+/// unrepairable without deleting it. Metadata still answers for a profile whose
+/// token carries no claim.
+pub fn workspace_of_profile(paths: &Paths, alias: &str) -> Option<String> {
+    let profile = get_profile_from(paths, alias).ok()?;
+    identity_of_auth_file(&profile.auth_json_path())
+        .account_id
+        .or(profile.meta.account_id)
+}
+
+/// Whether a candidate auth file may be attributed to a profile's workspace.
+///
+/// This is the single rule every attribution path shares, because each path
+/// that reimplemented it left a different way in. It is deliberately not
+/// symmetric: a candidate declaring no workspace cannot prove it belongs to a
+/// profile that declares one, which is how a second seat's token lands on the
+/// first seat's profile. The reverse is safe — a profile saved before
+/// workspaces were recorded still owns its own login's rotations, and a
+/// claimed candidate contradicts nothing about it.
+fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
+    match (candidate, stored) {
+        (Some(candidate), Some(stored)) => candidate == stored,
+        (None, Some(_)) => false,
+        (Some(_), None) | (None, None) => true,
+    }
+}
+
 /// Whether `alias` holds a profile whose account cannot be identified at all —
 /// no workspace in its metadata and none in the token it stored.
 ///
@@ -238,15 +270,10 @@ pub fn unidentifiable_profile(paths: &Paths, alias: &str) -> bool {
     // Something is there. Metadata that cannot be read is the strongest reason
     // to treat it as unidentifiable, not a reason to treat it as absent — an
     // interrupted save or a damaged file leaves exactly this shape.
-    let Ok(profile) = get_profile_from(paths, alias) else {
+    if get_profile_from(paths, alias).is_err() {
         return true;
-    };
-    profile
-        .meta
-        .account_id
-        .clone()
-        .or_else(|| identity_of_auth_file(&profile.auth_json_path()).account_id)
-        .is_none()
+    }
+    workspace_of_profile(paths, alias).is_none()
 }
 
 pub fn conflicting_workspace(
@@ -254,25 +281,8 @@ pub fn conflicting_workspace(
     alias: &str,
     incoming_account: Option<&str>,
 ) -> Option<String> {
-    let profile = get_profile_from(paths, alias).ok()?;
-    // A profile saved before workspaces were recorded has no `account_id` in
-    // its metadata, but the token it stored still carries the claim. Reading it
-    // keeps the guard working the moment this version ships, instead of only
-    // for profiles that happen to have been re-saved since.
-    let stored = profile
-        .meta
-        .account_id
-        .clone()
-        .or_else(|| identity_of_auth_file(&profile.auth_json_path()).account_id)?;
-    match incoming_account {
-        // A token naming a different workspace is a different account.
-        Some(incoming) => (stored != incoming).then_some(stored),
-        // A token naming no workspace cannot prove it is the same account, and
-        // this profile positively declares one. Treating "unprovable" as "same"
-        // is what lets a second seat overwrite the first's credentials, so the
-        // claim is required once the stored profile has one.
-        None => Some(stored),
-    }
+    let stored = workspace_of_profile(paths, alias)?;
+    (!workspace_permits(incoming_account, Some(stored.as_str()))).then_some(stored)
 }
 
 /// Short workspace id for an error message; the full uuid is noise.
@@ -561,6 +571,12 @@ fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
     let (Ok(left), Ok(right)) = (api::read_auth_json(left), api::read_auth_json(right)) else {
         return false;
     };
+    // An identical access token is not identity on its own: `read_auth_json`
+    // takes an explicit `account_id` from the file ahead of the JWT claim, so
+    // two files can carry one token and name different workspaces.
+    if !workspace_permits(left.account_id.as_deref(), right.account_id.as_deref()) {
+        return false;
+    }
     if left.access_token == right.access_token {
         return true;
     }
@@ -579,11 +595,7 @@ fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
     // captured over the first's. The reverse is safe: a profile saved before
     // workspaces were recorded still owns the rotations of its own login, and
     // nothing about them contradicts it.
-    match (&left.account_id, &right.account_id) {
-        (Some(left), Some(right)) => left == right,
-        (None, Some(_)) => false,
-        (Some(_), None) | (None, None) => true,
-    }
+    true
 }
 
 pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Option<String>> {
@@ -601,7 +613,12 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     }
 
     for (profile, profile_auth) in &profile_auths {
-        if profile_auth.access_token == target_auth.access_token {
+        if profile_auth.access_token == target_auth.access_token
+            && workspace_permits(
+                target_account.as_deref(),
+                profile_auth.account_id.as_deref(),
+            )
+        {
             return Ok(Some(profile.meta.alias.clone()));
         }
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -391,7 +391,11 @@ pub fn unidentifiable_profile(paths: &Paths, alias: &str) -> bool {
     if get_profile_from(paths, alias).is_err() {
         return true;
     }
-    workspace_of_profile(paths, alias).is_none()
+    // Both halves are required. A workspace holds many logins, so knowing only
+    // the workspace does not say whose credentials these are — and this guard
+    // protects an alias the operator never named, where "not proven different"
+    // is not good enough to overwrite.
+    workspace_of_profile(paths, alias).is_none() || user_of_profile(paths, alias).is_none()
 }
 
 pub fn conflicting_workspace(

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -277,32 +277,52 @@ fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     claim_permits(candidate, stored)
 }
 
-/// The one saved profile holding exactly this account, if there is exactly one.
+/// What the store already holds for one account.
 ///
-/// The alias is the store key, not the account, so a seat already saved under
-/// some alias should be refreshed rather than duplicated when the operator
-/// gives it a different label. Duplicates are also what make ownership
-/// ambiguous later, which is the failure this whole guard exists to avoid.
-pub fn alias_for_account(
+/// Three outcomes, kept apart on purpose: an `Option` would collapse "nothing
+/// matched" together with "the store could not be read" and "several aliases
+/// matched", and a caller reading either of those as "nothing" adds yet another
+/// copy of an account that is already saved.
+pub enum ExistingSeat {
+    /// No saved profile holds this account.
+    None,
+    /// Exactly one does, and it is the profile to refresh.
+    One(String),
+    /// Several do. The store is already ambiguous about this account, and
+    /// guessing between them is what would make it worse.
+    Ambiguous(Vec<String>),
+}
+
+/// Which saved profile, if any, already holds exactly this account.
+///
+/// The alias is the store key, not the account, so a seat saved under some
+/// alias should be refreshed rather than duplicated when the operator gives it
+/// a different label. A store that cannot be scanned is an error rather than an
+/// answer, because "no match" and "could not look" are not the same thing.
+pub fn existing_seat(
     paths: &Paths,
     workspace: Option<&str>,
     user: Option<&str>,
-) -> Option<String> {
+) -> Result<ExistingSeat> {
     // With nothing claimed there is nothing to match on, and every profile
     // would look equally like the owner.
     if workspace.is_none() && user.is_none() {
-        return None;
+        return Ok(ExistingSeat::None);
     }
-    let mut matching = list_profiles_from(paths)
-        .ok()?
+    let matching: Vec<String> = list_profiles_from(paths)?
         .into_iter()
         .filter(|profile| {
             let alias = profile.meta.alias.as_str();
             workspace_of_profile(paths, alias).as_deref() == workspace
                 && user_of_profile(paths, alias).as_deref() == user
-        });
-    let first = matching.next()?;
-    matching.next().is_none().then_some(first.meta.alias)
+        })
+        .map(|profile| profile.meta.alias)
+        .collect();
+    Ok(match matching.len() {
+        0 => ExistingSeat::None,
+        1 => ExistingSeat::One(matching.into_iter().next().expect("one match")),
+        _ => ExistingSeat::Ambiguous(matching),
+    })
 }
 
 /// Whether `alias` holds a profile whose account cannot be identified at all —

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -449,15 +449,23 @@ pub fn conflicting_workspace(
     incoming_user: Option<&str>,
 ) -> Option<AccountConflict> {
     let dir = store::profile_dir(paths, alias).ok()?;
+    // No profile here at all. There is no occupant to identify, protect, or ask
+    // about — this is a first login to a free alias.
+    if !dir.exists() {
+        return None;
+    }
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
     let stored_auth_readable = api::read_auth_json(&dir.join("auth.json")).is_ok();
     if stored_workspace.is_none() && stored_user.is_none() && !stored_auth_readable {
-        // Nothing identifiable *and* nothing usable: this is the profile an
-        // operator is sent back to `login` to repair, so replacing it loses
-        // nothing. A readable token that merely names nobody is intact, and
-        // overwriting it needs the same proof as any other profile.
-        return None;
+        // A profile that exists but cannot be identified *or* used. Replacing it
+        // plausibly loses nothing, but that judgement rests on `read_auth_json`
+        // having failed — so a future parser regression would silently reclassify
+        // every metadata-less legacy profile as free to overwrite, across exactly
+        // the population this upgrade exists to migrate. Ask instead: it costs one
+        // answer in the rarest case, and a parser bug then widens the questions
+        // rather than the permissions.
+        return Some(AccountConflict::Unprovable(None));
     }
     // This guard gates `login` and `save`, which replace what is stored.
     //
@@ -475,6 +483,14 @@ pub fn conflicting_workspace(
     // anyone who names one. The only profile safe to replace on no evidence is
     // one with no identity at all, and that case has already returned above —
     // reaching here means this profile still has something worth protecting.
+    // Neither side naming a login is settlement, not a question — deliberately.
+    // A matching workspace with both sides silent is two pre-`chatgpt_user_id`
+    // tokens, and asking about them would not help: adopting records no login
+    // either, so the same question would return on every refresh. A prompt that
+    // its own answer cannot satisfy is noise rather than consent, and a matching
+    // workspace with nothing contradicting it is the strongest evidence such a
+    // token can offer. Two seats in one workspace behind tokens that old are the
+    // residual exposure; a token carrying the claim closes it permanently.
     let user_contradicts = match (incoming_user, stored_user.as_deref()) {
         (Some(incoming), Some(stored)) => incoming != stored,
         (Some(_), None) => true,
@@ -497,8 +513,17 @@ pub fn conflicting_workspace(
     );
     let described = stored_workspace.clone().or_else(|| stored_user.clone());
     if workspace_differs || user_differs {
+        // Describe the claim that actually disagrees. Preferring the workspace
+        // unconditionally makes a same-workspace login conflict report "stored
+        // workspace W, incoming W" — two identical values offered as the reason
+        // they differ.
+        let culprit = if workspace_differs {
+            described
+        } else {
+            stored_user.clone().or(described)
+        };
         return Some(AccountConflict::Different(
-            described.unwrap_or_else(|| "unknown".to_string()),
+            culprit.unwrap_or_else(|| "unknown".to_string()),
         ));
     }
     Some(AccountConflict::Unprovable(described))

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -223,14 +223,19 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// a profile that belongs to another account on the same login.
 /// Which login a saved profile holds, by the same precedence as its workspace.
 ///
+/// Like [`workspace_of_profile`], this reads the stored files directly: a
+/// profile whose `meta.json` will not parse still has credentials worth
+/// protecting, and refusing to look at them is what lets a damaged profile be
+/// overwritten as though it held nothing.
+///
 /// A workspace is not an owner: several people hold seats in one team
 /// workspace, so the login is what separates their credentials.
 pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
-    let profile = get_profile_from(paths, alias).ok()?;
-    let stored_login = api::read_auth_json(&profile.auth_json_path())
+    let dir = store::profile_dir(paths, alias).ok()?;
+    let stored_login = api::read_auth_json(&dir.join("auth.json"))
         .ok()
         .and_then(|auth| api::token_login(&auth.access_token));
-    stored_login.or(profile.meta.user_id)
+    stored_login.or_else(|| read_meta(&dir.join("meta.json")).and_then(|meta| meta.user_id))
 }
 
 /// Which workspace a saved profile holds.
@@ -242,10 +247,10 @@ pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
 /// unrepairable without deleting it. Metadata still answers for a profile whose
 /// token carries no claim.
 pub fn workspace_of_profile(paths: &Paths, alias: &str) -> Option<String> {
-    let profile = get_profile_from(paths, alias).ok()?;
-    identity_of_auth_file(&profile.auth_json_path())
+    let dir = store::profile_dir(paths, alias).ok()?;
+    identity_of_auth_file(&dir.join("auth.json"))
         .account_id
-        .or(profile.meta.account_id)
+        .or_else(|| read_meta(&dir.join("meta.json")).and_then(|meta| meta.account_id))
 }
 
 /// Whether a candidate auth file may be attributed to a profile's workspace.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -295,6 +295,36 @@ fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     claim_permits(candidate, stored)
 }
 
+/// Every alias the store holds a directory for.
+///
+/// Deliberately not `list_profiles_from`, which skips a directory with no
+/// `meta.json`: a save writes `auth.json` first, so an interrupted one leaves a
+/// real seat in exactly that shape. Treating it as absent is how a second alias
+/// gets created for an account that is already saved.
+fn stored_aliases(paths: &Paths) -> Result<Vec<String>> {
+    let profiles_dir = paths.profiles_dir();
+    if !profiles_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut aliases = Vec::new();
+    for entry in std::fs::read_dir(&profiles_dir)
+        .with_context(|| format!("failed to read {}", profiles_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if store::validate_alias(&name).is_ok() {
+            aliases.push(name);
+        }
+    }
+    aliases.sort();
+    Ok(aliases)
+}
+
 /// What the store already holds for one account.
 ///
 /// Three outcomes, kept apart on purpose: an `Option` would collapse "nothing
@@ -327,14 +357,12 @@ pub fn existing_seat(
     if workspace.is_none() && user.is_none() {
         return Ok(ExistingSeat::None);
     }
-    let matching: Vec<String> = list_profiles_from(paths)?
+    let matching: Vec<String> = stored_aliases(paths)?
         .into_iter()
-        .filter(|profile| {
-            let alias = profile.meta.alias.as_str();
+        .filter(|alias| {
             workspace_of_profile(paths, alias).as_deref() == workspace
                 && user_of_profile(paths, alias).as_deref() == user
         })
-        .map(|profile| profile.meta.alias)
         .collect();
     Ok(match matching.len() {
         0 => ExistingSeat::None,
@@ -601,6 +629,16 @@ fn strongest_exact_match(
         return Some(only.0.clone());
     }
     if !declared.is_empty() {
+        return None;
+    }
+    // Nothing declares the target's workspace, but if something declares
+    // another one then this token demonstrably spans workspaces. A claimless
+    // sibling has no better claim to it than the contradicting one, so the
+    // answer is ambiguity rather than the lenient match.
+    let contradicted = candidates
+        .iter()
+        .any(|(_, workspace)| workspace.is_some() && workspace.as_deref() != target_workspace);
+    if contradicted {
         return None;
     }
     let permitted: Vec<&(String, Option<String>)> = candidates

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -284,7 +284,7 @@ pub fn workspace_of_profile(paths: &Paths, alias: &str) -> Option<String> {
 fn claim_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     match (candidate, stored) {
         (Some(candidate), Some(stored)) => candidate == stored,
-        (None, Some(_)) => false,
+        (None, Some(_)) => true,
         (Some(_), None) | (None, None) => true,
     }
 }
@@ -452,7 +452,11 @@ pub fn conflicting_workspace(
     let user_contradicts = match (incoming_user, stored_user.as_deref()) {
         (Some(incoming), Some(stored)) => incoming != stored,
         (Some(_), None) => stored_auth_readable,
-        _ => false,
+        // The arriving token names no login at all. A workspace is shared, so
+        // agreeing on it proves nothing about whose credentials these are, and
+        // the profile does name someone.
+        (None, Some(_)) => false,
+        (None, None) => false,
     };
     if workspace_settled && !user_contradicts {
         return None;
@@ -766,8 +770,14 @@ pub fn alias_for_auth_json_with_hint(
     }
     if let Some(profile) = hinted
         && auth_belongs_to_profile(paths, auth_json, &profile)
-        && !claimless_match_is_ambiguous(paths, auth_json, &profile)
     {
+        // Undecided means no owner. Falling through to the store-wide resolver
+        // would undo this: it enumerates through `list_profiles_from`, which
+        // skips the very half-written and unreadable profiles that made this
+        // ambiguous, and could then rediscover the hint as a lone candidate.
+        if claimless_match_is_ambiguous(paths, auth_json, &profile) {
+            return None;
+        }
         return Some(profile.meta.alias);
     }
     alias_for_auth_json_from(paths, auth_json).ok().flatten()

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -371,9 +371,11 @@ pub fn existing_seat(
     workspace: Option<&str>,
     user: Option<&str>,
 ) -> Result<ExistingSeat> {
-    // With nothing claimed there is nothing to match on, and every profile
-    // would look equally like the owner.
-    if workspace.is_none() && user.is_none() {
+    // Reuse replaces a profile, so it needs both halves positively matched.
+    // Comparing the claims as options would let `None == None` stand in for
+    // identity, and every legacy profile would look like the same seat as any
+    // token that happens to omit a claim.
+    if workspace.is_none() || user.is_none() {
         return Ok(ExistingSeat::None);
     }
     let matching: Vec<String> = stored_aliases(paths)?
@@ -696,6 +698,39 @@ fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String>
     strongest_exact_match(target.account_id.as_deref(), &candidates)
 }
 
+/// Whether a subject-only match on a claimless pair is really undecided.
+///
+/// When neither the file nor the hinted profile declares a workspace, the only
+/// evidence is the shared login — and a claimless file can equally be a
+/// rotation of a *declared* sibling on that same login, which need not carry
+/// the claim. The hint settles ties between equals; it does not settle this,
+/// so the store-wide resolver gets to answer (and refuses).
+fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profile) -> bool {
+    let (Ok(target), Ok(stored)) = (
+        api::read_auth_json(auth_json),
+        api::read_auth_json(&hinted.auth_json_path()),
+    ) else {
+        return false;
+    };
+    if target.account_id.is_some() || stored.account_id.is_some() {
+        return false;
+    }
+    let Some(subject) = api::token_subject(&target.access_token) else {
+        return false;
+    };
+    list_profiles_from(paths)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|profile| profile.meta.alias != hinted.meta.alias)
+        .any(|profile| {
+            let Ok(sibling) = api::read_auth_json(&profile.auth_json_path()) else {
+                return false;
+            };
+            sibling.account_id.is_some()
+                && api::token_subject(&sibling.access_token).as_deref() == Some(subject.as_str())
+        })
+}
+
 pub fn alias_for_auth_json_with_hint(
     paths: &Paths,
     auth_json: &Path,
@@ -715,6 +750,7 @@ pub fn alias_for_auth_json_with_hint(
     }
     if let Some(profile) = hinted
         && auth_files_have_same_owner(auth_json, &profile.auth_json_path())
+        && !claimless_match_is_ambiguous(paths, auth_json, &profile)
     {
         return Some(profile.meta.alias);
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -546,7 +546,14 @@ pub fn conflicting_workspace(
     // token can offer. Two seats in one workspace behind tokens that old are the
     // residual exposure; a token carrying the claim closes it permanently.
     let user_contradicts = if incoming_user.is_empty() && stored_logins.is_empty() {
-        false
+        // Mutual silence settles only when the stored side is actually saying
+        // nothing — a readable token that predates `chatgpt_user_id`. A profile
+        // whose credentials will not read is not saying nothing; nothing could
+        // be read from it, which is absence of evidence rather than a matching
+        // claim. A workspace is shared, so treating that as agreement lets
+        // anyone holding a seat in it replace a damaged profile by naming its
+        // alias — and lets a token carrying no login claim do the same.
+        !stored_auth_readable
     } else {
         // Anything short of positive proof of the same login is unsettled: one
         // side silent, or two claims that share no namespace to compare in.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -221,6 +221,17 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// missing identifier on either side is not proof of a conflict. Both `save`
 /// and `login` gate on this, because either one can replace the credentials of
 /// a profile that belongs to another account on the same login.
+/// Which login a saved profile holds, by the same precedence as its workspace.
+///
+/// A workspace is not an owner: several people hold seats in one team
+/// workspace, so the login is what separates their credentials.
+pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
+    let profile = get_profile_from(paths, alias).ok()?;
+    identity_of_auth_file(&profile.auth_json_path())
+        .user_id
+        .or(profile.meta.user_id)
+}
+
 /// Which workspace a saved profile holds.
 ///
 /// The stored token is asked first because it *is* the credential; metadata is
@@ -245,12 +256,19 @@ pub fn workspace_of_profile(paths: &Paths, alias: &str) -> Option<String> {
 /// first seat's profile. The reverse is safe — a profile saved before
 /// workspaces were recorded still owns its own login's rotations, and a
 /// claimed candidate contradicts nothing about it.
-fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
+fn claim_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     match (candidate, stored) {
         (Some(candidate), Some(stored)) => candidate == stored,
         (None, Some(_)) => false,
         (Some(_), None) | (None, None) => true,
     }
+}
+
+/// The same rule over a whole account identity. Both claims have to permit the
+/// attribution: one workspace holds many logins, and one login holds seats in
+/// many workspaces, so neither alone identifies whose credentials these are.
+fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
+    claim_permits(candidate, stored)
 }
 
 /// Whether `alias` holds a profile whose account cannot be identified at all —
@@ -280,9 +298,26 @@ pub fn conflicting_workspace(
     paths: &Paths,
     alias: &str,
     incoming_account: Option<&str>,
+    incoming_user: Option<&str>,
 ) -> Option<String> {
-    let stored = workspace_of_profile(paths, alias)?;
-    (!workspace_permits(incoming_account, Some(stored.as_str()))).then_some(stored)
+    let stored_workspace = workspace_of_profile(paths, alias);
+    let stored_user = user_of_profile(paths, alias);
+    if stored_workspace.is_none() && stored_user.is_none() {
+        return None;
+    }
+    let workspace_ok = claim_permits(incoming_account, stored_workspace.as_deref());
+    // A workspace is shared: two people with seats in one team workspace agree
+    // on it and are still different accounts. The login has to agree as well
+    // before this alias may be written over.
+    let user_ok = claim_permits(incoming_user, stored_user.as_deref());
+    if workspace_ok && user_ok {
+        return None;
+    }
+    Some(
+        stored_workspace
+            .or(stored_user)
+            .unwrap_or_else(|| "unknown".to_string()),
+    )
 }
 
 /// Short workspace id for an error message; the full uuid is noise.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -277,6 +277,34 @@ fn workspace_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     claim_permits(candidate, stored)
 }
 
+/// The one saved profile holding exactly this account, if there is exactly one.
+///
+/// The alias is the store key, not the account, so a seat already saved under
+/// some alias should be refreshed rather than duplicated when the operator
+/// gives it a different label. Duplicates are also what make ownership
+/// ambiguous later, which is the failure this whole guard exists to avoid.
+pub fn alias_for_account(
+    paths: &Paths,
+    workspace: Option<&str>,
+    user: Option<&str>,
+) -> Option<String> {
+    // With nothing claimed there is nothing to match on, and every profile
+    // would look equally like the owner.
+    if workspace.is_none() && user.is_none() {
+        return None;
+    }
+    let mut matching = list_profiles_from(paths)
+        .ok()?
+        .into_iter()
+        .filter(|profile| {
+            let alias = profile.meta.alias.as_str();
+            workspace_of_profile(paths, alias).as_deref() == workspace
+                && user_of_profile(paths, alias).as_deref() == user
+        });
+    let first = matching.next()?;
+    matching.next().is_none().then_some(first.meta.alias)
+}
+
 /// Whether `alias` holds a profile whose account cannot be identified at all —
 /// no workspace in its metadata and none in the token it stored.
 ///

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -227,9 +227,10 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// workspace, so the login is what separates their credentials.
 pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
     let profile = get_profile_from(paths, alias).ok()?;
-    identity_of_auth_file(&profile.auth_json_path())
-        .user_id
-        .or(profile.meta.user_id)
+    let stored_login = api::read_auth_json(&profile.auth_json_path())
+        .ok()
+        .and_then(|auth| api::token_login(&auth.access_token));
+    stored_login.or(profile.meta.user_id)
 }
 
 /// Which workspace a saved profile holds.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -892,12 +892,18 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         // The target declares no workspace, so it cannot prove it belongs to a
         // profile that declares one — the same reasoning `auth_files_have_same_owner`
         // applies, and this resolver is the other way credentials reach a profile.
-        // Profiles that declare nothing either remain plausible owners.
-        None => same_seat
-            .iter()
-            .filter(|(_, account)| account.is_none())
-            .map(|(alias, _)| alias)
-            .collect(),
+        //
+        // Nor is a claimless sibling then the answer by default: a rotation of
+        // the declared account need not carry the claim either, so both remain
+        // possible owners and neither is provable. Only a field where nothing
+        // declares a workspace leaves a claimless profile as the owner.
+        None => {
+            if same_seat.iter().any(|(_, account)| account.is_some()) {
+                Vec::new()
+            } else {
+                same_seat.iter().map(|(alias, _)| alias).collect()
+            }
+        }
     };
 
     if let [alias] = candidates.as_slice() {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -381,6 +381,42 @@ pub enum ExistingSeat {
 /// alias should be refreshed rather than duplicated when the operator gives it
 /// a different label. A store that cannot be scanned is an error rather than an
 /// answer, because "no match" and "could not look" are not the same thing.
+/// What a profile holds, using the live file when it proves to be this
+/// profile's own credential.
+///
+/// A profile's stored token can declare less than the live copy of that very
+/// token: `auth.json` carries an explicit `account_id` that a JWT claim may not,
+/// so a legacy profile can hold token T while the live T names a workspace. An
+/// exact access-token match already decides ownership everywhere else, and
+/// capture applies precisely this inference — but capture runs after a login has
+/// chosen its target. Resolving without it makes the profile invisible to
+/// `existing_seat`, and the login lands beside it as a second copy of one
+/// account, which every later lookup then reports as ambiguous.
+fn identity_of_profile(
+    paths: &Paths,
+    alias: &str,
+    live: Option<&api::AuthJson>,
+) -> (Option<String>, Option<String>) {
+    let stored_workspace = workspace_of_profile(paths, alias);
+    let stored_user = user_of_profile(paths, alias);
+    let Some(live) = live else {
+        return (stored_workspace, stored_user);
+    };
+    let holds_live_token = store::profile_dir(paths, alias)
+        .ok()
+        .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
+        .is_some_and(|stored| stored.access_token == live.access_token);
+    if !holds_live_token {
+        return (stored_workspace, stored_user);
+    }
+    // Only ever adds what the profile could not say for itself. A stored claim
+    // that disagrees is left to the conflict rules rather than overwritten here.
+    (
+        stored_workspace.or_else(|| live.account_id.clone()),
+        stored_user.or_else(|| api::token_login(&live.access_token)),
+    )
+}
+
 pub fn existing_seat(
     paths: &Paths,
     workspace: Option<&str>,
@@ -393,11 +429,13 @@ pub fn existing_seat(
     if workspace.is_none() || user.is_none() {
         return Ok(ExistingSeat::None);
     }
+    // The live file is read once, not per alias.
+    let live = api::read_auth_json(&paths.codex_auth_json()).ok();
     let matching: Vec<String> = stored_aliases(paths)?
         .into_iter()
         .filter(|alias| {
-            workspace_of_profile(paths, alias).as_deref() == workspace
-                && user_of_profile(paths, alias).as_deref() == user
+            let (stored_workspace, stored_user) = identity_of_profile(paths, alias, live.as_ref());
+            stored_workspace.as_deref() == workspace && stored_user.as_deref() == user
         })
         .collect();
     Ok(match matching.len() {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -639,8 +639,39 @@ fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Opt
     if !captured_auth_supersedes_profile(exec_auth, &dest) {
         return;
     }
+    let proven_workspace = workspace_of_profile(paths, &alias);
     if let Err(error) = store::atomic_copy(exec_auth, &dest) {
         eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
+        return;
+    }
+    // The captured file may carry no workspace claim while the profile had
+    // proven one. Losing it with the copy would erase the only ownership
+    // evidence a profile written before the metadata field has, and leave every
+    // later rotation unattributable — so it is kept in metadata instead.
+    if let Some(workspace) = proven_workspace
+        && workspace_of_profile(paths, &alias).is_none()
+    {
+        record_workspace(paths, &alias, &workspace);
+    }
+}
+
+/// Persist a workspace the profile has already proven, without touching its
+/// credentials.
+fn record_workspace(paths: &Paths, alias: &str, workspace: &str) {
+    let Ok(dir) = store::profile_dir(paths, alias) else {
+        return;
+    };
+    let meta_path = dir.join("meta.json");
+    let Some(mut meta) = read_meta(&meta_path) else {
+        return;
+    };
+    meta.alias = alias.to_string();
+    meta.account_id = Some(workspace.to_string());
+    let Ok(json) = serde_json::to_vec_pretty(&meta) else {
+        return;
+    };
+    if let Err(error) = store::atomic_write(&meta_path, &json) {
+        eprintln!("warning: failed to record the workspace for profile '{alias}': {error}");
     }
 }
 
@@ -962,20 +993,26 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     };
     let target_sub = api::token_subject(&target_auth.access_token);
     let target_account = target_auth.account_id.clone();
+    // Enumerated from the store's directories: `list_profiles_from` skips a
+    // profile with no `meta.json`, and an interrupted save leaves a real one in
+    // that shape whose claim still belongs in this decision.
     let mut profile_auths = Vec::new();
-    for profile in list_profiles_from(paths)? {
-        let Ok(profile_auth) = api::read_auth_json(&profile.auth_json_path()) else {
+    for alias in stored_aliases(paths)? {
+        let Ok(dir) = store::profile_dir(paths, &alias) else {
             continue;
         };
-        profile_auths.push((profile, profile_auth));
+        let Ok(profile_auth) = api::read_auth_json(&dir.join("auth.json")) else {
+            continue;
+        };
+        profile_auths.push((alias, profile_auth));
     }
 
     let exact: Vec<(String, Option<String>)> = profile_auths
         .iter()
         .filter(|(_, profile_auth)| profile_auth.access_token == target_auth.access_token)
-        .map(|(profile, _)| {
-            let workspace = workspace_of_profile(paths, &profile.meta.alias);
-            (profile.meta.alias.clone(), workspace)
+        .map(|(alias, _)| {
+            let workspace = workspace_of_profile(paths, alias);
+            (alias.clone(), workspace)
         })
         .collect();
     if !exact.is_empty() {
@@ -984,11 +1021,11 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
 
     let same_seat: Vec<(String, Option<String>)> = profile_auths
         .into_iter()
-        .filter_map(|(profile, profile_auth)| {
+        .filter_map(|(alias, profile_auth)| {
             let profile_sub = api::token_subject(&profile_auth.access_token);
             (target_sub.is_some() && target_sub == profile_sub).then_some({
-                let workspace = workspace_of_profile(paths, &profile.meta.alias);
-                (profile.meta.alias, workspace)
+                let workspace = workspace_of_profile(paths, &alias);
+                (alias, workspace)
             })
         })
         .collect();

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -661,8 +661,12 @@ fn capture_into_owner(paths: &Paths, source: &Path, alias: &str) {
     // evidence a profile written before the metadata field has, and leave every
     // later rotation unattributable — so it is kept in metadata instead.
     if let Some(workspace) = proven_workspace
-        && workspace_of_profile(paths, alias).is_none()
+        && workspace_of_profile(paths, alias).as_deref() != Some(workspace.as_str())
     {
+        // Not only when the lookup comes back empty: an interrupted save can
+        // leave metadata naming an older workspace, and after the copy that
+        // stale name would answer for the profile — misidentifying it and
+        // refusing the re-login that would repair it.
         record_workspace(paths, alias, &workspace);
     }
 }
@@ -738,7 +742,7 @@ fn strongest_exact_match(
     // answer is ambiguity rather than the lenient match.
     let contradicted = candidates
         .iter()
-        .any(|(_, workspace)| workspace.is_some() && workspace.as_deref() != target_workspace);
+        .any(|(_, workspace)| workspace_contradicts(target_workspace, workspace.as_deref()));
     if contradicted {
         return None;
     }
@@ -750,6 +754,15 @@ fn strongest_exact_match(
         return Some(only.0.clone());
     }
     None
+}
+
+/// Whether a stored workspace positively rules a file out.
+///
+/// A profile declaring a workspace the file does not name is not its owner —
+/// and that includes a file naming none at all, since a rotation of the
+/// declared account need not carry the claim.
+fn workspace_contradicts(target: Option<&str>, stored: Option<&str>) -> bool {
+    stored.is_some() && stored != target
 }
 
 /// A profile alias beside the workspace it effectively holds.
@@ -851,11 +864,10 @@ pub fn alias_for_auth_json_with_hint(
         // a contradiction anywhere in the set means this token demonstrably
         // spans workspaces — naming one holder would be an override, not a
         // tie-break.
+        // The same rule the weighing used: anything less would revive a
+        // candidate it had already ruled out.
         let contradicted = candidates.iter().any(|(_, workspace)| {
-            matches!(
-                (target_workspace.as_deref(), workspace.as_deref()),
-                (Some(target), Some(stored)) if target != stored
-            )
+            workspace_contradicts(target_workspace.as_deref(), workspace.as_deref())
         });
         if !contradicted
             && let Some(profile) = &hinted

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -221,6 +221,24 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 /// missing identifier on either side is not proof of a conflict. Both `save`
 /// and `login` gate on this, because either one can replace the credentials of
 /// a profile that belongs to another account on the same login.
+/// Whether `alias` holds a profile whose account cannot be identified at all —
+/// no workspace in its metadata and none in the token it stored.
+///
+/// Such a profile cannot be shown to be the same account as an incoming login,
+/// so an alias codexctl *derived* rather than the operator naming it must not
+/// be reused: the overwrite would rest on an unprovable match.
+pub fn unidentifiable_profile(paths: &Paths, alias: &str) -> bool {
+    let Ok(profile) = get_profile_from(paths, alias) else {
+        return false;
+    };
+    profile
+        .meta
+        .account_id
+        .clone()
+        .or_else(|| identity_of_auth_file(&profile.auth_json_path()).account_id)
+        .is_none()
+}
+
 pub fn conflicting_workspace(
     paths: &Paths,
     alias: &str,
@@ -543,9 +561,18 @@ fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
     // The same login is not the same account. Two workspace seats of one human
     // share a subject, so a declared workspace has to agree as well — otherwise
     // the live seat's usage renders under the other seat's row.
+    //
+    // `right` is always the saved profile and `left` the file being attributed
+    // to it, which makes the missing-claim cases asymmetric. A candidate that
+    // declares nothing cannot prove it belongs to a profile that declares a
+    // workspace, and treating it as proof is how a second seat's token gets
+    // captured over the first's. The reverse is safe: a profile saved before
+    // workspaces were recorded still owns the rotations of its own login, and
+    // nothing about them contradicts it.
     match (&left.account_id, &right.account_id) {
         (Some(left), Some(right)) => left == right,
-        _ => true,
+        (None, Some(_)) => false,
+        (Some(_), None) | (None, None) => true,
     }
 }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -666,6 +666,17 @@ fn strongest_exact_match(
     target_workspace: Option<&str>,
     candidates: &[(String, Option<String>)],
 ) -> Option<String> {
+    if let [only] = candidates {
+        // An identical access token is the same credential, so a lone holder of
+        // it owns the file. Only a workspace both sides declare *differently*
+        // disqualifies it — a claim on one side alone is what lets a profile
+        // record its own workspace, or receive its own refresh rotation.
+        let mismatch = matches!(
+            (target_workspace, only.1.as_deref()),
+            (Some(target), Some(stored)) if target != stored
+        );
+        return (!mismatch).then(|| only.0.clone());
+    }
     let declared: Vec<&(String, Option<String>)> = candidates
         .iter()
         .filter(|(_, workspace)| {
@@ -698,7 +709,12 @@ fn strongest_exact_match(
     None
 }
 
-fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String> {
+/// The profiles holding this exact access token, with the target's own
+/// workspace, so callers can weigh them rather than take the first that fits.
+fn exact_token_candidates(
+    paths: &Paths,
+    auth_json: &Path,
+) -> Option<(Option<String>, Vec<(String, Option<String>)>)> {
     let target = api::read_auth_json(auth_json).ok()?;
     let candidates: Vec<(String, Option<String>)> = list_profiles_from(paths)
         .ok()?
@@ -711,7 +727,7 @@ fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String>
             })
         })
         .collect();
-    strongest_exact_match(target.account_id.as_deref(), &candidates)
+    Some((target.account_id, candidates))
 }
 
 /// Whether a subject-only match on a claimless pair is really undecided.
@@ -767,16 +783,32 @@ pub fn alias_for_auth_json_with_hint(
     known_alias: Option<&str>,
 ) -> Option<String> {
     let hinted = known_alias.and_then(|alias| get_profile_from(paths, alias).ok());
-    // The named alias holding this very token is the strongest confirmation the
-    // hint can get. It outranks the store-wide scan, which would otherwise let
-    // directory order pick between two aliases saved from the same login.
+    // Every profile holding this exact token is weighed first: one that declares
+    // the target's workspace is a stronger owner than the hinted alias, and the
+    // hint must not outrank evidence.
+    let exact = exact_token_candidates(paths, auth_json);
+    if let Some((target_workspace, candidates)) = &exact
+        && let Some(alias) = strongest_exact_match(target_workspace.as_deref(), candidates)
+    {
+        return Some(alias);
+    }
+    // Exact matching was undecided. The hint settles it only when the hinted
+    // profile is itself one of those equally strong candidates — that is the
+    // duplicate-alias case it exists for.
     if let Some(profile) = &hinted
-        && auth_has_profile_access_token(paths, auth_json, profile)
+        && let Some((target_workspace, candidates)) = &exact
+        && candidates.iter().any(|(alias, workspace)| {
+            // Only among candidates the evidence left standing: a profile whose
+            // workspace positively differs is disqualified, and naming it is not
+            // a tie-break but an override.
+            alias == &profile.meta.alias
+                && !matches!(
+                    (target_workspace.as_deref(), workspace.as_deref()),
+                    (Some(target), Some(stored)) if target != stored
+                )
+        })
     {
         return Some(profile.meta.alias.clone());
-    }
-    if let Some(alias) = alias_for_exact_token_from(paths, auth_json) {
-        return Some(alias);
     }
     if let Some(profile) = hinted
         && auth_belongs_to_profile(paths, auth_json, &profile)
@@ -856,23 +888,6 @@ pub fn auth_json_path_for_profile_from(
     } else {
         profile.auth_json_path()
     }
-}
-
-fn auth_has_profile_access_token(paths: &Paths, auth_json: &Path, profile: &Profile) -> bool {
-    let (Ok(left), Ok(stored)) = (
-        api::read_auth_json(auth_json),
-        api::read_auth_json(&profile.auth_json_path()),
-    ) else {
-        return false;
-    };
-    // Against the profile's *effective* workspace, metadata included: a stored
-    // token with no claim does not make the profile anonymous, and this
-    // shortcut runs before the fuller ownership check gets a say.
-    left.access_token == stored.access_token
-        && workspace_permits(
-            left.account_id.as_deref(),
-            workspace_of_profile(paths, &profile.meta.alias).as_deref(),
-        )
 }
 
 fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -> bool {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -421,12 +421,33 @@ pub fn credentials_unreadable(paths: &Paths, alias: &str) -> bool {
     dir.exists() && api::read_auth_json(&dir.join("auth.json")).is_err()
 }
 
+/// Why a profile may not simply be written over.
+pub enum AccountConflict {
+    /// A claim on each side positively disagrees. No answer makes this the same
+    /// account, so it is never adoptable.
+    Different(String),
+    /// One side declares nothing, so the claims cannot be compared. The store
+    /// cannot settle this — but the operator usually can, which is why this is
+    /// offered for confirmation rather than refused outright.
+    Unprovable(Option<String>),
+}
+
+impl AccountConflict {
+    /// What the profile is understood to hold, for an operator-facing message.
+    pub fn stored(&self) -> Option<&str> {
+        match self {
+            Self::Different(stored) => Some(stored.as_str()),
+            Self::Unprovable(stored) => stored.as_deref(),
+        }
+    }
+}
+
 pub fn conflicting_workspace(
     paths: &Paths,
     alias: &str,
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
-) -> Option<String> {
+) -> Option<AccountConflict> {
     let dir = store::profile_dir(paths, alias).ok()?;
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
@@ -463,11 +484,24 @@ pub fn conflicting_workspace(
     if workspace_settled && !user_contradicts {
         return None;
     }
-    Some(
-        stored_workspace
-            .or(stored_user)
-            .unwrap_or_else(|| "unknown".to_string()),
-    )
+    // A claim that positively disagrees is different in kind from one that is
+    // merely missing. The first can never be talked round; the second is a
+    // question the operator can answer and the store cannot.
+    let workspace_differs = matches!(
+        (incoming_account, stored_workspace.as_deref()),
+        (Some(incoming), Some(stored)) if incoming != stored
+    );
+    let user_differs = matches!(
+        (incoming_user, stored_user.as_deref()),
+        (Some(incoming), Some(stored)) if incoming != stored
+    );
+    let described = stored_workspace.clone().or_else(|| stored_user.clone());
+    if workspace_differs || user_differs {
+        return Some(AccountConflict::Different(
+            described.unwrap_or_else(|| "unknown".to_string()),
+        ));
+    }
+    Some(AccountConflict::Unprovable(described))
 }
 
 /// Short workspace id for an error message; the full uuid is noise.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -263,7 +263,12 @@ pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
     let stored_login = api::read_auth_json(&dir.join("auth.json"))
         .ok()
         .and_then(|auth| api::token_login(&auth.access_token));
-    stored_login.or_else(|| read_meta(&dir.join("meta.json")).and_then(|meta| meta.user_id))
+    stored_login.or_else(|| {
+        read_meta(&dir.join("meta.json"))
+            .and_then(|meta| meta.user_id)
+            .as_deref()
+            .map(api::recorded_login)
+    })
 }
 
 /// Which workspace a saved profile holds.
@@ -793,8 +798,9 @@ fn metadata_contradicts(
     let workspace_disagrees = meta.account_id.is_some()
         && target_workspace.is_some()
         && meta.account_id.as_deref() != target_workspace;
+    let recorded = meta.user_id.as_deref().map(api::recorded_login);
     let login_disagrees =
-        meta.user_id.is_some() && target_login.is_some() && meta.user_id.as_deref() != target_login;
+        recorded.is_some() && target_login.is_some() && recorded.as_deref() != target_login;
     workspace_disagrees || login_disagrees
 }
 
@@ -1085,6 +1091,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
             // look like the sole owner of a credential this one may hold, so an
             // identified one makes the decision undecidable instead.
             let meta = read_meta(&dir.join("meta.json")).unwrap_or_default();
+            let recorded_login = meta.user_id.as_deref().map(api::recorded_login);
             // A field that positively disagrees rules the profile out, whatever
             // the other one says: a damaged profile for another login in the
             // same workspace is not a candidate, and letting it block would
@@ -1094,7 +1101,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
                 &alias,
                 target_account.as_deref(),
                 target_login.as_deref(),
-            ) && ((meta.user_id.is_some() && meta.user_id == target_login)
+            ) && ((recorded_login.is_some() && recorded_login == target_login)
                 || (meta.account_id.is_some() && meta.account_id == target_account));
             if identifies {
                 return Ok(None);

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -162,14 +162,23 @@ pub fn save_profile_and_activate_locked(
 ) -> Result<()> {
     let alias = store::validate_alias(alias)?;
     let live_auth = paths.codex_auth_json();
+
+    if auth_json_src != live_auth {
+        // Capture protects the *outgoing* profile's rotated tokens, and it runs
+        // before the incoming profile is written. Saving first would add a
+        // same-login sibling that declares a workspace, which is exactly what
+        // makes a claimless outgoing token look ownerless — capture would then
+        // decline it and the install below would destroy the only copy.
+        //
+        // The alias being written is excluded outright rather than by inferring
+        // ownership: an unreadable or absent stored token must not be able to
+        // route the stale live file back over this login.
+        capture_auth_file_profile_tokens(paths, &live_auth, Some(alias));
+    }
+
     save_profile_unlocked(paths, alias, email, auth_json_src)?;
 
     if auth_json_src != live_auth {
-        // Capture protects the *outgoing* profile's rotated tokens. The alias
-        // being written is never outgoing, so it is excluded outright rather
-        // than by inferring ownership — an unreadable or absent stored token
-        // must not be able to route the stale live file back over this login.
-        capture_auth_file_profile_tokens(paths, &live_auth, Some(alias));
         let saved_auth = store::profile_dir(paths, alias)?.join("auth.json");
         store::atomic_copy(&saved_auth, &live_auth)
             .with_context(|| format!("failed to install {}", live_auth.display()))?;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -270,6 +270,24 @@ fn claim_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     }
 }
 
+/// Whether two claims positively agree, for a write that destroys what is
+/// already stored.
+///
+/// [`claim_permits`] is deliberately lenient where a claim is missing, because
+/// capturing a rotation into a profile that never recorded one loses nothing.
+/// An overwrite is the opposite: a profile whose workspace was never recorded
+/// cannot confirm that an arriving workspace is the same account, and reading
+/// "cannot confirm" as "yes" is what destroys a legacy profile when its owner
+/// signs into a second workspace. Only a claim that matches, or the absence of
+/// any claim on both sides, is agreement.
+fn claims_agree(candidate: Option<&str>, stored: Option<&str>) -> bool {
+    match (candidate, stored) {
+        (Some(candidate), Some(stored)) => candidate == stored,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 /// The same rule over a whole account identity. Both claims have to permit the
 /// attribution: one workspace holds many logins, and one login holds seats in
 /// many workspaces, so neither alone identifies whose credentials these are.
@@ -354,16 +372,27 @@ pub fn conflicting_workspace(
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
 ) -> Option<String> {
+    let dir = store::profile_dir(paths, alias).ok()?;
+    if api::read_auth_json(&dir.join("auth.json")).is_err() {
+        // No readable token: nothing here can be identified, and nothing here
+        // can be used either. An operator whose stored token is corrupt is sent
+        // back to `login` precisely to replace it, so this is a repair rather
+        // than a loss. Every other path treats an unreadable profile as
+        // occupied; this one is the deliberate exception.
+        return None;
+    }
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
     if stored_workspace.is_none() && stored_user.is_none() {
         return None;
     }
-    let workspace_ok = claim_permits(incoming_account, stored_workspace.as_deref());
+    // This guard gates `login` and `save`, which replace what is stored, so it
+    // requires positive agreement rather than the absence of contradiction.
+    let workspace_ok = claims_agree(incoming_account, stored_workspace.as_deref());
     // A workspace is shared: two people with seats in one team workspace agree
     // on it and are still different accounts. The login has to agree as well
     // before this alias may be written over.
-    let user_ok = claim_permits(incoming_user, stored_user.as_deref());
+    let user_ok = claims_agree(incoming_user, stored_user.as_deref());
     if workspace_ok && user_ok {
         return None;
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -258,17 +258,27 @@ fn identity_of_auth_file(auth_json: &Path) -> api::TokenIdentity {
 ///
 /// A workspace is not an owner: several people hold seats in one team
 /// workspace, so the login is what separates their credentials.
-pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
-    let dir = store::profile_dir(paths, alias).ok()?;
-    let stored_login = api::read_auth_json(&dir.join("auth.json"))
+pub fn logins_of_profile(paths: &Paths, alias: &str) -> api::Logins {
+    let Ok(dir) = store::profile_dir(paths, alias) else {
+        return api::Logins::default();
+    };
+    let stored = api::read_auth_json(&dir.join("auth.json"))
         .ok()
-        .and_then(|auth| api::token_login(&auth.access_token));
-    stored_login.or_else(|| {
-        read_meta(&dir.join("meta.json"))
-            .and_then(|meta| meta.user_id)
-            .as_deref()
-            .map(api::recorded_login)
-    })
+        .map(|auth| api::token_logins(&auth.access_token))
+        .unwrap_or_default();
+    if !stored.is_empty() {
+        return stored;
+    }
+    read_meta(&dir.join("meta.json"))
+        .and_then(|meta| meta.user_id)
+        .as_deref()
+        .map(api::recorded_logins)
+        .unwrap_or_default()
+}
+
+/// The single identifier for this profile's login, for display and metadata.
+pub fn user_of_profile(paths: &Paths, alias: &str) -> Option<String> {
+    logins_of_profile(paths, alias).canonical()
 }
 
 /// Which workspace a saved profile holds.
@@ -396,37 +406,41 @@ fn identity_of_profile(
     paths: &Paths,
     alias: &str,
     live: Option<&api::AuthJson>,
-) -> (Option<String>, Option<String>) {
+) -> (Option<String>, api::Logins) {
     let stored_workspace = workspace_of_profile(paths, alias);
-    let stored_user = user_of_profile(paths, alias);
+    let stored_logins = logins_of_profile(paths, alias);
     let Some(live) = live else {
-        return (stored_workspace, stored_user);
+        return (stored_workspace, stored_logins);
     };
     let holds_live_token = store::profile_dir(paths, alias)
         .ok()
         .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
         .is_some_and(|stored| stored.access_token == live.access_token);
     if !holds_live_token {
-        return (stored_workspace, stored_user);
+        return (stored_workspace, stored_logins);
     }
     // Only ever adds what the profile could not say for itself. A stored claim
     // that disagrees is left to the conflict rules rather than overwritten here.
+    let live_logins = api::token_logins(&live.access_token);
     (
         stored_workspace.or_else(|| live.account_id.clone()),
-        stored_user.or_else(|| api::token_login(&live.access_token)),
+        api::Logins {
+            uid: stored_logins.uid.or(live_logins.uid),
+            sub: stored_logins.sub.or(live_logins.sub),
+        },
     )
 }
 
 pub fn existing_seat(
     paths: &Paths,
     workspace: Option<&str>,
-    user: Option<&str>,
+    user: &api::Logins,
 ) -> Result<ExistingSeat> {
     // Reuse replaces a profile, so it needs both halves positively matched.
     // Comparing the claims as options would let `None == None` stand in for
     // identity, and every legacy profile would look like the same seat as any
     // token that happens to omit a claim.
-    if workspace.is_none() || user.is_none() {
+    if workspace.is_none() || user.is_empty() {
         return Ok(ExistingSeat::None);
     }
     // The live file is read once, not per alias.
@@ -434,8 +448,9 @@ pub fn existing_seat(
     let matching: Vec<String> = stored_aliases(paths)?
         .into_iter()
         .filter(|alias| {
-            let (stored_workspace, stored_user) = identity_of_profile(paths, alias, live.as_ref());
-            stored_workspace.as_deref() == workspace && stored_user.as_deref() == user
+            let (stored_workspace, stored_logins) =
+                identity_of_profile(paths, alias, live.as_ref());
+            stored_workspace.as_deref() == workspace && user.same(&stored_logins)
         })
         .collect();
     Ok(match matching.len() {
@@ -484,7 +499,7 @@ pub fn conflicting_workspace(
     paths: &Paths,
     alias: &str,
     incoming_account: Option<&str>,
-    incoming_user: Option<&str>,
+    incoming_user: &api::Logins,
 ) -> Option<AccountConflict> {
     let dir = store::profile_dir(paths, alias).ok()?;
     // No profile here at all. There is no occupant to identify, protect, or ask
@@ -493,9 +508,10 @@ pub fn conflicting_workspace(
         return None;
     }
     let stored_workspace = workspace_of_profile(paths, alias);
-    let stored_user = user_of_profile(paths, alias);
+    let stored_logins = logins_of_profile(paths, alias);
+    let stored_user = stored_logins.canonical();
     let stored_auth_readable = api::read_auth_json(&dir.join("auth.json")).is_ok();
-    if stored_workspace.is_none() && stored_user.is_none() && !stored_auth_readable {
+    if stored_workspace.is_none() && stored_logins.is_empty() && !stored_auth_readable {
         // A profile that exists but cannot be identified *or* used. Replacing it
         // plausibly loses nothing, but that judgement rests on `read_auth_json`
         // having failed — so a future parser regression would silently reclassify
@@ -529,11 +545,12 @@ pub fn conflicting_workspace(
     // workspace with nothing contradicting it is the strongest evidence such a
     // token can offer. Two seats in one workspace behind tokens that old are the
     // residual exposure; a token carrying the claim closes it permanently.
-    let user_contradicts = match (incoming_user, stored_user.as_deref()) {
-        (Some(incoming), Some(stored)) => incoming != stored,
-        (Some(_), None) => true,
-        (None, Some(_)) => true,
-        (None, None) => false,
+    let user_contradicts = if incoming_user.is_empty() && stored_logins.is_empty() {
+        false
+    } else {
+        // Anything short of positive proof of the same login is unsettled: one
+        // side silent, or two claims that share no namespace to compare in.
+        !incoming_user.same(&stored_logins)
     };
     if workspace_settled && !user_contradicts {
         return None;
@@ -545,7 +562,7 @@ pub fn conflicting_workspace(
         (incoming_account, stored_workspace.as_deref()),
         (Some(incoming), Some(stored)) if incoming != stored
     );
-    let user_differs = logins_disagree(incoming_user, stored_user.as_deref());
+    let user_differs = incoming_user.differs(&stored_logins);
     let described = stored_workspace.clone().or_else(|| stored_user.clone());
     if workspace_differs || user_differs {
         // Describe the claim that actually disagrees. Preferring the workspace
@@ -892,7 +909,7 @@ fn metadata_contradicts(
     paths: &Paths,
     alias: &str,
     target_workspace: Option<&str>,
-    target_login: Option<&str>,
+    target_login: &api::Logins,
 ) -> bool {
     let Ok(dir) = store::profile_dir(paths, alias) else {
         return false;
@@ -901,9 +918,13 @@ fn metadata_contradicts(
     let workspace_disagrees = meta.account_id.is_some()
         && target_workspace.is_some()
         && meta.account_id.as_deref() != target_workspace;
-    let recorded = meta.user_id.as_deref().map(api::recorded_login);
-    let login_disagrees =
-        recorded.is_some() && target_login.is_some() && recorded.as_deref() != target_login;
+    // Metadata records a `chatgpt_user_id` and nothing else, so it can only
+    // disagree with a token that names one too. A token identified by its
+    // subject alone shares no namespace with it and settles nothing.
+    let login_disagrees = meta
+        .user_id
+        .as_deref()
+        .is_some_and(|recorded| api::recorded_logins(recorded).differs(target_login));
     workspace_disagrees || login_disagrees
 }
 
@@ -945,29 +966,6 @@ fn exact_token_candidates(paths: &Paths, auth_json: &Path) -> Option<ExactTokenC
     Some((target.account_id, candidates))
 }
 
-/// Whether two login identifiers *prove* they are different people.
-///
-/// Difference is only provable inside one namespace. `uid:` comes from
-/// `chatgpt_user_id` and `sub:` from the JWT subject, and a token gaining the
-/// former does not stop it being the same login — a legacy profile identified as
-/// `sub:S` meeting its own refreshed token, now reporting `uid:U`, is the same
-/// person. Reading that as proof of difference makes the refusal absolute, so
-/// the one population this design exists to migrate would be left with no way
-/// through at all. Unequal across namespaces is unproven, not different: the
-/// caller still treats it as unsettled, so it becomes a question instead.
-fn logins_disagree(incoming: Option<&str>, stored: Option<&str>) -> bool {
-    let (Some(incoming), Some(stored)) = (incoming, stored) else {
-        return false;
-    };
-    let namespace = |login: &str| login.split_once(':').map(|(tag, _)| tag.to_string());
-    match (namespace(incoming), namespace(stored)) {
-        (Some(a), Some(b)) if a == b => incoming != stored,
-        // An untagged value on both sides is a single namespace by default.
-        (None, None) => incoming != stored,
-        _ => false,
-    }
-}
-
 /// Whether a subject-only match on a claimless pair is really undecided.
 ///
 /// When neither the file nor the hinted profile declares a workspace, the only
@@ -990,10 +988,10 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
     {
         return false;
     }
-    let Some(login) = api::token_login(&target.access_token) else {
+    let target_login = api::token_logins(&target.access_token);
+    if target_login.is_empty() {
         return false;
-    };
-    let target_login = Some(login.clone());
+    }
     // A store that cannot be read is not evidence that no sibling declares a
     // workspace, and a half-written profile is still a profile — both count as
     // ambiguity rather than permission for the hint. Siblings are judged by
@@ -1009,14 +1007,29 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
                 return true;
             };
             let Ok(sibling) = api::read_auth_json(&dir.join("auth.json")) else {
-                // Unreadable credentials leave only the recorded identity. It
-                // blocks unless it proves this is somebody else's profile —
-                // otherwise an unrelated damaged profile would suppress a
-                // healthy one's rotation and let it expire.
-                return !metadata_contradicts(paths, &alias, None, target_login.as_deref());
+                // Unreadable credentials leave only the recorded identity,
+                // which is a `chatgpt_user_id` and never a subject.
+                let recorded = read_meta(&dir.join("meta.json"))
+                    .and_then(|meta| meta.user_id)
+                    .map(|user_id| api::recorded_logins(&user_id));
+                return match recorded {
+                    // A claim that can be weighed competes only if it matches.
+                    Some(recorded) if recorded.comparable(&target_login) => {
+                        recorded.same(&target_login)
+                    }
+                    // A claim in the other namespace weighs nothing either way,
+                    // while the hinted profile positively holds this login — so
+                    // this is not a rival. Reading it as one is how an unrelated
+                    // damaged profile suppresses a healthy profile's rotation and
+                    // lets its token expire.
+                    Some(_) => false,
+                    // Nothing recorded at all: it could still be anyone, so it
+                    // blocks unless its workspace rules it out.
+                    None => !metadata_contradicts(paths, &alias, None, &target_login),
+                };
             };
             workspace_of_profile(paths, &alias).is_some()
-                && api::token_login(&sibling.access_token).as_deref() == Some(login.as_str())
+                && target_login.same(&api::token_logins(&sibling.access_token))
         })
 }
 
@@ -1176,10 +1189,11 @@ fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -
         return false;
     }
     // The same login identity `login` and `save` compare, so a file is not one
-    // seat to capture and two accounts to an overwrite: `token_login` prefers
-    // `chatgpt_user_id` and only falls back to `sub`.
-    let left_login = api::token_login(&left.access_token);
-    if left_login.is_none() || left_login != api::token_login(&right.access_token) {
+    // seat to capture and two accounts to an overwrite. Compared inside a shared
+    // namespace: a rotation that adds `chatgpt_user_id` to a token the profile
+    // knows only by its subject is the same seat, and reading it as a stranger
+    // would leave the profile holding a token that never refreshes again.
+    if !api::token_logins(&left.access_token).same(&api::token_logins(&right.access_token)) {
         return false;
     }
     // The same login is not the same account. Two workspace seats of one human
@@ -1200,12 +1214,12 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     let Ok(target_auth) = api::read_auth_json(auth_json) else {
         return Ok(None);
     };
-    let target_seat = api::token_login(&target_auth.access_token);
+    let target_seat = api::token_logins(&target_auth.access_token);
     let target_account = target_auth.account_id.clone();
     // Enumerated from the store's directories: `list_profiles_from` skips a
     // profile with no `meta.json`, and an interrupted save leaves a real one in
     // that shape whose claim still belongs in this decision.
-    let target_login = api::token_login(&target_auth.access_token);
+    let target_login = api::token_logins(&target_auth.access_token);
     let mut profile_auths = Vec::new();
     for alias in stored_aliases(paths)? {
         let Ok(dir) = store::profile_dir(paths, &alias) else {
@@ -1217,18 +1231,17 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
             // look like the sole owner of a credential this one may hold, so an
             // identified one makes the decision undecidable instead.
             let meta = read_meta(&dir.join("meta.json")).unwrap_or_default();
-            let recorded_login = meta.user_id.as_deref().map(api::recorded_login);
+            let recorded_login = meta.user_id.as_deref().map(api::recorded_logins);
             // A field that positively disagrees rules the profile out, whatever
             // the other one says: a damaged profile for another login in the
             // same workspace is not a candidate, and letting it block would
             // discard a rotation belonging to the healthy profile that is.
-            let identifies = !metadata_contradicts(
-                paths,
-                &alias,
-                target_account.as_deref(),
-                target_login.as_deref(),
-            ) && ((recorded_login.is_some() && recorded_login == target_login)
-                || (meta.account_id.is_some() && meta.account_id == target_account));
+            let identifies =
+                !metadata_contradicts(paths, &alias, target_account.as_deref(), &target_login)
+                    && (recorded_login
+                        .as_ref()
+                        .is_some_and(|recorded| recorded.same(&target_login))
+                        || (meta.account_id.is_some() && meta.account_id == target_account));
             if identifies {
                 return Ok(None);
             }
@@ -1252,8 +1265,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     let same_seat: Vec<(String, Option<String>)> = profile_auths
         .into_iter()
         .filter_map(|(alias, profile_auth)| {
-            let profile_seat = api::token_login(&profile_auth.access_token);
-            (target_seat.is_some() && target_seat == profile_seat).then_some({
+            (target_seat.same(&api::token_logins(&profile_auth.access_token))).then_some({
                 let workspace = workspace_of_profile(paths, &alias);
                 (alias, workspace)
             })

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -372,28 +372,28 @@ pub fn conflicting_workspace(
     incoming_account: Option<&str>,
     incoming_user: Option<&str>,
 ) -> Option<String> {
-    let dir = store::profile_dir(paths, alias).ok()?;
-    if api::read_auth_json(&dir.join("auth.json")).is_err() {
-        // No readable token: nothing here can be identified, and nothing here
-        // can be used either. An operator whose stored token is corrupt is sent
-        // back to `login` precisely to replace it, so this is a repair rather
-        // than a loss. Every other path treats an unreadable profile as
-        // occupied; this one is the deliberate exception.
-        return None;
-    }
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
     if stored_workspace.is_none() && stored_user.is_none() {
         return None;
     }
-    // This guard gates `login` and `save`, which replace what is stored, so it
-    // requires positive agreement rather than the absence of contradiction.
-    let workspace_ok = claims_agree(incoming_account, stored_workspace.as_deref());
-    // A workspace is shared: two people with seats in one team workspace agree
-    // on it and are still different accounts. The login has to agree as well
-    // before this alias may be written over.
-    let user_ok = claims_agree(incoming_user, stored_user.as_deref());
-    if workspace_ok && user_ok {
+    // This guard gates `login` and `save`, which replace what is stored.
+    //
+    // The workspace has to be settled before anything may be written over it:
+    // the same claim on both sides, or no claim on either. "Stored declares
+    // nothing" is not agreement — one login holds seats in several workspaces,
+    // so a legacy profile that never recorded one cannot confirm that an
+    // arriving workspace is the same account.
+    let workspace_settled = claims_agree(incoming_account, stored_workspace.as_deref());
+    // The login only has to not contradict. A workspace is shared, so a
+    // different login in it is a different account; but a stored login that was
+    // never recorded blocks nothing on its own, which is what keeps a profile
+    // repairable when its token is unreadable and only metadata remains.
+    let user_contradicts = matches!(
+        (incoming_user, stored_user.as_deref()),
+        (Some(incoming), Some(stored)) if incoming != stored
+    );
+    if workspace_settled && !user_contradicts {
         return None;
     }
     Some(
@@ -581,19 +581,50 @@ fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Opt
 /// lane can rotate the file to a different account, so a file that matches
 /// nothing still falls back to a store-wide search.
 /// The profile holding this exact access token, if any.
+/// Choose the owner among profiles holding one access token.
+///
+/// A profile declaring the same workspace is a stronger match than one
+/// declaring none, so directory order must not decide between them — the
+/// weaker match would take the credentials and leave the real owner stale.
+/// Equally strong matches are genuinely ambiguous and get no answer.
+fn strongest_exact_match(
+    target_workspace: Option<&str>,
+    candidates: &[(String, Option<String>)],
+) -> Option<String> {
+    let declared: Vec<&(String, Option<String>)> = candidates
+        .iter()
+        .filter(|(_, workspace)| {
+            target_workspace.is_some() && workspace.as_deref() == target_workspace
+        })
+        .collect();
+    if let [only] = declared.as_slice() {
+        return Some(only.0.clone());
+    }
+    if !declared.is_empty() {
+        return None;
+    }
+    let permitted: Vec<&(String, Option<String>)> = candidates
+        .iter()
+        .filter(|(_, workspace)| workspace_permits(target_workspace, workspace.as_deref()))
+        .collect();
+    if let [only] = permitted.as_slice() {
+        return Some(only.0.clone());
+    }
+    None
+}
+
 fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String> {
     let target = api::read_auth_json(auth_json).ok()?;
-    list_profiles_from(paths)
+    let candidates: Vec<(String, Option<String>)> = list_profiles_from(paths)
         .ok()?
         .into_iter()
-        .find_map(|profile| {
+        .filter_map(|profile| {
             let stored = api::read_auth_json(&profile.auth_json_path()).ok()?;
-            // Token equality is a strong signal but not identity on its own,
-            // so it goes through the same rule as every other attribution.
-            (stored.access_token == target.access_token
-                && workspace_permits(target.account_id.as_deref(), stored.account_id.as_deref()))
-            .then_some(profile.meta.alias)
+            (stored.access_token == target.access_token)
+                .then_some((profile.meta.alias, stored.account_id))
         })
+        .collect();
+    strongest_exact_match(target.account_id.as_deref(), &candidates)
 }
 
 pub fn alias_for_auth_json_with_hint(
@@ -735,15 +766,15 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
         profile_auths.push((profile, profile_auth));
     }
 
-    for (profile, profile_auth) in &profile_auths {
-        if profile_auth.access_token == target_auth.access_token
-            && workspace_permits(
-                target_account.as_deref(),
-                profile_auth.account_id.as_deref(),
-            )
-        {
-            return Ok(Some(profile.meta.alias.clone()));
-        }
+    let exact: Vec<(String, Option<String>)> = profile_auths
+        .iter()
+        .filter(|(_, profile_auth)| profile_auth.access_token == target_auth.access_token)
+        .map(|(profile, profile_auth)| {
+            (profile.meta.alias.clone(), profile_auth.account_id.clone())
+        })
+        .collect();
+    if !exact.is_empty() {
+        return Ok(strongest_exact_match(target_account.as_deref(), &exact));
     }
 
     let same_seat: Vec<(String, Option<String>)> = profile_auths

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -631,13 +631,37 @@ pub fn capture_exec_auth_from(paths: &Paths, exec_auth: &Path, pinned_alias: &st
 /// token, which is what a re-login of the same alias during a long pinned run
 /// would otherwise cause.
 fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Option<&str>) {
-    if !exec_auth.exists() {
-        return;
-    }
-    let Some(alias) = alias_for_auth_json_with_hint(paths, exec_auth, pinned_alias) else {
+    capture_from_snapshot(paths, exec_auth, |snapshot| {
+        alias_for_auth_json_with_hint(paths, snapshot, pinned_alias)
+    });
+}
+
+/// Capture `source`, deciding and writing from a single snapshot of it.
+///
+/// Codex rewrites these files without taking the store lock, so reading the
+/// path more than once can resolve ownership from one account and copy the
+/// bytes of another. Everything downstream — ownership, freshness, workspace
+/// preservation, and the write itself — sees the same bytes.
+fn capture_from_snapshot(
+    paths: &Paths,
+    source: &Path,
+    resolve: impl FnOnce(&Path) -> Option<String>,
+) {
+    let Ok(bytes) = std::fs::read(source) else {
         return;
     };
-    capture_into_owner(paths, exec_auth, &alias);
+    let snapshot = paths.codexctl_dir().join(".capture-snapshot.json");
+    if let Err(error) = store::atomic_write(&snapshot, &bytes) {
+        eprintln!(
+            "warning: could not snapshot {} to capture it: {error}",
+            source.display()
+        );
+        return;
+    }
+    if let Some(alias) = resolve(&snapshot) {
+        capture_into_owner(paths, &snapshot, &alias);
+    }
+    let _ = std::fs::remove_file(&snapshot);
 }
 
 /// Fold `source` into the profile that owns it, once ownership is settled.
@@ -1151,14 +1175,10 @@ fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path, skip_alias
     } else {
         None
     };
-    let Some(alias) = alias_for_auth_json_with_hint(paths, codex_auth, known_alias.as_deref())
-    else {
-        return;
-    };
-    if skip_alias == Some(alias.as_str()) {
-        return;
-    }
-    capture_into_owner(paths, codex_auth, &alias);
+    capture_from_snapshot(paths, codex_auth, |snapshot| {
+        let alias = alias_for_auth_json_with_hint(paths, snapshot, known_alias.as_deref())?;
+        (skip_alias != Some(alias.as_str())).then_some(alias)
+    });
 }
 
 pub fn update_meta_plan_from(paths: &Paths, alias: &str, plan: &str) -> Result<()> {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -402,31 +402,18 @@ pub fn existing_seat(
     })
 }
 
-/// Whether `alias` holds a profile whose account cannot be identified at all —
-/// no workspace in its metadata and none in the token it stored.
+/// Whether `alias` holds a profile whose credentials cannot be read at all.
 ///
-/// Such a profile cannot be shown to be the same account as an incoming login,
-/// so an alias codexctl *derived* rather than the operator naming it must not
-/// be reused: the overwrite would rest on an unprovable match.
-pub fn unidentifiable_profile(paths: &Paths, alias: &str) -> bool {
+/// The guard for an alias codexctl *derived* rather than the operator naming
+/// it: an occupant whose auth file will not parse cannot be shown to be the
+/// same account, and replacing it on no evidence is not an approval anyone
+/// gave. Identity that is merely absent is judged by the agreement rule
+/// instead — two sides that both declare nothing still agree.
+pub fn credentials_unreadable(paths: &Paths, alias: &str) -> bool {
     let Ok(dir) = store::profile_dir(paths, alias) else {
         return false;
     };
-    if !dir.exists() {
-        // Nothing is there to overwrite.
-        return false;
-    }
-    // Something is there. Metadata that cannot be read is the strongest reason
-    // to treat it as unidentifiable, not a reason to treat it as absent — an
-    // interrupted save or a damaged file leaves exactly this shape.
-    if get_profile_from(paths, alias).is_err() {
-        return true;
-    }
-    // Both halves are required. A workspace holds many logins, so knowing only
-    // the workspace does not say whose credentials these are — and this guard
-    // protects an alias the operator never named, where "not proven different"
-    // is not good enough to overwrite.
-    workspace_of_profile(paths, alias).is_none() || user_of_profile(paths, alias).is_none()
+    dir.exists() && api::read_auth_json(&dir.join("auth.json")).is_err()
 }
 
 pub fn conflicting_workspace(

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -284,7 +284,8 @@ pub fn workspace_of_profile(paths: &Paths, alias: &str) -> Option<String> {
 fn claim_permits(candidate: Option<&str>, stored: Option<&str>) -> bool {
     match (candidate, stored) {
         (Some(candidate), Some(stored)) => candidate == stored,
-        (None, Some(_)) => true,
+        // Declaring nothing cannot prove membership of a declared account.
+        (None, Some(_)) => false,
         (Some(_), None) | (None, None) => true,
     }
 }
@@ -455,7 +456,7 @@ pub fn conflicting_workspace(
         // The arriving token names no login at all. A workspace is shared, so
         // agreeing on it proves nothing about whose credentials these are, and
         // the profile does name someone.
-        (None, Some(_)) => false,
+        (None, Some(_)) => true,
         (None, None) => false,
     };
     if workspace_settled && !user_contradicts {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -716,14 +716,19 @@ fn exact_token_candidates(
     auth_json: &Path,
 ) -> Option<(Option<String>, Vec<(String, Option<String>)>)> {
     let target = api::read_auth_json(auth_json).ok()?;
-    let candidates: Vec<(String, Option<String>)> = list_profiles_from(paths)
+    // Enumerated from the store's directories rather than `list_profiles_from`,
+    // which skips a profile with no `meta.json`. A save writes `auth.json`
+    // first, so an interrupted one leaves a real holder of this token — and
+    // omitting it can leave a claimless sibling looking like the sole owner.
+    let candidates: Vec<(String, Option<String>)> = stored_aliases(paths)
         .ok()?
         .into_iter()
-        .filter_map(|profile| {
-            let stored = api::read_auth_json(&profile.auth_json_path()).ok()?;
+        .filter_map(|alias| {
+            let dir = store::profile_dir(paths, &alias).ok()?;
+            let stored = api::read_auth_json(&dir.join("auth.json")).ok()?;
             (stored.access_token == target.access_token).then_some({
-                let workspace = workspace_of_profile(paths, &profile.meta.alias);
-                (profile.meta.alias, workspace)
+                let workspace = workspace_of_profile(paths, &alias);
+                (alias, workspace)
             })
         })
         .collect();
@@ -786,29 +791,35 @@ pub fn alias_for_auth_json_with_hint(
     // Every profile holding this exact token is weighed first: one that declares
     // the target's workspace is a stronger owner than the hinted alias, and the
     // hint must not outrank evidence.
-    let exact = exact_token_candidates(paths, auth_json);
-    if let Some((target_workspace, candidates)) = &exact
-        && let Some(alias) = strongest_exact_match(target_workspace.as_deref(), candidates)
+    //
+    // Once any profile holds this exact token, that evidence decides the
+    // outcome by itself: a weaker rule must not answer a question the strongest
+    // one already considered and declined.
+    if let Some((target_workspace, candidates)) = &exact_token_candidates(paths, auth_json)
+        && !candidates.is_empty()
     {
-        return Some(alias);
-    }
-    // Exact matching was undecided. The hint settles it only when the hinted
-    // profile is itself one of those equally strong candidates — that is the
-    // duplicate-alias case it exists for.
-    if let Some(profile) = &hinted
-        && let Some((target_workspace, candidates)) = &exact
-        && candidates.iter().any(|(alias, workspace)| {
-            // Only among candidates the evidence left standing: a profile whose
-            // workspace positively differs is disqualified, and naming it is not
-            // a tie-break but an override.
-            alias == &profile.meta.alias
-                && !matches!(
-                    (target_workspace.as_deref(), workspace.as_deref()),
-                    (Some(target), Some(stored)) if target != stored
-                )
-        })
-    {
-        return Some(profile.meta.alias.clone());
+        if let Some(alias) = strongest_exact_match(target_workspace.as_deref(), candidates) {
+            return Some(alias);
+        }
+        // Undecided. The hint settles a genuine tie among equal candidates, but
+        // a contradiction anywhere in the set means this token demonstrably
+        // spans workspaces — naming one holder would be an override, not a
+        // tie-break.
+        let contradicted = candidates.iter().any(|(_, workspace)| {
+            matches!(
+                (target_workspace.as_deref(), workspace.as_deref()),
+                (Some(target), Some(stored)) if target != stored
+            )
+        });
+        if !contradicted
+            && let Some(profile) = &hinted
+            && candidates
+                .iter()
+                .any(|(alias, _)| alias == &profile.meta.alias)
+        {
+            return Some(profile.meta.alias.clone());
+        }
+        return None;
     }
     if let Some(profile) = hinted
         && auth_belongs_to_profile(paths, auth_json, &profile)

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -123,8 +123,25 @@ pub fn save_profile_and_activate_to(
     email: Option<&str>,
     auth_json_src: &Path,
 ) -> Result<()> {
+    let lock = store::lock(paths)?;
+    save_profile_and_activate_locked(&lock, paths, alias, email, auth_json_src)
+}
+
+/// [`save_profile_and_activate_to`] for a caller that already holds the store
+/// lock, so it can decide *and* write without releasing it in between.
+///
+/// The lock is taken by reference as proof rather than for use: which alias a
+/// save lands on depends on what the store already holds, and a decision made
+/// outside the lock answers for a store another writer can still change before
+/// the write lands.
+pub fn save_profile_and_activate_locked(
+    _lock: &store::StoreLock,
+    paths: &Paths,
+    alias: &str,
+    email: Option<&str>,
+    auth_json_src: &Path,
+) -> Result<()> {
     let alias = store::validate_alias(alias)?;
-    let _lock = store::lock(paths)?;
     let live_auth = paths.codex_auth_json();
     save_profile_unlocked(paths, alias, email, auth_json_src)?;
 
@@ -209,9 +226,16 @@ pub fn conflicting_workspace(
     alias: &str,
     incoming_account: Option<&str>,
 ) -> Option<String> {
-    let incoming = incoming_account?;
     let stored = get_profile_from(paths, alias).ok()?.meta.account_id?;
-    (stored != incoming).then_some(stored)
+    match incoming_account {
+        // A token naming a different workspace is a different account.
+        Some(incoming) => (stored != incoming).then_some(stored),
+        // A token naming no workspace cannot prove it is the same account, and
+        // this profile positively declares one. Treating "unprovable" as "same"
+        // is what lets a second seat overwrite the first's credentials, so the
+        // claim is required once the stored profile has one.
+        None => Some(stored),
+    }
 }
 
 /// Short workspace id for an error message; the full uuid is noise.
@@ -225,9 +249,20 @@ pub fn short_workspace(account_id: &str) -> String {
 /// Set or clear a profile's display label. `None`, or text that is blank once
 /// trimmed, clears it.
 pub fn set_label_from(paths: &Paths, alias: &str, label: Option<&str>) -> Result<()> {
+    let lock = store::lock(paths)?;
+    set_label_locked(&lock, paths, alias, label)
+}
+
+/// [`set_label_from`] for a caller already holding the store lock, so a save
+/// and its label land as one locked sequence instead of two.
+pub fn set_label_locked(
+    _lock: &store::StoreLock,
+    paths: &Paths,
+    alias: &str,
+    label: Option<&str>,
+) -> Result<()> {
     let alias = store::validate_alias(alias)?;
     let label = label.map(store::validate_label).transpose()?.flatten();
-    let _lock = store::lock(paths)?;
     let dir = store::profile_dir(paths, alias)?;
     let meta_path = dir.join("meta.json");
     let Some(mut meta) = read_meta(&meta_path) else {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -858,10 +858,10 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
     {
         return false;
     }
-    let Some(subject) = api::token_subject(&target.access_token) else {
+    let Some(login) = api::token_login(&target.access_token) else {
         return false;
     };
-    let target_login = api::token_login(&target.access_token);
+    let target_login = Some(login.clone());
     // A store that cannot be read is not evidence that no sibling declares a
     // workspace, and a half-written profile is still a profile — both count as
     // ambiguity rather than permission for the hint. Siblings are judged by
@@ -884,7 +884,7 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
                 return !metadata_contradicts(paths, &alias, None, target_login.as_deref());
             };
             workspace_of_profile(paths, &alias).is_some()
-                && api::token_subject(&sibling.access_token).as_deref() == Some(subject.as_str())
+                && api::token_login(&sibling.access_token).as_deref() == Some(login.as_str())
         })
 }
 
@@ -1043,8 +1043,11 @@ fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -
     if !claims_agree(left.account_id.as_deref(), right.account_id.as_deref()) {
         return false;
     }
-    let left_subject = api::token_subject(&left.access_token);
-    if left_subject.is_none() || left_subject != api::token_subject(&right.access_token) {
+    // The same login identity `login` and `save` compare, so a file is not one
+    // seat to capture and two accounts to an overwrite: `token_login` prefers
+    // `chatgpt_user_id` and only falls back to `sub`.
+    let left_login = api::token_login(&left.access_token);
+    if left_login.is_none() || left_login != api::token_login(&right.access_token) {
         return false;
     }
     // The same login is not the same account. Two workspace seats of one human
@@ -1065,7 +1068,7 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     let Ok(target_auth) = api::read_auth_json(auth_json) else {
         return Ok(None);
     };
-    let target_sub = api::token_subject(&target_auth.access_token);
+    let target_seat = api::token_login(&target_auth.access_token);
     let target_account = target_auth.account_id.clone();
     // Enumerated from the store's directories: `list_profiles_from` skips a
     // profile with no `meta.json`, and an interrupted save leaves a real one in
@@ -1116,8 +1119,8 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
     let same_seat: Vec<(String, Option<String>)> = profile_auths
         .into_iter()
         .filter_map(|(alias, profile_auth)| {
-            let profile_sub = api::token_subject(&profile_auth.access_token);
-            (target_sub.is_some() && target_sub == profile_sub).then_some({
+            let profile_seat = api::token_login(&profile_auth.access_token);
+            (target_seat.is_some() && target_seat == profile_seat).then_some({
                 let workspace = workspace_of_profile(paths, &alias);
                 (alias, workspace)
             })

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -446,21 +446,17 @@ pub fn conflicting_workspace(
     // so a legacy profile that never recorded one cannot confirm that an
     // arriving workspace is the same account.
     let workspace_settled = claims_agree(incoming_account, stored_workspace.as_deref());
-    // The login only has to not contradict. A workspace is shared, so a
-    // different login in it is a different account; but a stored login that was
-    // never recorded blocks nothing on its own, which is what keeps a profile
-    // repairable when its token is unreadable and only metadata remains.
-    // A stored login that is merely absent blocks nothing only when there is
-    // genuinely nothing to read — an unreadable token is what sends an operator
-    // back to `login` to repair the profile. A *readable* token that yields no
-    // login is different: the profile is intact, its owner is simply unproven,
-    // and a workspace does not identify its owner.
+    // The login must be settled too, and a workspace does not settle it: a team
+    // workspace holds many people, so agreeing on it says nothing about whose
+    // credentials these are.
+    //
+    // A profile whose stored login cannot be recovered is not thereby open to
+    // anyone who names one. The only profile safe to replace on no evidence is
+    // one with no identity at all, and that case has already returned above —
+    // reaching here means this profile still has something worth protecting.
     let user_contradicts = match (incoming_user, stored_user.as_deref()) {
         (Some(incoming), Some(stored)) => incoming != stored,
-        (Some(_), None) => stored_auth_readable,
-        // The arriving token names no login at all. A workspace is shared, so
-        // agreeing on it proves nothing about whose credentials these are, and
-        // the profile does name someone.
+        (Some(_), None) => true,
         (None, Some(_)) => true,
         (None, None) => false,
     };

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -226,7 +226,16 @@ pub fn conflicting_workspace(
     alias: &str,
     incoming_account: Option<&str>,
 ) -> Option<String> {
-    let stored = get_profile_from(paths, alias).ok()?.meta.account_id?;
+    let profile = get_profile_from(paths, alias).ok()?;
+    // A profile saved before workspaces were recorded has no `account_id` in
+    // its metadata, but the token it stored still carries the claim. Reading it
+    // keeps the guard working the moment this version ships, instead of only
+    // for profiles that happen to have been re-saved since.
+    let stored = profile
+        .meta
+        .account_id
+        .clone()
+        .or_else(|| identity_of_auth_file(&profile.auth_json_path()).account_id)?;
     match incoming_account {
         // A token naming a different workspace is a different account.
         Some(incoming) => (stored != incoming).then_some(stored),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -788,6 +788,29 @@ fn strongest_exact_match(
     None
 }
 
+/// Whether a profile's *metadata* proves it is not the owner of this file.
+///
+/// Used where credentials cannot be read: the recorded identity is all that is
+/// left, and a field that positively disagrees is enough to rule the profile
+/// out of the decision entirely.
+fn metadata_contradicts(
+    paths: &Paths,
+    alias: &str,
+    target_workspace: Option<&str>,
+    target_login: Option<&str>,
+) -> bool {
+    let Ok(dir) = store::profile_dir(paths, alias) else {
+        return false;
+    };
+    let meta = read_meta(&dir.join("meta.json")).unwrap_or_default();
+    let workspace_disagrees = meta.account_id.is_some()
+        && target_workspace.is_some()
+        && meta.account_id.as_deref() != target_workspace;
+    let login_disagrees =
+        meta.user_id.is_some() && target_login.is_some() && meta.user_id.as_deref() != target_login;
+    workspace_disagrees || login_disagrees
+}
+
 /// Whether a stored workspace positively rules a file out.
 ///
 /// A profile declaring a workspace the file does not name is not its owner —
@@ -851,6 +874,7 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
     let Some(subject) = api::token_subject(&target.access_token) else {
         return false;
     };
+    let target_login = api::token_login(&target.access_token);
     // A store that cannot be read is not evidence that no sibling declares a
     // workspace, and a half-written profile is still a profile — both count as
     // ambiguity rather than permission for the hint. Siblings are judged by
@@ -866,7 +890,11 @@ fn claimless_match_is_ambiguous(paths: &Paths, auth_json: &Path, hinted: &Profil
                 return true;
             };
             let Ok(sibling) = api::read_auth_json(&dir.join("auth.json")) else {
-                return true;
+                // Unreadable credentials leave only the recorded identity. It
+                // blocks unless it proves this is somebody else's profile —
+                // otherwise an unrelated damaged profile would suppress a
+                // healthy one's rotation and let it expire.
+                return !metadata_contradicts(paths, &alias, None, target_login.as_deref());
             };
             workspace_of_profile(paths, &alias).is_some()
                 && api::token_subject(&sibling.access_token).as_deref() == Some(subject.as_str())
@@ -1071,14 +1099,13 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
             // the other one says: a damaged profile for another login in the
             // same workspace is not a candidate, and letting it block would
             // discard a rotation belonging to the healthy profile that is.
-            let contradicts =
-                (meta.user_id.is_some() && target_login.is_some() && meta.user_id != target_login)
-                    || (meta.account_id.is_some()
-                        && target_account.is_some()
-                        && meta.account_id != target_account);
-            let identifies = !contradicts
-                && ((meta.user_id.is_some() && meta.user_id == target_login)
-                    || (meta.account_id.is_some() && meta.account_id == target_account));
+            let identifies = !metadata_contradicts(
+                paths,
+                &alias,
+                target_account.as_deref(),
+                target_login.as_deref(),
+            ) && ((meta.user_id.is_some() && meta.user_id == target_login)
+                || (meta.account_id.is_some() && meta.account_id == target_account));
             if identifies {
                 return Ok(None);
             }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -892,11 +892,16 @@ fn auth_belongs_to_profile(paths: &Paths, auth_json: &Path, profile: &Profile) -
     // An identical access token is not identity on its own: `read_auth_json`
     // takes an explicit `account_id` from the file ahead of the JWT claim, so
     // two files can carry one token and name different workspaces.
-    if !workspace_permits(left.account_id.as_deref(), right.account_id.as_deref()) {
-        return false;
-    }
     if left.access_token == right.access_token {
-        return true;
+        return workspace_permits(left.account_id.as_deref(), right.account_id.as_deref());
+    }
+    // Beyond an identical token this is a *rotation*, and capture overwrites
+    // what the profile holds. A rotation that declares a workspace the profile
+    // never recorded cannot prove it is the same account — one login has seats
+    // in several workspaces — so it needs positive agreement, not the mere
+    // absence of contradiction.
+    if !claims_agree(left.account_id.as_deref(), right.account_id.as_deref()) {
+        return false;
     }
     let left_subject = api::token_subject(&left.access_token);
     if left_subject.is_none() || left_subject != api::token_subject(&right.access_token) {
@@ -969,18 +974,15 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
                 .filter(|(_, account)| declares(account))
                 .map(|(alias, _)| alias)
                 .collect();
-            let contradicted = same_seat
-                .iter()
-                .any(|(_, account)| account.is_some() && !declares(account));
-
             if !same_workspace.is_empty() {
                 same_workspace
-            } else if contradicted {
-                Vec::new()
             } else {
-                // Nothing declares a workspace at all: a profile saved before
-                // the claim was recorded still owns its own rotated tokens.
-                same_seat.iter().map(|(alias, _)| alias).collect()
+                // Nothing on this login declares the arriving workspace. A
+                // profile that never recorded one cannot confirm it is that
+                // account, and attributing a rotation here would copy another
+                // workspace's credential over it. The profile goes stale until
+                // its next save or login, which is recoverable; this is not.
+                Vec::new()
             }
         }
         // The target declares no workspace, so it cannot prove it belongs to a

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -438,7 +438,12 @@ pub fn conflicting_workspace(
     let dir = store::profile_dir(paths, alias).ok()?;
     let stored_workspace = workspace_of_profile(paths, alias);
     let stored_user = user_of_profile(paths, alias);
-    if stored_workspace.is_none() && stored_user.is_none() {
+    let stored_auth_readable = api::read_auth_json(&dir.join("auth.json")).is_ok();
+    if stored_workspace.is_none() && stored_user.is_none() && !stored_auth_readable {
+        // Nothing identifiable *and* nothing usable: this is the profile an
+        // operator is sent back to `login` to repair, so replacing it loses
+        // nothing. A readable token that merely names nobody is intact, and
+        // overwriting it needs the same proof as any other profile.
         return None;
     }
     // This guard gates `login` and `save`, which replace what is stored.
@@ -458,7 +463,6 @@ pub fn conflicting_workspace(
     // back to `login` to repair the profile. A *readable* token that yields no
     // login is different: the profile is intact, its owner is simply unproven,
     // and a workspace does not identify its owner.
-    let stored_auth_readable = api::read_auth_json(&dir.join("auth.json")).is_ok();
     let user_contradicts = match (incoming_user, stored_user.as_deref()) {
         (Some(incoming), Some(stored)) => incoming != stored,
         (Some(_), None) => stored_auth_readable,
@@ -1039,8 +1043,18 @@ pub fn alias_for_auth_json_from(paths: &Paths, auth_json: &Path) -> Result<Optio
             // look like the sole owner of a credential this one may hold, so an
             // identified one makes the decision undecidable instead.
             let meta = read_meta(&dir.join("meta.json")).unwrap_or_default();
-            let identifies = (meta.user_id.is_some() && meta.user_id == target_login)
-                || (meta.account_id.is_some() && meta.account_id == target_account);
+            // A field that positively disagrees rules the profile out, whatever
+            // the other one says: a damaged profile for another login in the
+            // same workspace is not a candidate, and letting it block would
+            // discard a rotation belonging to the healthy profile that is.
+            let contradicts =
+                (meta.user_id.is_some() && target_login.is_some() && meta.user_id != target_login)
+                    || (meta.account_id.is_some()
+                        && target_account.is_some()
+                        && meta.account_id != target_account);
+            let identifies = !contradicts
+                && ((meta.user_id.is_some() && meta.user_id == target_login)
+                    || (meta.account_id.is_some() && meta.account_id == target_account));
             if identifies {
                 return Ok(None);
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result, bail};
 use crate::config::Paths;
 
 const MAX_ALIAS_BYTES: usize = 128;
+const MAX_LABEL_BYTES: usize = 40;
 
 /// Validate one profile-store path component.
 ///
@@ -39,6 +40,28 @@ pub fn validate_alias(alias: &str) -> Result<&str> {
         bail!("profile alias must be one path component");
     }
     Ok(alias)
+}
+
+/// Validate a profile's display label.
+///
+/// A label never becomes a path component, so it carries none of the path rules
+/// an alias needs. It only has to render as one readable line inside a table.
+/// Blank input returns `Ok(None)`, which is how a label is cleared.
+pub fn validate_label(label: &str) -> Result<Option<&str>> {
+    let label = label.trim();
+    if label.is_empty() {
+        return Ok(None);
+    }
+    if label.len() > MAX_LABEL_BYTES {
+        bail!("profile label cannot exceed {MAX_LABEL_BYTES} bytes");
+    }
+    if !label.is_ascii() {
+        bail!("profile label must contain only ASCII characters");
+    }
+    if label.chars().any(char::is_control) {
+        bail!("profile label cannot contain control characters");
+    }
+    Ok(Some(label))
 }
 
 /// Return a checked profile directory below the profile-store root.
@@ -263,6 +286,41 @@ mod tests {
             validate_alias("  amir+8@sawmills.ai  ").unwrap(),
             "amir+8@sawmills.ai"
         );
+    }
+
+    #[test]
+    fn label_validation_trims_and_keeps_ordinary_text() {
+        assert_eq!(validate_label("  team  ").unwrap(), Some("team"));
+        assert_eq!(
+            validate_label("Sawmills team").unwrap(),
+            Some("Sawmills team")
+        );
+    }
+
+    /// A blank label is how the operator clears one, not an error.
+    #[test]
+    fn label_validation_treats_blank_as_a_clear() {
+        assert_eq!(validate_label("").unwrap(), None);
+        assert_eq!(validate_label("   ").unwrap(), None);
+    }
+
+    #[test]
+    fn label_validation_rejects_unrenderable_text() {
+        for label in [
+            "a".repeat(MAX_LABEL_BYTES + 1).as_str(),
+            "téam",
+            "two\nlines",
+        ] {
+            assert!(validate_label(label).is_err(), "accepted {label:?}");
+        }
+    }
+
+    /// A label is display text, never a path component, so path syntax that an
+    /// alias must reject is perfectly fine here.
+    #[test]
+    fn label_validation_allows_path_like_text() {
+        assert_eq!(validate_label("a/b").unwrap(), Some("a/b"));
+        assert_eq!(validate_label(".hidden").unwrap(), Some(".hidden"));
     }
 
     #[test]

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -610,6 +610,54 @@ fn token_subject_reads_sub_claim() {
     assert_eq!(api::token_subject("not-a-jwt"), None);
 }
 
+/// Build an unsigned JWT carrying `claims`. No real token value ever enters a
+/// fixture; every claim here is synthetic.
+fn synthetic_token(claims: &str) -> String {
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    format!("{JWT_HDR}.{payload}.sig")
+}
+
+#[test]
+fn token_identity_reads_profile_and_auth_claims() {
+    let token = synthetic_token(
+        r#"{
+            "sub": "seatA",
+            "https://api.openai.com/profile": {"email": "a@example.com", "name": "A Example"},
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct-1",
+                "chatgpt_user_id": "user-1",
+                "chatgpt_plan_type": "business"
+            }
+        }"#,
+    );
+
+    let identity = api::token_identity(&token).unwrap();
+
+    assert_eq!(identity.email.as_deref(), Some("a@example.com"));
+    assert_eq!(identity.name.as_deref(), Some("A Example"));
+    assert_eq!(identity.account_id.as_deref(), Some("acct-1"));
+    assert_eq!(identity.user_id.as_deref(), Some("user-1"));
+    assert_eq!(identity.plan.as_deref(), Some("business"));
+}
+
+#[test]
+fn token_identity_returns_none_for_an_unreadable_token() {
+    assert!(api::token_identity("not-a-jwt").is_none());
+}
+
+/// A token that decodes but carries neither claim object still yields an
+/// identity — every field simply stays empty, so callers keep one code path.
+#[test]
+fn token_identity_tolerates_missing_claim_objects() {
+    let identity = api::token_identity(&synthetic_token(r#"{"sub":"seatA"}"#)).unwrap();
+
+    assert!(identity.email.is_none());
+    assert!(identity.account_id.is_none());
+    assert!(identity.user_id.is_none());
+    assert!(identity.plan.is_none());
+}
+
 #[test]
 fn is_token_expired_distinguishes_exp_claim() {
     let future = format!("{JWT_HDR}.eyJleHAiOjk5OTk5OTk5OTl9.sig"); // exp 9999999999

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -599,6 +599,31 @@ fn parse_account_settings_missing_limits() {
     assert!(settings.seat_type_credit_limits.is_none());
 }
 
+/// A `team` plan returns `additional_rate_limits: null` rather than omitting
+/// the key or sending `[]`. Serde's `default` only covers a missing key, so an
+/// explicit null failed the whole response and the account rendered as `error`.
+#[test]
+fn parse_rate_limit_response_with_explicit_null_collections() {
+    let json = r#"{
+        "plan_type": "team",
+        "rate_limit": {
+            "allowed": true,
+            "primary_window": {"used_percent": 79, "limit_window_seconds": 604800}
+        },
+        "secondary_window": null,
+        "code_review_rate_limit": null,
+        "additional_rate_limits": null,
+        "credits": {"has_credits": false, "unlimited": false, "overage_limit_reached": false},
+        "rate_limit_reset_credits": {"available_count": 0, "applicable_available_count": 0}
+    }"#;
+
+    let usage: RateLimitResponse = serde_json::from_str(json).expect("team response must parse");
+
+    assert_eq!(usage.plan_type.as_deref(), Some("team"));
+    assert!(usage.additional_rate_limits.is_empty());
+    assert_eq!(usage.billing_class(), api::BillingClass::RateLimited);
+}
+
 // Fake JWT header `{"alg":"none"}`; only the (unverified) claims payload is read.
 const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -16,7 +16,221 @@ fn help_shows_all_subcommands() {
     assert!(stdout.contains("codex"));
     assert!(stdout.contains("resets"));
     assert!(stdout.contains("reset"));
+    assert!(stdout.contains("label"));
     assert!(stdout.contains("completions"));
+}
+
+// === Labels ===
+
+const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+
+/// Build an unsigned JWT carrying `claims`. Every claim is synthetic; no real
+/// token value enters a fixture.
+fn synthetic_token(claims: &str) -> String {
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    format!("{JWT_HDR}.{payload}.sig")
+}
+
+fn seat_token(email: &str, account_id: &str, plan: &str) -> String {
+    synthetic_token(&format!(
+        r#"{{"sub":"seat-{account_id}",
+             "https://api.openai.com/profile":{{"email":"{email}"}},
+             "https://api.openai.com/auth":{{
+                "chatgpt_account_id":"{account_id}",
+                "chatgpt_user_id":"user-1",
+                "chatgpt_plan_type":"{plan}"}}}}"#
+    ))
+}
+
+fn write_profile(home: &std::path::Path, alias: &str, token: &str, meta: &str) {
+    let dir = home.join(".codexctl/profiles").join(alias);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(dir.join("meta.json"), meta).unwrap();
+}
+
+fn run(home: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stdout_of(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
+#[test]
+fn label_sets_and_clears_a_profile_label() {
+    let tmp = tempfile::tempdir().unwrap();
+    let token = seat_token("amir@sawmills.ai", "acct-team", "business");
+    write_profile(
+        tmp.path(),
+        "amir-team",
+        &token,
+        r#"{"alias":"amir-team","email":"amir@sawmills.ai","plan":"business","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+
+    assert!(
+        run(tmp.path(), &["label", "amir-team", "team"])
+            .status
+            .success()
+    );
+    let listed = stdout_of(&run(tmp.path(), &["list"]));
+    assert!(listed.contains("team"), "label missing from list: {listed}");
+
+    // Omitting the text clears the label.
+    assert!(run(tmp.path(), &["label", "amir-team"]).status.success());
+    let cleared = stdout_of(&run(tmp.path(), &["list"]));
+    assert!(
+        !cleared.contains("Label"),
+        "cleared label still shown: {cleared}"
+    );
+}
+
+#[test]
+fn label_fails_for_an_unknown_alias() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    assert!(
+        !run(tmp.path(), &["label", "missing", "team"])
+            .status
+            .success()
+    );
+}
+
+/// Until a label exists the tables must look exactly as they did before, so an
+/// operator who never labels anything sees no new empty column.
+#[test]
+fn list_hides_the_label_column_until_a_label_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let token = seat_token("amir@sawmills.ai", "acct-personal", "pro");
+    write_profile(
+        tmp.path(),
+        "amir@sawmills.ai",
+        &token,
+        r#"{"alias":"amir@sawmills.ai","email":"amir@sawmills.ai","plan":"pro","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+
+    let bare = stdout_of(&run(tmp.path(), &["list"]));
+    assert!(bare.contains("Account"), "list is not a table: {bare}");
+    assert!(!bare.contains("Label"), "empty label column shown: {bare}");
+
+    run(tmp.path(), &["label", "amir@sawmills.ai", "personal"]);
+
+    let labeled = stdout_of(&run(tmp.path(), &["list"]));
+    assert!(labeled.contains("Label"), "label column missing: {labeled}");
+    assert!(labeled.contains("personal"), "label missing: {labeled}");
+}
+
+/// Two profiles on one email are the case this whole feature exists for: the
+/// email cannot tell them apart, so the label has to.
+#[test]
+fn list_distinguishes_two_profiles_that_share_one_email() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Label text deliberately shares no substring with the alias, so matching
+    // it proves the label column is rendered rather than the alias.
+    for (alias, account, plan, label) in [
+        ("amir-1", "acct-personal", "pro", "my own"),
+        ("amir-2", "acct-team", "business", "sawmills seat"),
+    ] {
+        let token = seat_token("amir@sawmills.ai", account, plan);
+        write_profile(
+            tmp.path(),
+            alias,
+            &token,
+            &format!(
+                r#"{{"alias":"{alias}","email":"amir@sawmills.ai","plan":"{plan}","account_id":"{account}","saved_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        );
+        run(tmp.path(), &["label", alias, label]);
+    }
+
+    let listed = stdout_of(&run(tmp.path(), &["list"]));
+
+    assert!(listed.contains("Label"), "{listed}");
+    assert!(listed.contains("my own"), "{listed}");
+    assert!(listed.contains("sawmills seat"), "{listed}");
+    // One email, two rows: the address alone cannot separate them.
+    assert_eq!(listed.matches("amir@sawmills.ai").count(), 2, "{listed}");
+}
+
+#[test]
+fn whoami_shows_the_label_of_the_active_profile() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_profile(
+        tmp.path(),
+        "amir-2",
+        &seat_token("amir@sawmills.ai", "acct-team", "business"),
+        r#"{"alias":"amir-2","label":"sawmills seat","email":"amir@sawmills.ai","plan":"business","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    std::fs::write(tmp.path().join(".codexctl/active"), "amir-2").unwrap();
+
+    let out = stdout_of(&run(tmp.path(), &["whoami"]));
+
+    assert!(out.contains("sawmills seat"), "label missing: {out}");
+    assert!(out.contains("amir@sawmills.ai"), "email missing: {out}");
+}
+
+#[test]
+fn save_and_login_accept_a_label() {
+    for command in ["save", "login"] {
+        let output = Command::cargo_bin("codexctl")
+            .unwrap()
+            .args([command, "--help"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.contains("--label"), "{command} lacks --label");
+    }
+}
+
+/// The hazard that makes a duplicate-email account dangerous: `save` with no
+/// alias targets the existing profile, and one keystroke at the overwrite
+/// prompt would destroy the other account's tokens.
+#[test]
+fn save_refuses_to_overwrite_a_profile_holding_a_different_account() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_profile(
+        tmp.path(),
+        "amir@sawmills.ai",
+        &seat_token("amir@sawmills.ai", "acct-personal", "pro"),
+        r#"{"alias":"amir@sawmills.ai","email":"amir@sawmills.ai","plan":"pro","account_id":"acct-personal","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    let codex_dir = tmp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let incoming = seat_token("amir@sawmills.ai", "acct-team", "business");
+    std::fs::write(
+        codex_dir.join("auth.json"),
+        format!(r#"{{"access_token":"{incoming}"}}"#),
+    )
+    .unwrap();
+
+    let output = run(tmp.path(), &["save"]);
+
+    assert!(!output.status.success(), "save did not refuse");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("different account"),
+        "unhelpful refusal: {stderr}"
+    );
+    // The stored tokens must be untouched.
+    let stored = std::fs::read_to_string(
+        tmp.path()
+            .join(".codexctl/profiles/amir@sawmills.ai/auth.json"),
+    )
+    .unwrap();
+    assert!(
+        !stored.contains(&incoming),
+        "personal profile was clobbered"
+    );
 }
 
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -179,6 +179,76 @@ fn whoami_shows_the_label_of_the_active_profile() {
     assert!(out.contains("amir@sawmills.ai"), "email missing: {out}");
 }
 
+/// An invalid label must fail before the save switches the live auth file,
+/// otherwise the active account changes under an error exit.
+#[test]
+fn save_rejects_an_invalid_label_without_touching_the_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let codex_dir = tmp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("auth.json"),
+        format!(
+            r#"{{"access_token":"{}"}}"#,
+            seat_token("amir@sawmills.ai", "acct-team", "business")
+        ),
+    )
+    .unwrap();
+
+    let output = run(
+        tmp.path(),
+        &[
+            "save",
+            "--label",
+            "wildly over the forty byte limit for a label",
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        !tmp.path()
+            .join(".codexctl/profiles/amir@sawmills.ai")
+            .exists()
+    );
+    assert!(!tmp.path().join(".codexctl/active").exists());
+}
+
+/// Telling an operator who already chose an alias to "pass an explicit alias"
+/// describes what they just did.
+#[test]
+fn save_refusal_names_a_usable_remedy_for_an_explicit_alias() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_profile(
+        tmp.path(),
+        "work",
+        &seat_token("amir@sawmills.ai", "acct-personal", "pro"),
+        r#"{"alias":"work","email":"amir@sawmills.ai","plan":"pro","account_id":"acct-personal","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    let codex_dir = tmp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("auth.json"),
+        format!(
+            r#"{{"access_token":"{}"}}"#,
+            seat_token("amir@sawmills.ai", "acct-team", "business")
+        ),
+    )
+    .unwrap();
+
+    let output = run(tmp.path(), &["save", "work"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("codexctl remove work"),
+        "no usable remedy: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Pass an explicit alias"),
+        "advice repeats what was already done: {stderr}"
+    );
+}
+
 #[test]
 fn save_and_login_accept_a_label() {
     for command in ["save", "login"] {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -78,13 +78,19 @@ fn label_sets_and_clears_a_profile_label() {
         r#"{"alias":"amir-team","email":"amir@sawmills.ai","plan":"business","saved_at":"2026-01-01T00:00:00Z"}"#,
     );
 
+    // Label text shares no substring with the alias, so matching it proves the
+    // label was rendered rather than the Account column.
     assert!(
-        run(tmp.path(), &["label", "amir-team", "team"])
+        run(tmp.path(), &["label", "amir-team", "sawmills seat"])
             .status
             .success()
     );
     let listed = stdout_of(&run(tmp.path(), &["list"]));
-    assert!(listed.contains("team"), "label missing from list: {listed}");
+    assert!(listed.contains("Label"), "label column missing: {listed}");
+    assert!(
+        listed.contains("sawmills seat"),
+        "label missing from list: {listed}"
+    );
 
     // Omitting the text clears the label.
     assert!(run(tmp.path(), &["label", "amir-team"]).status.success());

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -444,3 +444,77 @@ fn stateful_command_initializes_private_store() {
         }
     }
 }
+
+/// A profile the store cannot identify needs an answer, and an unattended run
+/// has nobody to give one. That must fail: exiting 0 having saved nothing would
+/// tell a script the account was captured when it was not.
+#[test]
+fn save_without_a_terminal_fails_rather_than_reporting_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    // A profile whose token declares a login but no workspace — what every
+    // profile written before workspaces were recorded looks like.
+    let legacy = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWF0QSJ9.sig";
+    let dir = home.join(".codexctl").join("profiles").join("legacy");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{legacy}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"legacy","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // The live file: the same login, now carrying a workspace.
+    let claims =
+        r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#;
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    let incoming = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+    let codex = home.join(".codex");
+    std::fs::create_dir_all(&codex).unwrap();
+    std::fs::write(
+        codex.join("auth.json"),
+        format!(r#"{{"access_token":"{incoming}"}}"#),
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(["save", "legacy"])
+        .write_stdin("")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "an unanswerable save reported success: {output:?}"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("--allow-adopt"), "{stderr}");
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains(legacy),
+        "the profile was replaced without approval"
+    );
+
+    // The same command with the answer supplied ahead of time does save.
+    Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(["save", "legacy", "--allow-adopt"])
+        .write_stdin("")
+        .assert()
+        .success();
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains(&incoming),
+        "the approved save did not land"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -518,3 +518,27 @@ fn save_without_a_terminal_fails_rather_than_reporting_success() {
         "the approved save did not land"
     );
 }
+
+/// `--allow-adopt` approves replacing a profile. Without an alias, `save`
+/// derives one from the token's email claim, so the flag would consent to
+/// whatever that resolves to — a target the operator never named. One login can
+/// hold seats in several workspaces behind one address, so that is the same
+/// hazard the prompt exists to prevent, re-entered through the flag.
+#[test]
+fn save_requires_an_explicit_alias_to_pre_approve_adoption() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .args(["save", "--allow-adopt"])
+        .write_stdin("")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("name the one you are approving"),
+        "{stderr}"
+    );
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -275,6 +275,56 @@ fn alias_for_auth_json_still_matches_a_claimless_profile_with_no_rival() {
     );
 }
 
+/// Displaying the active profile picks the live auth file only when it belongs
+/// to that profile. Two workspace seats of one login share a subject, so the
+/// subject alone is not ownership — otherwise the live seat's usage renders
+/// under the other seat's row.
+#[test]
+fn active_profile_ignores_live_auth_from_a_different_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = synthetic_token(
+        r#"{"sub":"seatA","jti":"stored","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    write_profile(&paths, "team@test", &stored);
+    // Live file: same login, other workspace.
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"live","https://api.openai.com/auth":{"chatgpt_account_id":"acct-personal"}}"#,
+    );
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{live}"}}"#),
+    )
+    .unwrap();
+
+    let profile = profile::get_profile_from(&paths, "team@test").unwrap();
+    let chosen = profile::auth_json_path_for_profile_from(&paths, &profile, Some("team@test"));
+
+    assert_eq!(chosen, profile.auth_json_path());
+}
+
+/// The same login and the same workspace is genuine ownership, so the live file
+/// still wins — that is what keeps the active row showing current usage.
+#[test]
+fn active_profile_uses_live_auth_from_the_same_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    let seat = |jti: &str| {
+        synthetic_token(&format!(
+            r#"{{"sub":"seatA","jti":"{jti}","https://api.openai.com/auth":{{"chatgpt_account_id":"acct-team"}}}}"#
+        ))
+    };
+    write_profile(&paths, "team@test", &seat("stored"));
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{}"}}"#, seat("live")),
+    )
+    .unwrap();
+
+    let profile = profile::get_profile_from(&paths, "team@test").unwrap();
+    let chosen = profile::auth_json_path_for_profile_from(&paths, &profile, Some("team@test"));
+
+    assert_eq!(chosen, paths.codex_auth_json());
+}
+
 /// A real Codex auth.json declares `tokens.account_id` directly. The saved
 /// workspace must come from the same resolution the rest of the code uses, or
 /// the save guard silently degrades to the plain overwrite prompt.

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -226,6 +226,55 @@ fn alias_for_auth_json_does_not_let_a_claimless_profile_absorb_a_new_workspace()
     );
 }
 
+/// The simplest shape of the same hazard: one saved profile, and a live token
+/// for a second workspace on that login which was never saved. A candidate that
+/// positively declares a *different* workspace is not the owner, so being the
+/// only candidate must not make it one.
+#[test]
+fn alias_for_auth_json_refuses_a_lone_profile_declaring_another_workspace() {
+    let (tmp, paths) = setup_test_env();
+    let stored = synthetic_token(
+        r#"{"sub":"seatA","jti":"stored","https://api.openai.com/auth":{"chatgpt_account_id":"acct-1"}}"#,
+    );
+    write_profile(&paths, "work@test", &stored);
+
+    // A second workspace on the same login, never saved as a profile.
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"live","https://api.openai.com/auth":{"chatgpt_account_id":"acct-2"}}"#,
+    );
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
+/// A profile saved before workspace claims existed still captures its own
+/// rotated tokens: with nothing declaring a conflicting workspace, a lone
+/// claimless candidate remains the owner.
+#[test]
+fn alias_for_auth_json_still_matches_a_claimless_profile_with_no_rival() {
+    let (tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy@test",
+        &synthetic_token(r#"{"sub":"seatA"}"#),
+    );
+
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"live","https://api.openai.com/auth":{"chatgpt_account_id":"acct-1"}}"#,
+    );
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        Some("legacy@test".to_string())
+    );
+}
+
 /// A real Codex auth.json declares `tokens.account_id` directly. The saved
 /// workspace must come from the same resolution the rest of the code uses, or
 /// the save guard silently degrades to the plain overwrite prompt.

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -71,8 +71,8 @@ fn switch_copies_auth_json() {
     let meta = codexctl::profile::Meta {
         alias: "acct@test.com".to_string(),
         email: Some("acct@test.com".to_string()),
-        plan: None,
         saved_at: "2026-01-01T00:00:00Z".to_string(),
+        ..codexctl::profile::Meta::default()
     };
     std::fs::write(
         profile_dir.join("meta.json"),
@@ -171,6 +171,55 @@ fn alias_for_auth_json_rejects_ambiguous_subject_fallback() {
     );
 }
 
+/// The case adding a team seat on an existing email creates: one login, two
+/// workspaces. The subject alone is ambiguous, so the workspace has to settle
+/// it — otherwise a rotated token is never captured back and the profile later
+/// reports `expired` for no visible reason.
+#[test]
+fn alias_for_auth_json_separates_one_login_across_two_workspaces() {
+    let (tmp, paths) = setup_test_env();
+    let seat = |account: &str, jti: &str| {
+        synthetic_token(&format!(
+            r#"{{"sub":"seatA","jti":"{jti}","https://api.openai.com/auth":{{"chatgpt_account_id":"{account}"}}}}"#
+        ))
+    };
+    write_profile(&paths, "personal@test", &seat("acct-personal", "stored"));
+    write_profile(&paths, "team@test", &seat("acct-team", "stored"));
+
+    // Same seat and workspace as the team profile, but a rotated token value,
+    // so the exact-token pass cannot resolve it.
+    let live = seat("acct-team", "rotated");
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        Some("team@test".to_string())
+    );
+}
+
+/// Two profiles holding the same seat *and* the same workspace stay ambiguous.
+/// Guessing between them could overwrite the wrong profile's tokens.
+#[test]
+fn alias_for_auth_json_rejects_two_profiles_on_one_workspace() {
+    let (tmp, paths) = setup_test_env();
+    let seat = |jti: &str| {
+        synthetic_token(&format!(
+            r#"{{"sub":"seatA","jti":"{jti}","https://api.openai.com/auth":{{"chatgpt_account_id":"acct-one"}}}}"#
+        ))
+    };
+    write_profile(&paths, "copy-a@test", &seat("a"));
+    write_profile(&paths, "copy-b@test", &seat("b"));
+    let auth_json = tmp.path().join("auth.json");
+    let live = seat("live");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();
@@ -178,8 +227,16 @@ fn active_starts_as_none() {
     assert!(active.is_none());
 }
 
-// Fake JWT header `{"alg":"none"}`; profile capture only reads the `sub` claim.
+// Fake JWT header `{"alg":"none"}`; profile capture only reads the claims payload.
 const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+
+/// Build an unsigned JWT carrying `claims`. Every claim here is synthetic; no
+/// real token value enters a fixture.
+fn synthetic_token(claims: &str) -> String {
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    format!("{JWT_HDR}.{payload}.sig")
+}
 
 fn write_profile(paths: &Paths, alias: &str, access_token: &str) {
     let dir = paths.profiles_dir().join(alias);
@@ -191,15 +248,100 @@ fn write_profile(paths: &Paths, alias: &str, access_token: &str) {
     .unwrap();
     let meta = profile::Meta {
         alias: alias.to_string(),
-        email: None,
-        plan: None,
         saved_at: "2026-01-01T00:00:00Z".to_string(),
+        ..profile::Meta::default()
     };
     std::fs::write(
         dir.join("meta.json"),
         serde_json::to_string_pretty(&meta).unwrap(),
     )
     .unwrap();
+}
+
+/// A `meta.json` written before labels existed must keep loading unchanged.
+/// No migration runs, so this is the format most stores are still in.
+#[test]
+fn meta_json_without_label_fields_still_parses() {
+    let (_tmp, paths) = setup_test_env();
+    let dir = paths.profiles_dir().join("legacy@test");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("auth.json"), r#"{"access_token":"tok"}"#).unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"legacy@test","email":"legacy@test","plan":"pro","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let profiles = profile::list_profiles_from(&paths).unwrap();
+
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].meta.plan.as_deref(), Some("pro"));
+    assert!(profiles[0].meta.label.is_none());
+    assert!(profiles[0].meta.account_id.is_none());
+    assert!(profiles[0].meta.user_id.is_none());
+}
+
+#[test]
+fn save_profile_records_identity_from_token_claims() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(
+        r#"{
+            "https://api.openai.com/profile": {"email": "claim@example.com"},
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct-team",
+                "chatgpt_user_id": "user-1",
+                "chatgpt_plan_type": "business"
+            }
+        }"#,
+    );
+    let auth_src = paths.codex_auth_json();
+    std::fs::write(&auth_src, format!(r#"{{"access_token":"{token}"}}"#)).unwrap();
+
+    profile::save_profile_to(&paths, "team", None, &auth_src).unwrap();
+
+    let profile = profile::get_profile_from(&paths, "team").unwrap();
+    assert_eq!(profile.meta.account_id.as_deref(), Some("acct-team"));
+    assert_eq!(profile.meta.user_id.as_deref(), Some("user-1"));
+    assert_eq!(profile.meta.plan.as_deref(), Some("business"));
+    // The claim is authoritative for the address, so no alias guess is needed.
+    assert_eq!(profile.meta.email.as_deref(), Some("claim@example.com"));
+}
+
+#[test]
+fn set_label_trims_clears_and_rejects_invalid_text() {
+    let (_tmp, paths) = setup_test_env();
+    let auth_src = paths.codex_auth_json();
+    profile::save_profile_to(&paths, "team", None, &auth_src).unwrap();
+    let label_of = |paths: &Paths| profile::get_profile_from(paths, "team").unwrap().meta.label;
+
+    profile::set_label_from(&paths, "team", Some("  team  ")).unwrap();
+    assert_eq!(label_of(&paths).as_deref(), Some("team"));
+
+    profile::set_label_from(&paths, "team", Some("   ")).unwrap();
+    assert_eq!(label_of(&paths), None);
+
+    assert!(profile::set_label_from(&paths, "team", Some("two\nlines")).is_err());
+}
+
+#[test]
+fn set_label_fails_for_an_unknown_alias() {
+    let (_tmp, paths) = setup_test_env();
+
+    assert!(profile::set_label_from(&paths, "missing", Some("team")).is_err());
+}
+
+/// Re-saving an account must not silently erase the name the operator gave it.
+#[test]
+fn save_profile_preserves_an_existing_label() {
+    let (_tmp, paths) = setup_test_env();
+    let auth_src = paths.codex_auth_json();
+    profile::save_profile_to(&paths, "team", None, &auth_src).unwrap();
+    profile::set_label_from(&paths, "team", Some("team")).unwrap();
+
+    profile::save_profile_to(&paths, "team", None, &auth_src).unwrap();
+
+    let profile = profile::get_profile_from(&paths, "team").unwrap();
+    assert_eq!(profile.meta.label.as_deref(), Some("team"));
 }
 
 #[test]

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -198,6 +198,61 @@ fn alias_for_auth_json_separates_one_login_across_two_workspaces() {
     );
 }
 
+/// Excluding a candidate by workspace must not promote a *claimless* sibling to
+/// a unique win. Otherwise a seat whose workspace was never saved would capture
+/// its tokens into an unrelated profile and overwrite that profile's
+/// credentials — the ambiguity guard exists to prevent exactly that guess.
+#[test]
+fn alias_for_auth_json_does_not_let_a_claimless_profile_absorb_a_new_workspace() {
+    let (tmp, paths) = setup_test_env();
+    let with_workspace = synthetic_token(
+        r#"{"sub":"seatA","jti":"x","https://api.openai.com/auth":{"chatgpt_account_id":"acct-1"}}"#,
+    );
+    // Same seat, but its stored token declares no workspace at all.
+    let claimless = synthetic_token(r#"{"sub":"seatA","jti":"y"}"#);
+    write_profile(&paths, "has-workspace@test", &with_workspace);
+    write_profile(&paths, "claimless@test", &claimless);
+
+    // A third workspace on the same seat, matching neither stored profile.
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"live","https://api.openai.com/auth":{"chatgpt_account_id":"acct-2"}}"#,
+    );
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
+/// A real Codex auth.json declares `tokens.account_id` directly. The saved
+/// workspace must come from the same resolution the rest of the code uses, or
+/// the save guard silently degrades to the plain overwrite prompt.
+#[test]
+fn save_profile_records_the_account_id_declared_by_the_auth_file() {
+    let (_tmp, paths) = setup_test_env();
+    // Token payload carries a subject but no workspace claim.
+    let token = synthetic_token(r#"{"sub":"seatA"}"#);
+    let auth_src = paths.codex_auth_json();
+    std::fs::write(
+        &auth_src,
+        format!(r#"{{"tokens":{{"access_token":"{token}","account_id":"acct-from-file"}}}}"#),
+    )
+    .unwrap();
+
+    profile::save_profile_to(&paths, "team", None, &auth_src).unwrap();
+
+    assert_eq!(
+        profile::get_profile_from(&paths, "team")
+            .unwrap()
+            .meta
+            .account_id
+            .as_deref(),
+        Some("acct-from-file")
+    );
+}
+
 /// Two profiles holding the same seat *and* the same workspace stay ambiguous.
 /// Guessing between them could overwrite the wrong profile's tokens.
 #[test]

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -251,11 +251,15 @@ fn alias_for_auth_json_refuses_a_lone_profile_declaring_another_workspace() {
     );
 }
 
-/// A profile saved before workspace claims existed still captures its own
-/// rotated tokens: with nothing declaring a conflicting workspace, a lone
-/// claimless candidate remains the owner.
+/// A profile that never recorded a workspace cannot confirm that an arriving
+/// one is the same account — one login holds seats in several workspaces, and
+/// a native login elsewhere can put another seat's credential in the live file.
+/// So a claimed rotation is left unattributed rather than written over it.
+///
+/// The cost is that such a profile goes stale until its next `save` or `login`.
+/// That is recoverable; overwriting its credentials is not.
 #[test]
-fn alias_for_auth_json_still_matches_a_claimless_profile_with_no_rival() {
+fn alias_for_auth_json_leaves_a_claimed_rotation_unattributed_to_a_claimless_profile() {
     let (tmp, paths) = setup_test_env();
     write_profile(
         &paths,
@@ -271,7 +275,7 @@ fn alias_for_auth_json_still_matches_a_claimless_profile_with_no_rival() {
 
     assert_eq!(
         profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
-        Some("legacy@test".to_string())
+        None
     );
 }
 
@@ -668,11 +672,11 @@ fn active_profile_ignores_a_claimless_live_token_against_a_claimed_profile() {
     );
 }
 
-/// The reverse is deliberately still allowed: a profile saved before workspaces
-/// were recorded owns the rotations of its own login, and a claimed live token
-/// contradicts nothing about it.
+/// The same rule governs which auth file the active row reads: a claimed live
+/// token is not shown as a claimless profile's own, because it may be another
+/// seat of that login. The stored copy is used instead.
 #[test]
-fn active_profile_still_uses_live_auth_for_a_claimless_stored_profile() {
+fn active_profile_ignores_a_claimed_live_token_for_a_claimless_profile() {
     let (_tmp, paths) = setup_test_env();
     write_profile(
         &paths,
@@ -691,7 +695,7 @@ fn active_profile_still_uses_live_auth_for_a_claimless_stored_profile() {
     let profile = profile::get_profile_from(&paths, "legacy@test").unwrap();
     let chosen = profile::auth_json_path_for_profile_from(&paths, &profile, Some("legacy@test"));
 
-    assert_eq!(chosen, paths.codex_auth_json());
+    assert_eq!(chosen, profile.auth_json_path());
 }
 
 /// The store-wide resolver is the other route credentials reach a profile, so

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1024,6 +1024,60 @@ fn subject_fallback_refuses_a_claimless_token_when_a_sibling_declares_a_workspac
     );
 }
 
+/// The pinned-alias hint settles ties between equals. It does not settle a
+/// claimless file against a login that also has a declared profile: that file
+/// may be the declared sibling's rotation, so the hint must not claim it.
+#[test]
+fn hint_does_not_claim_a_claimless_token_when_a_sibling_declares_a_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy@test",
+        &synthetic_token(r#"{"sub":"seatA","jti":"legacy"}"#),
+    );
+    write_profile(
+        &paths,
+        "team@test",
+        &synthetic_token(
+            r#"{"sub":"seatA","jti":"team","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+        ),
+    );
+
+    let rotated = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{rotated}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "legacy@test").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("legacy@test").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "an undecided token was captured into the hinted profile"
+    );
+}
+
+/// Automatic seat reuse replaces a profile, so a missing claim on either side
+/// is not a match. Otherwise a claimless token would look like the same seat as
+/// any legacy profile on that login.
+#[test]
+fn existing_seat_requires_both_identity_halves() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy@test",
+        &synthetic_token(r#"{"sub":"seatA","jti":"legacy"}"#),
+    );
+
+    // The incoming token names a login but no workspace.
+    let seat = profile::existing_seat(&paths, None, Some("seatA")).unwrap();
+
+    assert!(
+        matches!(seat, profile::ExistingSeat::None),
+        "a partial identity was accepted as an exact saved seat"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -787,22 +787,22 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     // So the same login re-saving the account actually stored can repair the
     // profile. (`seatA` is the stored token's subject, which is the login claim
     // a real incoming token always carries.)
-    assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatA")),
-        None
+    assert!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatA"))
+            .is_none()
     );
-    // ...while the stale metadata's workspace is still refused.
-    assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("sub:seatA"))
-            .as_deref(),
-        Some("acct-new")
-    );
+    // ...while the stale metadata's workspace is still refused. Both sides make
+    // a claim and the claims disagree, so no answer could reconcile them: this
+    // is a refusal, not a question for the operator.
+    assert!(matches!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("sub:seatA")),
+        Some(profile::AccountConflict::Different(stored)) if stored == "acct-new"
+    ));
     // A different login in the workspace actually stored is refused too.
-    assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatB"))
-            .as_deref(),
-        Some("acct-new")
-    );
+    assert!(matches!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatB")),
+        Some(profile::AccountConflict::Different(stored)) if stored == "acct-new"
+    ));
 }
 
 /// The pinned-alias capture takes an exact-token shortcut before the ownership

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1291,6 +1291,85 @@ fn a_sole_exact_token_owner_receives_a_claimless_rotation() {
     );
 }
 
+/// A contradiction anywhere in the candidate set makes ownership undecidable
+/// for all of them: the token demonstrably spans workspaces. Naming one holder
+/// is then an override, not a tie-break.
+#[test]
+fn hint_does_not_revive_a_candidate_after_a_contradiction() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    for (alias, account) in [("legacy", None), ("other", Some("acct-b"))] {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        let auth = match account {
+            Some(account) => format!(r#"{{"access_token":"{shared}","account_id":"{account}"}}"#),
+            None => format!(r#"{{"access_token":"{shared}"}}"#),
+        };
+        std::fs::write(dir.join("auth.json"), auth).unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            format!(
+                r#"{{"alias":"{alias}","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    // A third workspace, same token, rotated refresh.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{shared}","refresh_token":"rotated","account_id":"acct-c"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "legacy").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("legacy").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "the hint revived a candidate after ownership was undecidable"
+    );
+}
+
+/// A save writes `auth.json` before `meta.json`, so an interrupted one still
+/// holds the token. Omitting it can leave a claimless sibling looking like the
+/// sole owner of another workspace's credential.
+#[test]
+fn exact_token_candidates_include_a_profile_left_without_metadata() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    // Complete, claimless.
+    write_profile(&paths, "legacy", &shared);
+    // Half-written, and it declares the arriving workspace.
+    let dir = paths.profiles_dir().join("half-written");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(
+            r#"{{"access_token":"{shared}","refresh_token":"rotated","account_id":"acct-team"}}"#
+        ),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "legacy").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("legacy").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "an interrupted profile was ignored and its workspace landed on a sibling"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -719,6 +719,79 @@ fn alias_for_auth_json_refuses_a_claimless_token_against_a_lone_claimed_profile(
     );
 }
 
+/// `auth.json` may carry an explicit `account_id`, which `read_auth_json`
+/// prefers over the JWT claim. Two files can therefore share one access token
+/// and still name different workspaces, so token equality alone is not identity.
+#[test]
+fn alias_for_auth_json_refuses_one_token_naming_two_workspaces() {
+    let (tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    let dir = paths.profiles_dir().join("team@test");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team@test","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same token, explicitly a different workspace.
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(
+        &auth_json,
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-personal"}}"#),
+    )
+    .unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
+/// A save writes `auth.json` before `meta.json`. If it stops in between, the
+/// stored credential is the newer fact — trusting metadata there would reject
+/// the account actually stored and leave the profile unrepairable.
+#[test]
+fn workspace_comes_from_the_stored_token_when_metadata_lags() {
+    let (_tmp, paths) = setup_test_env();
+    let dir = paths.profiles_dir().join("work@test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let stored = synthetic_token(
+        r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-new"}}"#,
+    );
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{stored}"}}"#),
+    )
+    .unwrap();
+    // Metadata still describes the workspace held before the interrupted save.
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"work@test","email":null,"plan":null,"account_id":"acct-old","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        profile::workspace_of_profile(&paths, "work@test").as_deref(),
+        Some("acct-new")
+    );
+    // So a login for the account actually stored can repair the profile...
+    assert_eq!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new")),
+        None
+    );
+    // ...while the stale metadata's workspace is still refused.
+    assert_eq!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old")).as_deref(),
+        Some("acct-new")
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1108,10 +1108,15 @@ fn attribution_honours_a_workspace_recorded_only_in_metadata() {
 
     profile::capture_exec_auth_from(&paths, &exec_auth, "team@test").unwrap();
 
+    // Assert on the token itself: the workspace name lives inside a base64
+    // payload, so searching the file for it would match nothing either way.
+    let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
     assert!(
-        !std::fs::read_to_string(dir.join("auth.json"))
-            .unwrap()
-            .contains("other"),
+        kept.contains(&stored),
+        "the profile's own credential was replaced"
+    );
+    assert!(
+        !kept.contains(&foreign),
         "a foreign workspace was captured over a profile identified by metadata"
     );
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1,6 +1,15 @@
 use codexctl::config::Paths;
 use codexctl::profile;
 
+/// A login known only by its JWT subject, as every pre-`chatgpt_user_id` token
+/// is.
+fn sub(subject: &str) -> codexctl::api::Logins {
+    codexctl::api::Logins {
+        uid: None,
+        sub: Some(subject.to_string()),
+    }
+}
+
 fn setup_test_env() -> (tempfile::TempDir, Paths) {
     let tmp = tempfile::tempdir().unwrap();
     let paths = Paths::from_home(tmp.path().to_path_buf());
@@ -788,14 +797,14 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     // profile. (`seatA` is the stored token's subject, which is the login claim
     // a real incoming token always carries.)
     assert!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatA"))
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), &sub("seatA"))
             .is_none()
     );
     // ...while the stale metadata's workspace is still refused. Both sides make
     // a claim and the claims disagree, so no answer could reconcile them: this
     // is a refusal, not a question for the operator.
     assert!(matches!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("sub:seatA")),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), &sub("seatA")),
         Some(profile::AccountConflict::Different(stored)) if stored == "acct-new"
     ));
     // A different login in the workspace actually stored is refused too — and
@@ -803,7 +812,7 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     // Naming the workspace here would report "stored acct-new, incoming
     // acct-new" as the reason the two differ.
     assert!(matches!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatB")),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), &sub("seatB")),
         Some(profile::AccountConflict::Different(stored)) if stored == "sub:seatA"
     ));
 }
@@ -992,7 +1001,7 @@ fn existing_seat_sees_a_profile_left_without_metadata() {
     .unwrap();
     // No meta.json: the save stopped between the two writes.
 
-    let seat = profile::existing_seat(&paths, Some("acct-team"), Some("sub:seatA")).unwrap();
+    let seat = profile::existing_seat(&paths, Some("acct-team"), &sub("seatA")).unwrap();
 
     assert!(
         matches!(seat, profile::ExistingSeat::One(alias) if alias == "half-written"),
@@ -1077,7 +1086,7 @@ fn existing_seat_requires_both_identity_halves() {
     );
 
     // The incoming token names a login but no workspace.
-    let seat = profile::existing_seat(&paths, None, Some("sub:seatA")).unwrap();
+    let seat = profile::existing_seat(&paths, None, &sub("seatA")).unwrap();
 
     assert!(
         matches!(seat, profile::ExistingSeat::None),
@@ -2214,4 +2223,64 @@ fn a_claim_is_described_as_what_it_is() {
     let workspace = profile::describe_claim("acct-team");
     assert!(workspace.starts_with("workspace "), "{workspace}");
     assert!(!workspace.contains("login"), "{workspace}");
+}
+
+/// The ordinary legacy-to-current token transition: one seat keeps its subject
+/// and gains a `chatgpt_user_id`. Identifying a token by a single preferred
+/// claim makes the before and after look like two different people, so the
+/// profile stops absorbing its own rotations and its saved token ages out.
+#[test]
+fn capture_absorbs_a_rotation_that_adds_a_user_id_claim() {
+    let (_tmp, paths) = setup_test_env();
+    // Saved before `chatgpt_user_id` existed: a subject and a workspace.
+    let stored = synthetic_token(
+        r#"{"sub":"seatA","jti":"stored","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    write_profile(&paths, "mine", &stored);
+
+    // The same seat, refreshed: same subject and workspace, now also a user id.
+    let rotated = synthetic_token(
+        r#"{"sub":"seatA","jti":"rotated","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#,
+    );
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{rotated}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "mine").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("mine").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "the profile refused its own refreshed token, so its saved copy will expire"
+    );
+}
+
+/// The guard the rule above must not weaken: two claims in different namespaces
+/// are unrelated facts, so a `uid` must never match a `sub` that happens to
+/// carry the same string.
+#[test]
+fn a_user_id_never_matches_a_subject_by_coincidence() {
+    let shared = "collision";
+    let uid_only = codexctl::api::Logins {
+        uid: Some(shared.to_string()),
+        sub: None,
+    };
+    let sub_only = codexctl::api::Logins {
+        uid: None,
+        sub: Some(shared.to_string()),
+    };
+    assert!(!uid_only.same(&sub_only), "a uid matched a sub");
+    assert!(
+        !uid_only.differs(&sub_only),
+        "unrelated claims proved a difference"
+    );
+    assert!(!uid_only.comparable(&sub_only));
+
+    // Within one namespace both verdicts are available as usual.
+    let other_uid = codexctl::api::Logins {
+        uid: Some("someone-else".to_string()),
+        sub: None,
+    };
+    assert!(uid_only.differs(&other_uid));
+    assert!(uid_only.same(&uid_only.clone()));
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1648,6 +1648,72 @@ fn capture_replaces_stale_metadata_with_the_proven_workspace() {
     );
 }
 
+/// An interrupted save leaves credentials with no metadata. That profile's
+/// workspace lives only in its stored token, so a claimless capture must write
+/// the evidence out before replacing the file that carries it.
+#[test]
+fn capture_preserves_a_workspace_for_a_profile_with_no_metadata() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(
+        r#"{"sub":"seatA","jti":"stable","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    let dir = paths.profiles_dir().join("half-written");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}","refresh_token":"old"}}"#),
+    )
+    .unwrap();
+    // No meta.json at all.
+
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{token}","refresh_token":"new"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "half-written").unwrap();
+
+    assert_eq!(
+        profile::workspace_of_profile(&paths, "half-written").as_deref(),
+        Some("acct-team"),
+        "the workspace was lost with the file that carried it"
+    );
+}
+
+/// A profile whose credentials are unreadable can still be identified by its
+/// metadata. Dropping it from the vote would let a readable sibling look like
+/// the sole owner of a credential this one may hold.
+#[test]
+fn resolution_stops_when_an_unreadable_profile_still_identifies_the_seat() {
+    let (tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy",
+        &synthetic_token(r#"{"sub":"seatA","jti":"legacy"}"#),
+    );
+    // Damaged credentials, but metadata names this login.
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("auth.json"), "{ truncated").unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"account_id":"acct-team","user_id":"seatA","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let live = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None,
+        "a damaged but identified profile was dropped from the decision"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1202,6 +1202,95 @@ fn saving_a_sibling_workspace_captures_the_outgoing_rotation_first() {
     );
 }
 
+/// The hint must not outrank evidence: when another profile holds the same
+/// access token *and* declares the arriving workspace, it is the stronger
+/// owner even though the caller named a different alias.
+#[test]
+fn hint_does_not_outrank_a_stronger_exact_token_owner() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    for (alias, account) in [("legacy", None), ("team", Some("acct-team"))] {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        let auth = match account {
+            Some(account) => format!(r#"{{"access_token":"{shared}","account_id":"{account}"}}"#),
+            None => format!(r#"{{"access_token":"{shared}"}}"#),
+        };
+        std::fs::write(dir.join("auth.json"), auth).unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            format!(
+                r#"{{"alias":"{alias}","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    // Same token, declaring the team workspace, with a rotated refresh token.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(
+            r#"{{"access_token":"{shared}","refresh_token":"rotated","account_id":"acct-team"}}"#
+        ),
+    )
+    .unwrap();
+
+    // The caller names the legacy profile; the declared one is stronger.
+    profile::capture_exec_auth_from(&paths, &exec_auth, "legacy").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("legacy").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "the hint took a credential belonging to a stronger owner"
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "the declared owner did not receive its rotation"
+    );
+}
+
+/// A lone holder of an exact access token owns it even when only the profile
+/// declares a workspace — otherwise a refresh-only rotation is discarded and
+/// the profile keeps stale credentials.
+#[test]
+fn a_sole_exact_token_owner_receives_a_claimless_rotation() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same token, refresh rotated, and this file declares no workspace.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{shared}","refresh_token":"rotated"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "team").unwrap();
+
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "a sole exact-token owner lost its refresh rotation"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1570,6 +1570,84 @@ fn switch_capture_keeps_the_workspace_through_a_claimless_rotation() {
     );
 }
 
+/// The weighing rules out a claimless file against a declared sibling. The
+/// hint must apply the same rule, or it revives a candidate already ruled out.
+#[test]
+fn hint_does_not_revive_a_claimless_candidate_against_a_declared_sibling() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    write_profile(&paths, "legacy", &shared);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same token, rotated refresh, declaring no workspace.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{shared}","refresh_token":"rotated"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "legacy").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("legacy").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "the hint revived a candidate the weighing had ruled out"
+    );
+}
+
+/// Preservation has to correct stale metadata, not merely fill an empty field:
+/// an interrupted save can leave metadata naming the previous workspace, and
+/// after a claimless capture that stale name would answer for the profile.
+#[test]
+fn capture_replaces_stale_metadata_with_the_proven_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(
+        r#"{"sub":"seatA","jti":"stable","https://api.openai.com/auth":{"chatgpt_account_id":"acct-new"}}"#,
+    );
+    let dir = paths.profiles_dir().join("work");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}","refresh_token":"old"}}"#),
+    )
+    .unwrap();
+    // Metadata still names the workspace held before the interrupted save.
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"work","email":null,"plan":null,"account_id":"acct-old","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // A refresh rotation whose file carries no claim at all.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{token}","refresh_token":"new"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "work").unwrap();
+
+    assert_eq!(
+        profile::workspace_of_profile(&paths, "work").as_deref(),
+        Some("acct-new"),
+        "stale metadata answered for the profile after capture"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -780,14 +780,23 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
         profile::workspace_of_profile(&paths, "work@test").as_deref(),
         Some("acct-new")
     );
-    // So a login for the account actually stored can repair the profile...
+    // So the same login re-saving the account actually stored can repair the
+    // profile. (`seatA` is the stored token's subject, which is the login claim
+    // a real incoming token always carries.)
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), None),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("seatA")),
         None
     );
     // ...while the stale metadata's workspace is still refused.
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), None).as_deref(),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("seatA"))
+            .as_deref(),
+        Some("acct-new")
+    );
+    // A different login in the workspace actually stored is refused too.
+    assert_eq!(
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("seatB"))
+            .as_deref(),
         Some("acct-new")
     );
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -891,6 +891,44 @@ fn exact_token_resolution_prefers_the_declared_workspace_over_directory_order() 
     );
 }
 
+/// Codex can add an explicit `account_id` without changing either token. That
+/// is a real credential update: discarding it leaves the profile claimless, and
+/// a claimless profile is what keeps duplicate-email ownership ambiguous.
+#[test]
+fn capture_records_a_workspace_that_appears_without_a_token_change() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(r#"{"sub":"seatA","jti":"stable"}"#);
+    let dir = paths.profiles_dir().join("work");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"work","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same token, now naming its workspace.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{token}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "work").unwrap();
+
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("acct-team"),
+        "the workspace claim was discarded"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1078,6 +1078,44 @@ fn existing_seat_requires_both_identity_halves() {
     );
 }
 
+/// A stored token with no claim does not make a profile anonymous when its
+/// metadata records the account. Ignoring that fallback during attribution lets
+/// another workspace's token be captured over it.
+#[test]
+fn attribution_honours_a_workspace_recorded_only_in_metadata() {
+    let (_tmp, paths) = setup_test_env();
+    // Stored token is claimless; metadata knows the workspace.
+    let dir = paths.profiles_dir().join("team@test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let stored = synthetic_token(r#"{"sub":"seatA","jti":"stored"}"#);
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{stored}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team@test","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same login, a different workspace, rotated.
+    let foreign = synthetic_token(
+        r#"{"sub":"seatA","jti":"other","https://api.openai.com/auth":{"chatgpt_account_id":"acct-other"}}"#,
+    );
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{foreign}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "team@test").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("other"),
+        "a foreign workspace was captured over a profile identified by metadata"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1522,6 +1522,54 @@ fn rotated_token_resolution_sees_a_profile_left_without_metadata() {
     );
 }
 
+/// The live-file capture that `use` performs preserves a proven workspace just
+/// as the pinned one does — both go through the same step, so neither can
+/// erase the evidence the other protects.
+#[test]
+fn switch_capture_keeps_the_workspace_through_a_claimless_rotation() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(r#"{"sub":"seatA","jti":"stable"}"#);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}","refresh_token":"old","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    write_profile(
+        &paths,
+        "next",
+        &synthetic_token(r#"{"sub":"seatB","jti":"next"}"#),
+    );
+    profile::set_active_from(&paths, "team").unwrap();
+
+    // The live file rotated its refresh token and carries no workspace claim.
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{token}","refresh_token":"new"}}"#),
+    )
+    .unwrap();
+
+    profile::switch_to_from(&paths, "next").unwrap();
+
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("new"),
+        "the outgoing rotation was not captured"
+    );
+    assert_eq!(
+        profile::workspace_of_profile(&paths, "team").as_deref(),
+        Some("acct-team"),
+        "the outgoing profile's proven workspace was erased"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1121,6 +1121,46 @@ fn attribution_honours_a_workspace_recorded_only_in_metadata() {
     );
 }
 
+/// The exact-token shortcut runs before the fuller ownership check, so it has
+/// to honour a workspace held only in metadata too. One access token can name
+/// two workspaces through an explicit `account_id`.
+#[test]
+fn exact_token_shortcut_honours_a_metadata_only_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    let dir = paths.profiles_dir().join("team@test");
+    std::fs::create_dir_all(&dir).unwrap();
+    // Claimless stored token; the workspace lives in metadata only.
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team@test","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same access token, explicitly a different workspace, rotated refresh.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(
+            r#"{{"access_token":"{shared}","refresh_token":"foreign","account_id":"acct-other"}}"#
+        ),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "team@test").unwrap();
+
+    let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
+    assert!(
+        !kept.contains("foreign"),
+        "a foreign workspace was captured through the exact-token shortcut"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -694,6 +694,31 @@ fn active_profile_still_uses_live_auth_for_a_claimless_stored_profile() {
     assert_eq!(chosen, paths.codex_auth_json());
 }
 
+/// The store-wide resolver is the other route credentials reach a profile, so
+/// it needs the same rule as ownership matching: a token declaring no workspace
+/// cannot be attributed to the one profile that declares one, even when it is
+/// the only candidate on that login.
+#[test]
+fn alias_for_auth_json_refuses_a_claimless_token_against_a_lone_claimed_profile() {
+    let (tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "team@test",
+        &synthetic_token(
+            r#"{"sub":"seatA","jti":"stored","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+        ),
+    );
+    // Same login, rotated, declaring no workspace.
+    let live = synthetic_token(r#"{"sub":"seatA","jti":"live"}"#);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -2284,3 +2284,56 @@ fn a_user_id_never_matches_a_subject_by_coincidence() {
     assert!(uid_only.differs(&other_uid));
     assert!(uid_only.same(&uid_only.clone()));
 }
+
+/// One access token recorded under two profiles that declare different
+/// workspaces — which an explicit `account_id` makes possible.
+///
+/// The file's own declaration decides, and it decides positively: the profile
+/// agreeing on both the token and the workspace owns it. A sibling declaring
+/// some *other* workspace does not disqualify that agreement, or a stale
+/// duplicate anywhere in the store would stop a healthy profile receiving its
+/// own rotation — the way an unrelated damaged profile once did.
+///
+/// Fail-closed still applies where it is actually undecided: a file naming no
+/// workspace has nothing to agree with, and resolves to no owner rather than
+/// the lenient match.
+#[test]
+fn an_exact_token_in_two_workspaces_is_owned_by_the_one_it_declares() {
+    let case = |declared: Option<&str>| {
+        let (_tmp, paths) = setup_test_env();
+        let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+        for (alias, workspace) in [("a", "acct-one"), ("b", "acct-two")] {
+            let dir = paths.profiles_dir().join(alias);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("auth.json"),
+                format!(r#"{{"access_token":"{shared}"}}"#),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("meta.json"),
+                format!(
+                    r#"{{"alias":"{alias}","email":null,"plan":null,"account_id":"{workspace}","saved_at":"2026-01-01T00:00:00Z"}}"#
+                ),
+            )
+            .unwrap();
+        }
+        let file = paths.home.join("incoming.json");
+        let body = match declared {
+            Some(workspace) => {
+                format!(r#"{{"access_token":"{shared}","account_id":"{workspace}"}}"#)
+            }
+            None => format!(r#"{{"access_token":"{shared}"}}"#),
+        };
+        std::fs::write(&file, body).unwrap();
+        profile::alias_for_auth_json_from(&paths, &file).unwrap()
+    };
+
+    assert_eq!(case(Some("acct-one")).as_deref(), Some("a"));
+    assert_eq!(case(Some("acct-two")).as_deref(), Some("b"));
+    assert_eq!(
+        case(None),
+        None,
+        "a file declaring no workspace picked an owner out of two"
+    );
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1442,6 +1442,86 @@ fn active_profile_defers_to_a_stronger_exact_token_sibling() {
     );
 }
 
+/// A refresh-only rotation whose file omits the workspace still captures — but
+/// the profile's proven workspace has to survive it, or a pre-0.1.22 profile
+/// loses its only ownership evidence and later rotations become unattributable.
+#[test]
+fn capture_keeps_the_workspace_through_a_claimless_refresh_rotation() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(r#"{"sub":"seatA","jti":"stable"}"#);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}","refresh_token":"old","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same access token, rotated refresh, and no workspace claim in the file.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{token}","refresh_token":"new"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "team").unwrap();
+
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("new"),
+        "the refresh rotation was not captured"
+    );
+    assert_eq!(
+        profile::workspace_of_profile(&paths, "team").as_deref(),
+        Some("acct-team"),
+        "the profile's proven workspace was lost with the copy"
+    );
+}
+
+/// The rotated-token pass must see interrupted profiles too: a half-written
+/// sibling declaring a workspace makes a claimless rotation ambiguous rather
+/// than leaving the visible profile as its sole owner.
+#[test]
+fn rotated_token_resolution_sees_a_profile_left_without_metadata() {
+    let (tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy",
+        &synthetic_token(r#"{"sub":"seatA","jti":"legacy"}"#),
+    );
+    // Half-written sibling on the same login, declaring a workspace.
+    let dir = paths.profiles_dir().join("half-written");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(
+            r#"{{"access_token":"{}"}}"#,
+            synthetic_token(
+                r#"{"sub":"seatA","jti":"team","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#
+            )
+        ),
+    )
+    .unwrap();
+
+    // A claimless rotation on that login.
+    let live = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None,
+        "an interrupted sibling was ignored, making an ambiguous token look owned"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1772,6 +1772,40 @@ fn capture_proceeds_despite_an_unrelated_damaged_profile() {
     );
 }
 
+/// Two colleagues can share a `sub` while differing on `chatgpt_user_id`, and
+/// `login` already treats those as different accounts. Capture has to agree,
+/// or a file is one seat to attribution and two accounts to an overwrite.
+#[test]
+fn capture_uses_the_same_login_identity_as_login_does() {
+    let (_tmp, paths) = setup_test_env();
+    let seat = |user: &str, jti: &str| {
+        synthetic_token(&format!(
+            r#"{{"sub":"shared","jti":"{jti}","https://api.openai.com/auth":{{"chatgpt_account_id":"acct-team","chatgpt_user_id":"{user}"}}}}"#
+        ))
+    };
+    write_profile(&paths, "mine", &seat("user-a", "stored"));
+
+    // Same subject and workspace, a different login, rotated.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(
+            r#"{{"access_token":"{}","refresh_token":"rotated"}}"#,
+            seat("user-b", "live")
+        ),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "mine").unwrap();
+
+    assert!(
+        !std::fs::read_to_string(paths.profiles_dir().join("mine").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "a colleague's credential was captured over this profile"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -798,10 +798,13 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
         profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("sub:seatA")),
         Some(profile::AccountConflict::Different(stored)) if stored == "acct-new"
     ));
-    // A different login in the workspace actually stored is refused too.
+    // A different login in the workspace actually stored is refused too — and
+    // the refusal names the login, since that is the claim that disagrees.
+    // Naming the workspace here would report "stored acct-new, incoming
+    // acct-new" as the reason the two differ.
     assert!(matches!(
         profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatB")),
-        Some(profile::AccountConflict::Different(stored)) if stored == "acct-new"
+        Some(profile::AccountConflict::Different(stored)) if stored == "sub:seatA"
     ));
 }
 

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -640,6 +640,60 @@ fn exec_capture_keeps_a_refresh_rotation_on_the_pinned_identical_duplicate() {
     );
 }
 
+/// A token declaring no workspace cannot prove it belongs to a profile that
+/// declares one. Accepting it is how the other seat's rotated token gets
+/// attributed to — and captured over — this profile's credentials.
+#[test]
+fn active_profile_ignores_a_claimless_live_token_against_a_claimed_profile() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = synthetic_token(
+        r#"{"sub":"seatA","jti":"stored","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    write_profile(&paths, "team@test", &stored);
+    // Same login, rotated, and declaring no workspace at all.
+    let live = synthetic_token(r#"{"sub":"seatA","jti":"live"}"#);
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{live}"}}"#),
+    )
+    .unwrap();
+
+    let profile = profile::get_profile_from(&paths, "team@test").unwrap();
+    let chosen = profile::auth_json_path_for_profile_from(&paths, &profile, Some("team@test"));
+
+    assert_eq!(
+        chosen,
+        profile.auth_json_path(),
+        "an unprovable live token was treated as this profile's own"
+    );
+}
+
+/// The reverse is deliberately still allowed: a profile saved before workspaces
+/// were recorded owns the rotations of its own login, and a claimed live token
+/// contradicts nothing about it.
+#[test]
+fn active_profile_still_uses_live_auth_for_a_claimless_stored_profile() {
+    let (_tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy@test",
+        &synthetic_token(r#"{"sub":"seatA"}"#),
+    );
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"live","https://api.openai.com/auth":{"chatgpt_account_id":"acct-1"}}"#,
+    );
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{live}"}}"#),
+    )
+    .unwrap();
+
+    let profile = profile::get_profile_from(&paths, "legacy@test").unwrap();
+    let chosen = profile::auth_json_path_for_profile_from(&paths, &profile, Some("legacy@test"));
+
+    assert_eq!(chosen, paths.codex_auth_json());
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -2337,3 +2337,61 @@ fn an_exact_token_in_two_workspaces_is_owned_by_the_one_it_declares() {
         "a file declaring no workspace picked an owner out of two"
     );
 }
+
+/// The live file identifies a profile holding its token — but only while its own
+/// workspace is not in dispute.
+///
+/// A is claimless and holds token T. B holds the same T and declares another
+/// workspace, so T demonstrably spans workspaces and the live copy's
+/// `account_id` is one claim among several. Copying it onto A would invent a
+/// workspace A never recorded, make A look like the unique seat for it, and let
+/// a labelled login redirect onto A and overwrite it with no consent asked.
+/// `strongest_exact_match` already calls this shape undecidable; seat lookup
+/// must not disagree with it.
+#[test]
+fn a_contested_live_workspace_is_not_inferred_onto_a_claimless_profile() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    let write = |alias: &str, meta: &str| {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{shared}"}}"#),
+        )
+        .unwrap();
+        std::fs::write(dir.join("meta.json"), meta).unwrap();
+    };
+    write(
+        "a",
+        r#"{"alias":"a","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    write(
+        "b",
+        r#"{"alias":"b","email":null,"plan":null,"account_id":"acct-bee","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-see"}}"#),
+    )
+    .unwrap();
+
+    assert!(
+        matches!(
+            profile::existing_seat(&paths, Some("acct-see"), &sub("seatA")).unwrap(),
+            profile::ExistingSeat::None
+        ),
+        "a contested live workspace was inferred onto a claimless profile"
+    );
+
+    // The uncontested case still works: with B gone, nothing disputes the live
+    // file and A is identified as its seat.
+    std::fs::remove_dir_all(paths.profiles_dir().join("b")).unwrap();
+    assert!(
+        matches!(
+            profile::existing_seat(&paths, Some("acct-see"), &sub("seatA")).unwrap(),
+            profile::ExistingSeat::One(ref alias) if alias == "a"
+        ),
+        "an uncontested live workspace stopped identifying its own profile"
+    );
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -842,6 +842,55 @@ fn exec_capture_refuses_a_foreign_workspace_sharing_the_access_token() {
     assert!(kept.contains("acct-pinned"));
 }
 
+/// Two profiles can hold one access token: a legacy one declaring no workspace
+/// and the real owner declaring it. The one that declares it is the stronger
+/// match, and directory order must not hand the credentials to the other.
+#[test]
+fn exact_token_resolution_prefers_the_declared_workspace_over_directory_order() {
+    let (tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    // Sorts first, declares nothing.
+    let legacy = paths.profiles_dir().join("aaa-legacy");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(
+        legacy.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        legacy.join("meta.json"),
+        r#"{"alias":"aaa-legacy","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    // Sorts later, declares the workspace the target names.
+    let owner = paths.profiles_dir().join("zzz-owner");
+    std::fs::create_dir_all(&owner).unwrap();
+    std::fs::write(
+        owner.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        owner.join("meta.json"),
+        r#"{"alias":"zzz-owner","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(
+        &auth_json,
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json)
+            .unwrap()
+            .as_deref(),
+        Some("zzz-owner")
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -993,6 +993,37 @@ fn existing_seat_sees_a_profile_left_without_metadata() {
     );
 }
 
+/// A rotated token need not carry the workspace claim, so a claimless token on
+/// a login that also has a declared profile could belong to either. Handing it
+/// to the claimless one would capture the declared account's rotation into the
+/// wrong profile.
+#[test]
+fn subject_fallback_refuses_a_claimless_token_when_a_sibling_declares_a_workspace() {
+    let (tmp, paths) = setup_test_env();
+    write_profile(
+        &paths,
+        "legacy@test",
+        &synthetic_token(r#"{"sub":"seatA","jti":"legacy"}"#),
+    );
+    write_profile(
+        &paths,
+        "team@test",
+        &synthetic_token(
+            r#"{"sub":"seatA","jti":"team","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+        ),
+    );
+
+    // Rotated, same login, declaring no workspace.
+    let live = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -788,18 +788,18 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     // profile. (`seatA` is the stored token's subject, which is the login claim
     // a real incoming token always carries.)
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("seatA")),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatA")),
         None
     );
     // ...while the stale metadata's workspace is still refused.
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("seatA"))
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), Some("sub:seatA"))
             .as_deref(),
         Some("acct-new")
     );
     // A different login in the workspace actually stored is refused too.
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("seatB"))
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), Some("sub:seatB"))
             .as_deref(),
         Some("acct-new")
     );
@@ -989,7 +989,7 @@ fn existing_seat_sees_a_profile_left_without_metadata() {
     .unwrap();
     // No meta.json: the save stopped between the two writes.
 
-    let seat = profile::existing_seat(&paths, Some("acct-team"), Some("seatA")).unwrap();
+    let seat = profile::existing_seat(&paths, Some("acct-team"), Some("sub:seatA")).unwrap();
 
     assert!(
         matches!(seat, profile::ExistingSeat::One(alias) if alias == "half-written"),
@@ -1074,7 +1074,7 @@ fn existing_seat_requires_both_identity_halves() {
     );
 
     // The incoming token names a login but no workspace.
-    let seat = profile::existing_seat(&paths, None, Some("seatA")).unwrap();
+    let seat = profile::existing_seat(&paths, None, Some("sub:seatA")).unwrap();
 
     assert!(
         matches!(seat, profile::ExistingSeat::None),
@@ -1699,11 +1699,14 @@ fn resolution_stops_when_an_unreadable_profile_still_identifies_the_seat() {
     std::fs::write(dir.join("auth.json"), "{ truncated").unwrap();
     std::fs::write(
         dir.join("meta.json"),
-        r#"{"alias":"team","email":null,"plan":null,"account_id":"acct-team","user_id":"seatA","saved_at":"2026-01-01T00:00:00Z"}"#,
+        r#"{"alias":"team","email":null,"plan":null,"account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
     )
     .unwrap();
 
-    let live = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    // The arriving token names the same `chatgpt_user_id` the metadata records.
+    let live = synthetic_token(
+        r#"{"sub":"seatA","jti":"rotated","https://api.openai.com/auth":{"chatgpt_user_id":"user-a"}}"#,
+    );
     let auth_json = tmp.path().join("auth.json");
     std::fs::write(&auth_json, format!(r#"{{"access_token":"{live}"}}"#)).unwrap();
 
@@ -1772,26 +1775,28 @@ fn capture_proceeds_despite_an_unrelated_damaged_profile() {
     );
 }
 
-/// Two colleagues can share a `sub` while differing on `chatgpt_user_id`, and
-/// `login` already treats those as different accounts. Capture has to agree,
-/// or a file is one seat to attribution and two accounts to an overwrite.
+/// `chatgpt_user_id` and `sub` are different namespaces. A profile identified
+/// by one must not match a token carrying the other, or a foreign credential
+/// could be attributed to it by a coincidental string match.
 #[test]
-fn capture_uses_the_same_login_identity_as_login_does() {
+fn login_identity_does_not_match_across_claim_namespaces() {
     let (_tmp, paths) = setup_test_env();
-    let seat = |user: &str, jti: &str| {
-        synthetic_token(&format!(
-            r#"{{"sub":"shared","jti":"{jti}","https://api.openai.com/auth":{{"chatgpt_account_id":"acct-team","chatgpt_user_id":"{user}"}}}}"#
-        ))
-    };
-    write_profile(&paths, "mine", &seat("user-a", "stored"));
+    // Stored: identified by its `chatgpt_user_id`.
+    write_profile(
+        &paths,
+        "mine",
+        &synthetic_token(
+            r#"{"sub":"seat-1","jti":"stored","https://api.openai.com/auth":{"chatgpt_user_id":"shared-value"}}"#,
+        ),
+    );
 
-    // Same subject and workspace, a different login, rotated.
+    // Arriving: no `chatgpt_user_id`, and a subject that happens to read the same.
     let exec_auth = paths.home.join("exec-auth.json");
     std::fs::write(
         &exec_auth,
         format!(
             r#"{{"access_token":"{}","refresh_token":"rotated"}}"#,
-            seat("user-b", "live")
+            synthetic_token(r#"{"sub":"shared-value","jti":"live"}"#)
         ),
     )
     .unwrap();
@@ -1802,7 +1807,7 @@ fn capture_uses_the_same_login_identity_as_login_does() {
         !std::fs::read_to_string(paths.profiles_dir().join("mine").join("auth.json"))
             .unwrap()
             .contains("rotated"),
-        "a colleague's credential was captured over this profile"
+        "a subject matched a user id and carried a foreign credential in"
     );
 }
 

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -782,12 +782,12 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     );
     // So a login for the account actually stored can repair the profile...
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-new")),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-new"), None),
         None
     );
     // ...while the stale metadata's workspace is still refused.
     assert_eq!(
-        profile::conflicting_workspace(&paths, "work@test", Some("acct-old")).as_deref(),
+        profile::conflicting_workspace(&paths, "work@test", Some("acct-old"), None).as_deref(),
         Some("acct-new")
     );
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -2202,3 +2202,16 @@ fn case_fold_alias_collision_cannot_overwrite_credentials() {
     assert!(original.contains("original-token"));
     assert!(!original.contains("new-token"));
 }
+
+/// A conflict may be proven by either half of the identity, so the value in an
+/// operator message is sometimes a workspace and sometimes a login. Announcing
+/// both as "workspace" mislabels the evidence exactly where it is used to
+/// decide.
+#[test]
+fn a_claim_is_described_as_what_it_is() {
+    assert_eq!(profile::describe_claim("uid:user-a"), "login user-a");
+    assert_eq!(profile::describe_claim("sub:seatA"), "login seatA");
+    let workspace = profile::describe_claim("acct-team");
+    assert!(workspace.starts_with("workspace "), "{workspace}");
+    assert!(!workspace.contains("login"), "{workspace}");
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1714,6 +1714,32 @@ fn resolution_stops_when_an_unreadable_profile_still_identifies_the_seat() {
     );
 }
 
+/// Capture leaves no snapshot behind, and the snapshot it works from is the
+/// file it decided on: the source is read once, so ownership and the bytes
+/// written can never come from different accounts.
+#[test]
+fn capture_cleans_up_its_snapshot() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = synthetic_token(r#"{"sub":"seatA","jti":"stored"}"#);
+    write_profile(&paths, "work", &stored);
+    let rotated = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{rotated}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "work").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("work").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "the rotation was not captured"
+    );
+    assert!(
+        !paths.codexctl_dir().join(".capture-snapshot.json").exists(),
+        "the capture snapshot was left in the store"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1161,6 +1161,43 @@ fn exact_token_shortcut_honours_a_metadata_only_workspace() {
     );
 }
 
+/// Adding a second workspace for one login creates a declared sibling. If that
+/// happens before the outgoing credential is captured, the outgoing token —
+/// claimless, rotated, and the only copy — looks ownerless and is lost when the
+/// new profile is installed over the live file.
+#[test]
+fn saving_a_sibling_workspace_captures_the_outgoing_rotation_first() {
+    let (_tmp, paths) = setup_test_env();
+    // Active legacy profile: same login, no workspace claim.
+    let stored = synthetic_token(r#"{"sub":"seatA","jti":"stored"}"#);
+    write_profile(&paths, "personal", &stored);
+    profile::set_active_from(&paths, "personal").unwrap();
+
+    // Its live token rotated, still claimless — this is the only copy.
+    let rotated = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{rotated}"}}"#),
+    )
+    .unwrap();
+
+    // Now save a second workspace for the same login from an isolated home.
+    let incoming = synthetic_token(
+        r#"{"sub":"seatA","jti":"team","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    let login_home = paths.home.join("login-auth.json");
+    std::fs::write(&login_home, format!(r#"{{"access_token":"{incoming}"}}"#)).unwrap();
+
+    profile::save_profile_and_activate_to(&paths, "team", None, &login_home).unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("personal").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "the outgoing rotation was lost when the sibling workspace was added"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1740,6 +1740,38 @@ fn capture_cleans_up_its_snapshot() {
     );
 }
 
+/// A damaged profile belonging to somebody else must not suppress a healthy
+/// profile's capture. Failing closed against every unreadable sibling would
+/// let a valid rotation be discarded and the healthy profile expire.
+#[test]
+fn capture_proceeds_despite_an_unrelated_damaged_profile() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = synthetic_token(r#"{"sub":"seatA","jti":"stored"}"#);
+    write_profile(&paths, "mine", &stored);
+    // Damaged credentials, and its metadata names a different login.
+    let other = paths.profiles_dir().join("someone-else");
+    std::fs::create_dir_all(&other).unwrap();
+    std::fs::write(other.join("auth.json"), "{ truncated").unwrap();
+    std::fs::write(
+        other.join("meta.json"),
+        r#"{"alias":"someone-else","email":null,"plan":null,"user_id":"seatZ","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let rotated = synthetic_token(r#"{"sub":"seatA","jti":"rotated"}"#);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{rotated}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "mine").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("mine").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "an unrelated damaged profile suppressed a valid rotation"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -1370,6 +1370,78 @@ fn exact_token_candidates_include_a_profile_left_without_metadata() {
     );
 }
 
+/// A capture that simply omits the workspace is not an update. Erasing it
+/// would destroy a legacy profile's only ownership evidence and make every
+/// later rotation unattributable.
+#[test]
+fn capture_does_not_erase_a_stored_workspace() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(r#"{"sub":"seatA","jti":"stable"}"#);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Identical credential, but this copy names no workspace.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{token}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "team").unwrap();
+
+    assert!(
+        std::fs::read_to_string(dir.join("auth.json"))
+            .unwrap()
+            .contains("acct-team"),
+        "the stored workspace was erased by a claimless copy"
+    );
+}
+
+/// The active row reads the live file only when it truly belongs to the active
+/// profile. A sibling holding the same token and declaring the live workspace
+/// is the stronger owner, so its usage must not render under this alias.
+#[test]
+fn active_profile_defers_to_a_stronger_exact_token_sibling() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    write_profile(&paths, "legacy", &shared);
+    let dir = paths.profiles_dir().join("team");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"team","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // The live file is that team seat.
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-team"}}"#),
+    )
+    .unwrap();
+
+    let legacy = profile::get_profile_from(&paths, "legacy").unwrap();
+    let chosen = profile::auth_json_path_for_profile_from(&paths, &legacy, Some("legacy"));
+
+    assert_eq!(
+        chosen,
+        legacy.auth_json_path(),
+        "another seat's live usage would render under this alias"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -792,6 +792,47 @@ fn workspace_comes_from_the_stored_token_when_metadata_lags() {
     );
 }
 
+/// The pinned-alias capture takes an exact-token shortcut before the ownership
+/// rule. One access token can name two workspaces through an explicit
+/// `account_id`, so that shortcut has to honour the rule too — otherwise a
+/// pinned run copies a foreign workspace's whole auth file over the profile.
+#[test]
+fn exec_capture_refuses_a_foreign_workspace_sharing_the_access_token() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    let dir = paths.profiles_dir().join("pinned");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-pinned"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("meta.json"),
+        r#"{"alias":"pinned","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    // Same access token, different workspace, and a rotated refresh token.
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(
+            r#"{{"access_token":"{shared}","refresh_token":"foreign","account_id":"acct-other"}}"#
+        ),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "pinned").unwrap();
+
+    let kept = std::fs::read_to_string(dir.join("auth.json")).unwrap();
+    assert!(
+        !kept.contains("foreign"),
+        "a foreign workspace was captured over the pinned profile"
+    );
+    assert!(kept.contains("acct-pinned"));
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -929,6 +929,70 @@ fn capture_records_a_workspace_that_appears_without_a_token_change() {
     );
 }
 
+/// One token held by a claimless profile and by a profile declaring another
+/// workspace is demonstrably ambiguous. The claimless one is not the safe
+/// default there — it is simply the one that declares nothing.
+#[test]
+fn exact_token_resolution_refuses_when_a_sibling_declares_another_workspace() {
+    let (tmp, paths) = setup_test_env();
+    let shared = synthetic_token(r#"{"sub":"seatA","jti":"shared"}"#);
+    for (alias, account) in [("legacy", None), ("other", Some("acct-other"))] {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        let auth = match account {
+            Some(account) => format!(r#"{{"access_token":"{shared}","account_id":"{account}"}}"#),
+            None => format!(r#"{{"access_token":"{shared}"}}"#),
+        };
+        std::fs::write(dir.join("auth.json"), auth).unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            format!(
+                r#"{{"alias":"{alias}","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    // The live file names a third workspace nobody declared.
+    let auth_json = tmp.path().join("auth.json");
+    std::fs::write(
+        &auth_json,
+        format!(r#"{{"access_token":"{shared}","account_id":"acct-target"}}"#),
+    )
+    .unwrap();
+
+    assert_eq!(
+        profile::alias_for_auth_json_from(&paths, &auth_json).unwrap(),
+        None
+    );
+}
+
+/// A save writes `auth.json` before `meta.json`, so an interrupted one leaves a
+/// real seat with no metadata. Reading that as "not saved" is how a second
+/// alias gets created for an account already in the store.
+#[test]
+fn existing_seat_sees_a_profile_left_without_metadata() {
+    let (_tmp, paths) = setup_test_env();
+    let token = synthetic_token(
+        r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team"}}"#,
+    );
+    let dir = paths.profiles_dir().join("half-written");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+    // No meta.json: the save stopped between the two writes.
+
+    let seat = profile::existing_seat(&paths, Some("acct-team"), Some("seatA")).unwrap();
+
+    assert!(
+        matches!(seat, profile::ExistingSeat::One(alias) if alias == "half-written"),
+        "an interrupted save was treated as no seat at all"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();


### PR DESCRIPTION
Two Codex accounts can share one email — a personal account and a team/business workspace seat — and `codexctl` could not tell them apart. This adds an operator-set label plus token-derived account identity, and closes the ways the duplicate-email case destroyed or misattributed stored credentials.

## Description

- **Identity from the token, not the network.** `api::token_identity` reads email, workspace (`chatgpt_account_id`), login (`chatgpt_user_id`), and plan from the access-token claims. No network call, and it still resolves on an expired token — which is when a profile most needs to stay identifiable.
- **Labels.** `codexctl label <alias> [text]`, plus `--label` on `login` and `save`. The alias stays the only key and selector; the label reaches selection only through the `switch` picker. The `Label` column appears in `list` and `status` only once some profile has one, so an unlabeled store looks exactly as it did.
- **The label qualifies the alias instead of overwriting.** `login <email> --label team` lands on `<email>+team` when `<email>` already holds a different account. The requested alias still wins when free or holding the same account, so re-logins are stable.

## The account model

An account is a **(workspace, login) pair**. Neither half identifies one alone: a workspace holds many people, and one login holds seats in many workspaces. A profile's identity is read from its stored token first and its `meta.json` second, so a profile written before this release is still identified.

From that, two rules:

- **Destructive writes require positive agreement.** `login` and `save` replace what is stored, so "cannot confirm" is not "yes". The single exception is a profile with no readable token and no recorded account — nothing there can be identified or used, which is what a repair re-login is for.
- **Capture follows the evidence.** An identical access token is the same credential and decides ownership on its own. Anything rotated needs the claims to agree. Ownership that cannot be decided resolves to *no owner* rather than a guess, and a caller-supplied alias (the active marker, or `CODEXCTL_PINNED_ALIAS`) breaks only the ties token inspection cannot.

## Credential-safety fixes

| what | effect before |
| --- | --- |
| `save` had no different-account guard | a second account landed on the first's profile with `Overwrite? [y/N]` one keystroke away |
| `login` had no guard at all | logging a second workspace into an existing alias **silently replaced** that profile's credentials |
| ownership matched on `sub` alone | ambiguous once one login held two workspaces, so rotated tokens stopped being captured and profiles reported `expired` for no visible reason |
| a workspace was treated as an owner | a colleague in the same workspace could replace another person's profile |
| `save` and `login` checked before locking | a concurrent write could land between the check and the write |
| `save` copied a path it had re-read | a native `codex login` during the prompt meant storing one account's credentials under another's alias |
| capture could erase a workspace | a claimless copy destroyed the only ownership evidence a pre-0.1.22 profile has |

## Upgrade impact

Three refusals can surprise a store saved before this release: a second workspace on a profile that never recorded one, a claimless profile no longer absorbing rotations that declare a workspace, and a re-login blocked on a profile whose token will not parse. All three are recoverable and each error names its remedy; README has an "Upgrading an existing store" section with the symptom and fix for each. Nothing runs at upgrade time, and older `meta.json` files parse unchanged.

## Testing

344 tests; `cargo fmt --check`, `cargo clippy --all-targets`, `trunk check`, and a release build all clean.

Coverage includes the duplicate-email matrix (matching / contradicting / claimless / metadata-only / half-written / unreadable), both `save` and `login` refusals, the overwrite-race guards driven through the locked half of `save`, capture ordering by issued-at with an expiry tie-break, workspace preservation across claimless rotations, and namespace separation between `chatgpt_user_id` and `sub`.

## Review

Reviewed by `gpt-5.6-sol` autoreview and the Sawmills architect across many rounds; both clean on the current head. The architect held one credential-overwrite defect — a damaged profile with a known workspace being replaceable by any colleague in it — through several rounds before it was fixed in 47433a0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
