### PR TITLE
SAW-9631 Account-pinned, non-mutating exec launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@
 - Refuse `codexctl exec` when `CODEX_HOME` is already set. A pinned launch must not replace an inherited Codex home without saying so.
 - Capture a token back to the alias the caller named. Fall back to token inspection only when the file does not belong to that alias.
 - Pass the pinned alias to children in `CODEXCTL_PINNED_ALIAS`. Recovery must exclude the account a pinned launch already selected.
-- Never overwrite a saved token with an earlier-expiring copy of the same seat.
-- Pin a launch with `CODEX_HOME=~/.codexctl/exec-homes/<alias>`. Keep `auth.json` the only real file in that home and share every other `~/.codex` entry by symbolic link.
+- Order captured tokens by issued-at and fall back to expiry. Never overwrite a saved token with an older copy of the same seat.
+- Pin a launch with `CODEX_HOME=~/.codexctl/exec-homes/<alias>`. Seed `auth.json` as a real file and share every other `~/.codex` entry by symbolic link. Never replace an entry that already exists, so an entry Codex turned into a real file stays as it left it until the home is deleted.
 - Never auto-select usage-based accounts during recovery.
 - Require confirmation before a switch can bill credits. Refuse that switch on a non-interactive terminal unless `--allow-billing` is set.
 - Keep reset approval separate from billing approval. `--allow-billing` must not imply `--allow-resets`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 ## Project
 
 - `codexctl` is a Rust 2024 CLI for managing multiple OpenAI Codex CLI accounts.
-- It saves profiles, switches accounts, reports rate limits, manages banked resets, and launches Codex with account recovery.
-- The package version is `0.1.16`.
+- It saves profiles, switches accounts, reports rate limits, manages banked resets, launches Codex with account recovery, and runs account-pinned commands.
+- The package version is `0.1.20`.
 - The license is Apache-2.0.
 
 ## Map
@@ -14,7 +14,7 @@
 - `src/commands/` contains CLI command implementations.
 - `src/api.rs` contains API code.
 - `src/config.rs` and `src/profile.rs` contain configuration and profile code.
-- `tests/api_test.rs`, `tests/cli_test.rs`, `tests/config_test.rs`, and `tests/profile_test.rs` contain tests.
+- `tests/api_test.rs`, `tests/cli_test.rs`, `tests/config_test.rs`, `tests/exec_test.rs`, and `tests/profile_test.rs` contain tests.
 - `docs/superpowers/specs/` contains design specifications.
 - `docs/superpowers/plans/` contains implementation runbooks. Use the existing matching plan instead of adding task workflow here.
 
@@ -30,12 +30,19 @@
 ## Rules
 
 - Preserve isolated login homes at `~/.codexctl/login-homes/<alias>`.
+- Preserve pinned exec homes at `~/.codexctl/exec-homes/<alias>`.
 - Run Codex login with `CODEX_HOME=~/.codexctl/login-homes/<alias>`.
 - Keep `codexctl use` as a local auth-file swap that does not contact OpenAI.
+- Keep `codexctl exec` non-mutating. It must never write `~/.codex/auth.json` or the active marker.
+- Refuse `codexctl exec` when `CODEX_HOME` is already set. A pinned launch must not replace an inherited Codex home without saying so.
+- Capture a token back to the alias the caller named. Fall back to token inspection only when the file does not belong to that alias.
+- Pass the pinned alias to children in `CODEXCTL_PINNED_ALIAS`. Recovery must exclude the account a pinned launch already selected.
+- Never overwrite a saved token with an earlier-expiring copy of the same seat.
+- Pin a launch with `CODEX_HOME=~/.codexctl/exec-homes/<alias>`. Keep `auth.json` the only real file in that home and share every other `~/.codex` entry by symbolic link.
 - Never auto-select usage-based accounts during recovery.
 - Require confirmation before a switch can bill credits. Refuse that switch on a non-interactive terminal unless `--allow-billing` is set.
 - Keep reset approval separate from billing approval. `--allow-billing` must not imply `--allow-resets`.
 - Never redeem a banked reset before its account has an exhausted window.
 - Spend the qualifying banked reset closest to expiry.
 - Keep explicit alias selection from redeeming a reset.
-- Preserve the current working directory when `codexctl codex` launches Codex.
+- Preserve the current working directory when `codexctl codex` or `codexctl exec` launches a child.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"

--- a/README.md
+++ b/README.md
@@ -280,8 +280,9 @@ codexctl completions bash >> ~/.bashrc
 codexctl completions fish > ~/.config/fish/completions/codexctl.fish
 ```
 
-Completions dynamically list profile names for `use` and `remove`, and for `exec --account` in
-zsh and fish.
+Completions dynamically list profile names for `use` and `remove`. zsh and fish also complete
+`exec --account`; bash leaves it out on purpose, because its rules bind by command name and would
+take over completion for the shell's own `exec`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ Account selection during recovery:
   100%), it asks for confirmation before switching, and refuses on a non-interactive terminal.
   Pass `--allow-billing` to approve those switches without prompting (e.g. for unattended runs).
 
+### Pinned launches
+
+`codexctl use` changes the account for the whole machine. When two agent lanes start at the same
+time, the second `use` can take the first lane's account before it launches. `codexctl exec` pins
+credentials to one child process instead, and never touches `~/.codex/auth.json` or the active
+marker:
+
+```bash
+codexctl exec --account amir+2@sawmills.ai -- codex -m gpt-5 "start prompt"
+codexctl exec --account amir+2@sawmills.ai -- codexctl codex -- "start prompt"
+```
+
+`exec` owns `CODEX_HOME`, so it refuses to run when one is already set rather than replacing it
+silently. Unset it first, or launch the pinned command from a shell that never exported it.
+
+The second form composes pinning with spend-cap recovery: the wrapper reads its account from
+`CODEX_HOME`, so its recovery switches stay inside the pinned home and remain invisible to every
+other lane. `exec` also names the pinned account to its children in `CODEXCTL_PINNED_ALIAS`, so
+recovery knows which account just failed and never switches straight back to it. `codexctl whoami` still reports whatever `codexctl use` last selected.
+
+Each alias gets a persistent pinned home at `~/.codexctl/exec-homes/<alias>/`. Only `auth.json` is
+a real per-account file there. Every other entry of `~/.codex` — `config.toml`, `AGENTS.md`,
+`sessions/` — is symlinked, so settings stay shared and session rollouts land in the real
+`~/.codex/sessions/` where `codex resume` looks for them. A refreshed token is folded back into
+the saved profile when the child exits, and an older token never overwrites a newer one. If Codex
+ever replaces a symlink with a real file, that copy stops tracking the shared one; delete
+`~/.codexctl/exec-homes/<alias>` to start clean. The child's exit code becomes codexctl's.
+
 ### Reset-aware selection (default)
 
 Both `codexctl use` (no alias) and `codexctl codex` recovery prefer, among otherwise-eligible
@@ -232,6 +260,7 @@ codexctl list          # list saved profiles
 codexctl login <alias> # isolated Codex login and save
 codexctl whoami        # show active account
 codexctl codex -- ...  # run Codex with spend-cap recovery
+codexctl exec --account <alias> -- <command>  # pinned, non-mutating launch
 codexctl resets        # list banked rate-limit resets
 codexctl reset [alias] # redeem a banked reset
 codexctl remove <alias>
@@ -251,11 +280,12 @@ codexctl completions bash >> ~/.bashrc
 codexctl completions fish > ~/.config/fish/completions/codexctl.fish
 ```
 
-Completions dynamically list profile names for `use` and `remove`.
+Completions dynamically list profile names for `use` and `remove`, and for `exec --account` in
+zsh and fish.
 
 ## How it works
 
-Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a copy of `auth.json` and `meta.json`. `codexctl login <alias>` runs `codex login --device-auth` with a unique isolated `CODEX_HOME` under `~/.codexctl/login-homes/<alias>/`, imports that auth file, removes the temporary login home, then switches to the saved profile. Switching copies the profile's `auth.json` into `~/.codex/auth.json`.
+Profiles are stored in `~/.codexctl/profiles/<alias>/` — each containing a copy of `auth.json` and `meta.json`. `codexctl login <alias>` runs `codex login --device-auth` with a unique isolated `CODEX_HOME` under `~/.codexctl/login-homes/<alias>/`, imports that auth file, removes the temporary login home, then switches to the saved profile. Switching copies the profile's `auth.json` into `~/.codex/auth.json`. `codexctl exec` copies it into `~/.codexctl/exec-homes/<alias>/auth.json` instead and passes that directory to the child as `CODEX_HOME`, so a pinned launch changes no shared state at all.
 
 The live auth file and active marker are separate atomic files. A switch installs auth first and
 writes the marker last. If the process stops between those writes, the marker can remain on the

--- a/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
+++ b/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
@@ -1,0 +1,154 @@
+# PLAN: Account-pinned, non-mutating launch (`codexctl exec`)
+
+Ticket context: SAW-9631 selected-account mismatch. `codexctl use <alias>` mutates global state
+(`~/.codex/auth.json` + `~/.codexctl/active`), so two concurrent herdr HQs race: HQ-A selects
+account A, HQ-B runs `use B` before A's lane spawns, and A's lane launches on B. Fix: a launcher
+that injects credentials per child process and never touches global state. `use` stays intact.
+
+## 1. Chosen CLI shape
+
+```
+codexctl exec --account <alias> [--] <command> [args...]
+```
+
+Runs `<command>` with `CODEX_HOME` pointed at a per-alias exec home seeded with the pinned
+profile's credentials. Propagates the child's exit code. Examples:
+
+```
+codexctl exec --account amir+2@sawmills.ai -- codex -m gpt-5 "prompt"
+codexctl exec --account amir+2@sawmills.ai -- codexctl codex -- "prompt"   # pinned + recovery
+```
+
+The second form works today with zero wrapper changes: `codexctl codex` already resolves the
+child auth file and sessions dir from `CODEX_HOME` when set (`src/commands/codex.rs:976-984`,
+`888-893`), and its recovery switch writes only that auth file — `profile::switch_to_auth_json_from`
+skips the active marker for non-global paths (`src/profile.rs:226-230`). So recovery inside a
+pinned lane rotates accounts privately without ever mutating `~/.codex` or the marker.
+
+Alternatives considered:
+- `codexctl codex --account <alias>`: sugar over the same provisioning; conflates pinning with
+  recovery policy in one flag surface. Deferred (open question 1); `exec` composition covers it.
+- `codexctl use --print-env <alias>` (eval-style exporter): no lifecycle — nothing captures
+  refreshed tokens back, and a stale exported snapshot recreates the race. Rejected.
+- Positional alias (`codexctl exec <alias> -- cmd`): ambiguous with the command word; `--account`
+  is explicit and matches the ticket language. Rejected.
+
+## 2. Credential injection mechanism
+
+What the Codex CLI actually supports:
+- **`CODEX_HOME` env (chosen)**: relocates the whole home — `auth.json`, `config.toml`,
+  `sessions/`, logs. This repo already relies on it for isolated logins
+  (`src/commands/login.rs:25`) and the wrapper already honors it (above). Supported and proven.
+- **Env var for credentials**: no Codex env var points at an alternate `auth.json`.
+  `OPENAI_API_KEY` switches to API-key auth — the wrong auth mode for ChatGPT-plan seats. Rejected.
+- **Config override (`codex -c key=value`)**: the config schema has no auth-file-path key; the
+  auth path is always derived from `CODEX_HOME`. Also only reaches a direct `codex` child, not a
+  `codexctl codex`-wrapped one. Rejected.
+
+Exec home layout — persistent per alias at `~/.codexctl/exec-homes/<alias>/` (sibling of
+`login-homes`, same `store::checked_child` validation):
+- `auth.json`: real file, seeded at every launch via `profile::switch_to_auth_json_from(paths,
+  alias, exec_auth)` — which first folds any leftover exec-home token back into its owning
+  profile (subject-matched capture), then installs the profile copy, and skips the marker.
+- Every other top-level entry of `~/.codex` (`config.toml`, `AGENTS.md`, `sessions/`,
+  `history.jsonl`, ...): symlinked into the exec home at seed time when absent. Config and global
+  instructions stay shared; session rollouts land in the real `~/.codex/sessions` through the
+  symlink, so `codex resume`, wrapper session discovery, and herdr breadcrumbs keep working.
+- Seeding never overwrites an existing non-`auth.json` entry (a symlink codex replaced with a
+  real file stays put). Reset path: delete `~/.codexctl/exec-homes/<alias>`.
+
+Persistent-per-alias over ephemeral-per-run: same-alias concurrent runs share one home (same
+credentials — benign), a crash cannot lose a refreshed token to cleanup, and it mirrors the
+login-homes precedent. Different aliases get disjoint homes — that is the isolation that matters.
+
+## 3. Interaction with use / status / login / token refresh
+
+- `use`, `switch`: untouched. `exec` never writes `~/.codex/auth.json` or `~/.codexctl/active`.
+- `status`, `whoami`: the `*` active marker stays truthful. Token refreshes from pinned runs fold
+  back into the profile store (below), so the `Token` column stays accurate.
+- `login`, `save`: untouched; login-homes and exec-homes are separate trees.
+- Token refresh mid-run: codex rewrites `$CODEX_HOME/auth.json` in the exec home. On child exit,
+  `exec` captures it back into the owning profile (matched by JWT subject via
+  `profile::alias_for_auth_json_from`, copied with `store::atomic_copy` under `store::lock`),
+  guarded so it never replaces a profile token with a *strictly earlier-expiring* same-subject
+  token (`api::token_expiry` compare). A crash before capture is healed by the capture built into
+  the next seed. Mid-run recovery switches (wrapped form) already capture on every switch.
+- All profile-store mutations (seed capture, install, exit capture) run under the existing
+  `store.lock`, so concurrent execs serialize their store writes.
+
+## 4. Failure modes
+
+- **Unknown alias**: `profile::get_profile` bails `profile '<alias>' not found` before anything
+  is provisioned or spawned. Non-zero exit, no exec home created.
+- **Expired access token at launch**: `exec` stays offline (same contract as `use`). It warns via
+  `api::is_token_expired` and launches anyway — codex refreshes with the stored refresh token. If
+  refresh fails, codex prompts for login *inside the exec home*; a foreign login there is folded
+  back only if its subject matches a saved profile, so the store cannot be corrupted.
+- **Refresh mid-run writing back**: covered above; the exp-guard prevents an old exec-home copy
+  from clobbering a newer profile token (e.g. after a re-login during the run).
+- **Two runs, same alias**: shared exec home, same credentials; seeds serialize on the store
+  lock; last refresh wins — same account, no cross-account risk.
+- **Codex replaces a symlink** (atomic rename of `config.toml`): file materializes in the exec
+  home and drifts from the shared one. Documented; reset by deleting the exec home.
+- **`~/.codex` absent**: exec home gets only `auth.json`; sessions then stay per-home. Documented.
+- **Child killed by signal**: exit code maps to `128+signal` on unix, else 1.
+
+## 5. File-level implementation plan
+
+1. `src/config.rs`: add `Paths::exec_homes_dir()` → `.codexctl/exec-homes`.
+2. `src/store.rs`: add `pub fn exec_home(paths, alias)` mirroring `login_home` (checked child).
+3. `src/profile.rs`: add `pub fn capture_exec_auth_from(paths, auth_path)` — subject-matched,
+   exp-guarded fold into the owning profile under the store lock (reuses
+   `alias_for_auth_json_from`; leaves the existing switch-path capture semantics unchanged).
+4. New `src/commands/exec.rs`:
+   - `pub fn run(account: &str, args: &[String]) -> Result<i32>`.
+   - `provision_exec_home(paths, alias) -> Result<PathBuf>`: validate alias + profile exists,
+     seed auth via `switch_to_auth_json_from`, symlink missing top-level `~/.codex` entries.
+   - Spawn `std::process::Command` with `.env("CODEX_HOME", home)`, inherited stdio and cwd
+     (preserves the AGENTS.md cwd rule); wait; `capture_exec_auth_from`; return status code.
+   - Unit tests with `Paths::from_home(tempdir)` and `/bin/sh -c` children.
+5. `src/main.rs`: add `Exec { account: String, #[arg(trailing_var_arg, allow_hyphen_values,
+   num_args(1..))] args: Vec<String> }`; route through `codex_command_outcome` so the child exit
+   code becomes the process exit code.
+6. `src/commands/mod.rs`: register `pub mod exec;`.
+7. `src/commands/completions.rs`: alias completion for `exec --account` (zsh/bash/fish blocks).
+8. Docs: README "Pinned launches" section (shape, composition with `codexctl codex`, exec-home
+   lifecycle); AGENTS.md map/rules line for `exec` (non-mutating invariant).
+9. Gates: `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test --all-targets`.
+
+## 6. Acceptance tests
+
+Integration (`tests/exec_test.rs`, `assert_cmd` + temp `HOME`, unsigned JWTs with distinct `sub`
+claims as tokens):
+1. `exec --help` shows `--account` and requires a trailing command.
+2. Unknown alias: non-zero exit, stderr names the alias, no `exec-homes/<alias>` created.
+3. Seeding: exec-home `auth.json` equals the profile's; pre-existing `~/.codex` entries are
+   symlinked (except `auth.json`); `~/.codex/auth.json` and `~/.codexctl/active` byte-identical
+   to before.
+4. Child env: `exec --account a -- /bin/sh -c 'printf %s "$CODEX_HOME" > out'` lands in
+   `exec-homes/a`.
+5. Exit-code propagation: child `exit 7` → codexctl exits 7.
+6. Capture: child rewrites `$CODEX_HOME/auth.json` with a later-exp same-subject token → profile
+   `auth.json` holds it after exit; a foreign-subject token is not folded into any profile; an
+   earlier-exp same-subject token does not regress the profile.
+7. **Concurrency (the SAW-9631 regression)**: profiles `a` and `b` with distinct tokens; global
+   auth holds a third token. Spawn simultaneously
+   `exec --account a -- /bin/sh -c 'sleep 1; cat "$CODEX_HOME/auth.json" > out_a'` and the same
+   for `b`. Assert `out_a` has exactly token-a, `out_b` exactly token-b, and global auth + active
+   marker are unchanged — two simultaneous launches never cross credentials.
+8. Session sharing: with a real `~/.codex/sessions` present, a child writing
+   `$CODEX_HOME/sessions/x` lands in `~/.codex/sessions/x` (symlink proof).
+
+Manual smoke (needs a live codex): `codexctl exec --account <a> -- codexctl codex -- "hi"`; then
+`codexctl whoami` still reports the pre-exec active account.
+
+## 7. Open questions
+
+1. Add `codexctl codex --account <alias>` sugar (same provisioning, one flag) now or as follow-up?
+2. Closed in this branch: `captured_auth_supersedes_profile` guards the switch capture too, `iat` then `exp`.
+3. Unattended lanes: add `--require-fresh` to fail fast instead of risking an interactive login
+   prompt inside the exec home when the token is expired and refresh fails?
+4. Symlink policy: is sharing `history.jsonl` and `log/` across accounts desired, or should those
+   stay per-alias (allowlist instead of link-everything)?
+5. Herdr side (outside this repo): which lane launcher switches to `codexctl exec`, and does HQ
+   pass the alias it already selected?

--- a/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
+++ b/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
@@ -7,14 +7,14 @@ that injects credentials per child process and never touches global state. `use`
 
 ## 1. Chosen CLI shape
 
-```
+```text
 codexctl exec --account <alias> [--] <command> [args...]
 ```
 
 Runs `<command>` with `CODEX_HOME` pointed at a per-alias exec home seeded with the pinned
 profile's credentials. Propagates the child's exit code. Examples:
 
-```
+```bash
 codexctl exec --account amir+2@sawmills.ai -- codex -m gpt-5 "prompt"
 codexctl exec --account amir+2@sawmills.ai -- codexctl codex -- "prompt"   # pinned + recovery
 ```
@@ -26,6 +26,7 @@ skips the active marker for non-global paths (`src/profile.rs:226-230`). So reco
 pinned lane rotates accounts privately without ever mutating `~/.codex` or the marker.
 
 Alternatives considered:
+
 - `codexctl codex --account <alias>`: sugar over the same provisioning; conflates pinning with
   recovery policy in one flag surface. Deferred (open question 1); `exec` composition covers it.
 - `codexctl use --print-env <alias>` (eval-style exporter): no lifecycle — nothing captures
@@ -36,6 +37,7 @@ Alternatives considered:
 ## 2. Credential injection mechanism
 
 What the Codex CLI actually supports:
+
 - **`CODEX_HOME` env (chosen)**: relocates the whole home — `auth.json`, `config.toml`,
   `sessions/`, logs. This repo already relies on it for isolated logins
   (`src/commands/login.rs:25`) and the wrapper already honors it (above). Supported and proven.
@@ -47,8 +49,9 @@ What the Codex CLI actually supports:
 
 Exec home layout — persistent per alias at `~/.codexctl/exec-homes/<alias>/` (sibling of
 `login-homes`, same `store::checked_child` validation):
+
 - `auth.json`: real file, seeded at every launch via `profile::switch_to_auth_json_from(paths,
-  alias, exec_auth)` — which first folds any leftover exec-home token back into its owning
+alias, exec_auth)` — which first folds any leftover exec-home token back into its owning
   profile (subject-matched capture), then installs the profile copy, and skips the marker.
 - Every other top-level entry of `~/.codex` (`config.toml`, `AGENTS.md`, `sessions/`,
   `history.jsonl`, ...): symlinked into the exec home at seed time when absent. Config and global
@@ -70,7 +73,7 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
 - Token refresh mid-run: codex rewrites `$CODEX_HOME/auth.json` in the exec home. On child exit,
   `exec` captures it back into the owning profile (matched by JWT subject via
   `profile::alias_for_auth_json_from`, copied with `store::atomic_copy` under `store::lock`),
-  guarded so it never replaces a profile token with a *strictly earlier-expiring* same-subject
+  guarded so it never replaces a profile token with a _strictly earlier-expiring_ same-subject
   token (`api::token_expiry` compare). A crash before capture is healed by the capture built into
   the next seed. Mid-run recovery switches (wrapped form) already capture on every switch.
 - All profile-store mutations (seed capture, install, exit capture) run under the existing
@@ -82,10 +85,11 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
   is provisioned or spawned. Non-zero exit, no exec home created.
 - **Expired access token at launch**: `exec` stays offline (same contract as `use`). It warns via
   `api::is_token_expired` and launches anyway — codex refreshes with the stored refresh token. If
-  refresh fails, codex prompts for login *inside the exec home*; a foreign login there is folded
+  refresh fails, codex prompts for login _inside the exec home_; a foreign login there is folded
   back only if its subject matches a saved profile, so the store cannot be corrupted.
-- **Refresh mid-run writing back**: covered above; the exp-guard prevents an old exec-home copy
-  from clobbering a newer profile token (e.g. after a re-login during the run).
+- **Refresh mid-run writing back**: covered above; the freshness guard (issued-at, then expiry)
+  prevents an old exec-home copy from clobbering a newer profile token (e.g. after a re-login
+  during the run).
 - **Two runs, same alias**: shared exec home, same credentials; seeds serialize on the store
   lock; last refresh wins — same account, no cross-account risk.
 - **Codex replaces a symlink** (atomic rename of `config.toml`): file materializes in the exec
@@ -108,7 +112,7 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
      (preserves the AGENTS.md cwd rule); wait; `capture_exec_auth_from`; return status code.
    - Unit tests with `Paths::from_home(tempdir)` and `/bin/sh -c` children.
 5. `src/main.rs`: add `Exec { account: String, #[arg(trailing_var_arg, allow_hyphen_values,
-   num_args(1..))] args: Vec<String> }`; route through `codex_command_outcome` so the child exit
+num_args(1..))] args: Vec<String> }`; route through `codex_command_outcome` so the child exit
    code becomes the process exit code.
 6. `src/commands/mod.rs`: register `pub mod exec;`.
 7. `src/commands/completions.rs`: alias completion for `exec --account` (zsh/bash/fish blocks).
@@ -120,6 +124,7 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
 
 Integration (`tests/exec_test.rs`, `assert_cmd` + temp `HOME`, unsigned JWTs with distinct `sub`
 claims as tokens):
+
 1. `exec --help` shows `--account` and requires a trailing command.
 2. Unknown alias: non-zero exit, stderr names the alias, no `exec-homes/<alias>` created.
 3. Seeding: exec-home `auth.json` equals the profile's; pre-existing `~/.codex` entries are

--- a/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
+++ b/docs/superpowers/plans/2026-08-19-exec-account-pinning.md
@@ -71,10 +71,13 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
   back into the profile store (below), so the `Token` column stays accurate.
 - `login`, `save`: untouched; login-homes and exec-homes are separate trees.
 - Token refresh mid-run: codex rewrites `$CODEX_HOME/auth.json` in the exec home. On child exit,
-  `exec` captures it back into the owning profile (matched by JWT subject via
-  `profile::alias_for_auth_json_from`, copied with `store::atomic_copy` under `store::lock`),
-  guarded so it never replaces a profile token with a _strictly earlier-expiring_ same-subject
-  token (`api::token_expiry` compare). A crash before capture is healed by the capture built into
+  `exec` captures it back into the owning profile (copied with `store::atomic_copy` under
+  `store::lock`), guarded so it never replaces a profile token with an older copy: captures are
+  ordered by `api::token_issued_at` and fall back to `api::token_expiry` when either token omits
+  `iat`. **As implemented**, ownership is resolved by evidence strength rather than by subject
+  alone — an exact token match on the alias the caller named, then a store-wide exact match, then
+  the verified alias hint, then the token subject — because one seat saved under two aliases is
+  ambiguous by subject. A crash before capture is healed by the capture built into
   the next seed. Mid-run recovery switches (wrapped form) already capture on every switch.
 - All profile-store mutations (seed capture, install, exit capture) run under the existing
   `store.lock`, so concurrent execs serialize their store writes.
@@ -101,13 +104,14 @@ login-homes precedent. Different aliases get disjoint homes — that is the isol
 
 1. `src/config.rs`: add `Paths::exec_homes_dir()` → `.codexctl/exec-homes`.
 2. `src/store.rs`: add `pub fn exec_home(paths, alias)` mirroring `login_home` (checked child).
-3. `src/profile.rs`: add `pub fn capture_exec_auth_from(paths, auth_path)` — subject-matched,
-   exp-guarded fold into the owning profile under the store lock (reuses
-   `alias_for_auth_json_from`; leaves the existing switch-path capture semantics unchanged).
+3. `src/profile.rs`: add `pub fn capture_exec_auth_from(paths, auth_path, pinned_alias)` — a
+   freshness-guarded fold into the owning profile under the store lock. **As implemented**, it
+   takes the pinned alias and resolves ownership through `alias_for_auth_json_with_hint`, and the
+   guard was extended to the switch-path capture as well, which this plan had left unchanged.
 4. New `src/commands/exec.rs`:
    - `pub fn run(account: &str, args: &[String]) -> Result<i32>`.
    - `provision_exec_home(paths, alias) -> Result<PathBuf>`: validate alias + profile exists,
-     seed auth via `switch_to_auth_json_from`, symlink missing top-level `~/.codex` entries.
+     seed auth via `seed_exec_auth_from`, symlink missing top-level `~/.codex` entries.
    - Spawn `std::process::Command` with `.env("CODEX_HOME", home)`, inherited stdio and cwd
      (preserves the AGENTS.md cwd rule); wait; `capture_exec_auth_from`; return status code.
    - Unit tests with `Paths::from_home(tempdir)` and `/bin/sh -c` children.

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,6 @@ const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 /// - Simple: `{"access_token": "...", "refresh_token": "..."}`
 pub struct AuthJson {
     pub access_token: String,
-    #[allow(dead_code)]
     pub refresh_token: Option<String>,
     pub account_id: Option<String>,
 }
@@ -637,6 +636,16 @@ pub fn token_subject(token: &str) -> Option<String> {
         .get("sub")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
+}
+
+/// The `iat` (issued-at) claim as a unix timestamp, if present.
+///
+/// This orders two tokens even when the newer one expires first, which happens
+/// whenever the issued lifetime is shortened between two logins.
+pub fn token_issued_at(token: &str) -> Option<i64> {
+    decode_jwt_payload(token)?
+        .get("iat")
+        .and_then(|v| v.as_i64())
 }
 
 /// The `exp` (expiry) claim as a unix timestamp, if present.

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -819,6 +819,19 @@ impl ProfileSwitcher for CodexctlProfileSwitcher {
     }
 
     fn switch_to(&mut self, alias: &str) -> Result<()> {
+        // Inside a pinned lane the outgoing token is this lane's own account,
+        // and the switch is about to overwrite it. Fold it back under the alias
+        // the launch named first: subject alone cannot name it when one seat is
+        // saved under two aliases, and by the time `exec` captures on exit the
+        // home already holds the recovered account instead.
+        if let Ok(pinned_alias) = std::env::var(super::exec::PINNED_ALIAS_ENV)
+            && !pinned_alias.is_empty()
+            && let Ok(paths) = config::default_paths()
+            && let Err(error) =
+                profile::capture_exec_auth_from(&paths, &self.auth_json, &pinned_alias)
+        {
+            eprintln!("warning: failed to capture tokens for profile '{pinned_alias}': {error:#}");
+        }
         let email = profile::switch_to_auth_json(alias, &self.auth_json)?;
         eprintln!("codexctl: switched to {alias} ({email})");
         Ok(())
@@ -985,16 +998,20 @@ fn codex_home_for_child(paths: &Paths) -> PathBuf {
 
 fn failed_alias_for_child_auth(paths: &Paths) -> Option<String> {
     let auth_json = codex_auth_json_for_child(paths);
-    profile::alias_for_auth_json_from(paths, &auth_json)
-        .ok()
-        .flatten()
-        .or_else(|| {
+    // A pinned launch names the account it selected. Reading it back beats
+    // inferring it from the token, which is ambiguous when one seat is saved
+    // under two aliases — and an alias recovery cannot identify is an alias it
+    // will happily switch back to after that account just failed.
+    let pinned_alias = std::env::var(super::exec::PINNED_ALIAS_ENV).ok();
+    profile::alias_for_auth_json_with_hint(paths, &auth_json, pinned_alias.as_deref()).or_else(
+        || {
             if auth_json == paths.codex_auth_json() {
                 profile::get_active_from(paths).ok().flatten()
             } else {
                 None
             }
-        })
+        },
+    )
 }
 
 fn invocation_session_cwd(invocation: &CodexInvocation) -> PathBuf {

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -41,6 +41,10 @@ _codexctl_profiles() {
             "'::alias -- Profile alias to redeem for (defaults to the active account):_default'",
             "'::alias -- Profile alias to redeem for (defaults to the active account):_codexctl_profiles'",
         );
+        script = script.replace(
+            "'--account=[Profile alias the command runs as]:ACCOUNT:_default'",
+            "'--account=[Profile alias the command runs as]:ACCOUNT:_codexctl_profiles'",
+        );
 
         // Insert profile function before the main _codexctl function
         print!("{profile_fn}{script}");
@@ -59,11 +63,16 @@ _codexctl_profiles() {
         println!(r#"complete -F _codexctl_profiles codexctl use"#);
         println!(r#"complete -F _codexctl_profiles codexctl remove"#);
         println!(r#"complete -F _codexctl_profiles codexctl reset"#);
+        // `exec` is left out on purpose: these rules bind by command name, so
+        // adding it would take over completion for the shell's own `exec`.
     } else if shell == Shell::Fish {
         generate(shell, &mut cmd, name, &mut std::io::stdout());
         println!();
         println!(
             r#"complete -c codexctl -n '__fish_seen_subcommand_from use remove reset' -xa '(ls ~/.codexctl/profiles/ 2>/dev/null)'"#
+        );
+        println!(
+            r#"complete -c codexctl -n '__fish_seen_subcommand_from exec' -l account -xa '(ls ~/.codexctl/profiles/ 2>/dev/null)'"#
         );
     } else {
         generate(shell, &mut cmd, name, &mut std::io::stdout());

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -1,0 +1,541 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::api;
+use crate::commands::alias;
+use crate::config::{self, Paths};
+use crate::profile;
+use crate::store;
+
+const AUTH_FILE: &str = "auth.json";
+
+/// Names the account a pinned launch selected, for codexctl processes inside it.
+///
+/// A nested `codexctl codex` otherwise has to infer that account from the token
+/// in the pinned home, which one seat saved under two aliases makes ambiguous.
+/// Guessing wrong lets recovery hand back the account that just failed.
+pub const PINNED_ALIAS_ENV: &str = "CODEXCTL_PINNED_ALIAS";
+
+pub fn run(account: &str, args: &[String]) -> Result<i32> {
+    refuse_inherited_codex_home(std::env::var_os("CODEX_HOME").as_deref())?;
+    run_from(&config::default_paths()?, account, args)
+}
+
+/// Refuse to launch from inside somebody else's Codex home.
+///
+/// A pinned launch owns `CODEX_HOME`, so an inherited one would be replaced
+/// without a word: the child would read the shared `~/.codex` settings instead
+/// of the caller's, and write its rollouts where the caller's `codex resume`
+/// never looks. Refusing keeps that surprise out of the launch path.
+fn refuse_inherited_codex_home(codex_home: Option<&OsStr>) -> Result<()> {
+    // Presence is the test, not usefulness. An empty value is still a caller
+    // who touched the variable, and guessing what they meant by it is the
+    // silent substitution this refusal exists to prevent.
+    let Some(codex_home) = codex_home else {
+        return Ok(());
+    };
+    bail!(
+        "CODEX_HOME is already set to '{}'. `codexctl exec` sets CODEX_HOME itself and will not run inside another Codex home; unset it to pin a launch.",
+        Path::new(codex_home).display()
+    )
+}
+
+/// Run a command with its Codex credentials pinned to one saved profile.
+///
+/// The pinning is per child process: `CODEX_HOME` points the child at a home
+/// that holds that account's `auth.json`. The live Codex home and the active
+/// profile marker are never written, so two pinned launches cannot take each
+/// other's account, and neither can a concurrent `codexctl use`.
+fn run_from(paths: &Paths, account: &str, args: &[String]) -> Result<i32> {
+    let alias = alias::required(account)?;
+    let Some((program, arguments)) = args.split_first() else {
+        bail!("no command to run. Use 'codexctl exec --account <alias> -- <command> [args...]'");
+    };
+
+    let home = provision_exec_home(paths, alias)?;
+    let status = Command::new(program)
+        .args(arguments)
+        .env("CODEX_HOME", &home)
+        .env(PINNED_ALIAS_ENV, alias)
+        .status()
+        .with_context(|| format!("failed to run `{program}`"))?;
+
+    // Codex rotates its token in place, so the refreshed copy lives in the
+    // pinned home. Fold it back, or `status` and the next launch keep reporting
+    // the token this run started with.
+    if let Err(error) = profile::capture_exec_auth_from(paths, &home.join(AUTH_FILE), alias) {
+        eprintln!("warning: failed to capture tokens for profile '{alias}': {error:#}");
+    }
+
+    Ok(exit_code(status))
+}
+
+/// Prepare the pinned Codex home for `alias` and return its path.
+fn provision_exec_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    // Resolve the profile first so an unknown alias fails before anything is
+    // created on its behalf.
+    profile::get_profile_from(paths, alias)?;
+
+    store::ensure_private_dir(&paths.exec_homes_dir())?;
+    let home = store::exec_home(paths, alias)?;
+    store::ensure_private_dir(&home)?;
+    let exec_auth = home.join(AUTH_FILE);
+    profile::seed_exec_auth_from(paths, alias, &exec_auth)?;
+    // Judge the token the child will actually use. Seeding can fold a fresher
+    // token left behind by a killed run back over the saved copy, and warning
+    // before that runs cries stale about a token that is live.
+    warn_when_token_expired(alias, &exec_auth);
+    link_shared_codex_entries(paths, &home)?;
+    Ok(home)
+}
+
+/// Stay offline like `codexctl use`: report the stale token and launch anyway,
+/// since Codex refreshes it from the stored refresh token.
+fn warn_when_token_expired(alias: &str, auth_json: &Path) {
+    let Ok(auth) = api::read_auth_json(auth_json) else {
+        return;
+    };
+    if api::is_token_expired(&auth.access_token) {
+        eprintln!(
+            "warning: profile '{alias}' has an expired access token; Codex will try to refresh it"
+        );
+    }
+}
+
+/// Share everything except credentials with the live Codex home.
+///
+/// Config, global instructions, and the sessions directory are symlinked, so a
+/// pinned run reads the same settings and writes its rollouts where `codex
+/// resume` and the `codexctl codex` wrapper already look for them. Only
+/// `auth.json` is a real per-alias file. An entry that already exists is never
+/// replaced, so a link the child turned into a real file stays as it left it.
+fn link_shared_codex_entries(paths: &Paths, home: &Path) -> Result<()> {
+    let codex_home = paths.codex_home();
+    let entries = match std::fs::read_dir(&codex_home) {
+        Ok(entries) => entries,
+        // No live Codex home to share: the pinned home holds credentials only.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", codex_home.display()));
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("failed to read {}", codex_home.display()))?;
+        let name = entry.file_name();
+        if name == OsStr::new(AUTH_FILE) || is_atomic_replace_temp(&name) {
+            continue;
+        }
+        let link = home.join(&name);
+        if std::fs::symlink_metadata(&link).is_ok() {
+            continue;
+        }
+        symlink_shared_entry(&entry.path(), &link)?;
+    }
+
+    Ok(())
+}
+
+/// Whether a name is one of the temporary files `store::atomic_replace` holds
+/// for the moment before its rename.
+///
+/// Linking one leaves a symlink that dangles as soon as the rename lands, and
+/// nothing replaces an existing entry afterwards — so a `codexctl use` running
+/// during the scan would leave permanent litter in the pinned home.
+fn is_atomic_replace_temp(name: &OsStr) -> bool {
+    name.to_str()
+        .is_some_and(|name| name.starts_with('.') && name.ends_with(".tmp"))
+}
+
+#[cfg(unix)]
+fn symlink_shared_entry(target: &Path, link: &Path) -> Result<()> {
+    match std::os::unix::fs::symlink(target, link) {
+        Ok(()) => Ok(()),
+        // A concurrent launch of the same alias won the race and linked the
+        // same target, so the entry is already shared.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to link {}", link.display())),
+    }
+}
+
+#[cfg(not(unix))]
+fn symlink_shared_entry(_target: &Path, link: &Path) -> Result<()> {
+    // Silently keeping the entry unshared would send session rollouts somewhere
+    // `codex resume` never looks, so say so instead of pretending it worked.
+    bail!(
+        "cannot share {} with the pinned Codex home: this platform has no symbolic links",
+        link.display()
+    )
+}
+
+/// Map the child status onto an exit code the way a shell does, so a signal
+/// death stays distinguishable from a clean exit with the same number.
+fn exit_code(status: std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fake JWT header `{"alg":"none"}`; only the claims payload is read.
+    const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+    // `{"sub":"seatA","exp":2000000000}`
+    const SEAT_A: &str = "eyJzdWIiOiJzZWF0QSIsImV4cCI6MjAwMDAwMDAwMH0";
+    // `{"sub":"seatB","exp":2000000000}`
+    const SEAT_B: &str = "eyJzdWIiOiJzZWF0QiIsImV4cCI6MjAwMDAwMDAwMH0";
+
+    fn setup(aliases: &[(&str, &str)]) -> (tempfile::TempDir, Paths) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        paths.ensure_dirs().unwrap();
+        for (alias, token) in aliases {
+            write_profile(&paths, alias, token);
+        }
+        (tmp, paths)
+    }
+
+    fn write_profile(paths: &Paths, alias: &str, access_token: &str) {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(AUTH_FILE),
+            format!(r#"{{"access_token":"{access_token}"}}"#),
+        )
+        .unwrap();
+        let meta = profile::Meta {
+            alias: alias.to_string(),
+            email: None,
+            plan: None,
+            saved_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        std::fs::write(
+            dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn token_of(path: &Path) -> String {
+        api::read_auth_json(path).unwrap().access_token
+    }
+
+    #[test]
+    fn an_inherited_codex_home_is_refused() {
+        assert!(refuse_inherited_codex_home(None).is_ok());
+        // Set-but-empty is still set.
+        assert!(refuse_inherited_codex_home(Some(OsStr::new(""))).is_err());
+
+        let error = refuse_inherited_codex_home(Some(OsStr::new("/tmp/work-codex"))).unwrap_err();
+
+        assert!(error.to_string().contains("/tmp/work-codex"), "{error:#}");
+    }
+
+    #[test]
+    fn atomic_replace_temporaries_are_not_shared() {
+        assert!(is_atomic_replace_temp(OsStr::new(
+            ".auth.json.codexctl-1-2-3.tmp"
+        )));
+        assert!(!is_atomic_replace_temp(OsStr::new("config.toml")));
+        assert!(!is_atomic_replace_temp(OsStr::new("sessions")));
+    }
+
+    #[test]
+    fn unknown_alias_fails_before_creating_an_exec_home() {
+        let (_tmp, paths) = setup(&[]);
+
+        let error = run_from(&paths, "missing", &["true".to_string()]).unwrap_err();
+
+        assert!(error.to_string().contains("missing"), "{error:#}");
+        assert!(!paths.exec_homes_dir().exists());
+    }
+
+    #[test]
+    fn missing_command_is_rejected() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+
+        assert!(run_from(&paths, "a", &[]).is_err());
+    }
+
+    #[test]
+    fn provisioning_seeds_the_pinned_auth_without_touching_global_state() {
+        let token = format!("{JWT_HDR}.{SEAT_A}.sig");
+        let (_tmp, paths) = setup(&[("a", &token)]);
+        let live = format!("{JWT_HDR}.{SEAT_B}.live");
+        std::fs::create_dir_all(paths.codex_home()).unwrap();
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{live}"}}"#),
+        )
+        .unwrap();
+
+        let home = provision_exec_home(&paths, "a").unwrap();
+
+        assert_eq!(home, paths.exec_homes_dir().join("a"));
+        assert_eq!(token_of(&home.join(AUTH_FILE)), token);
+        assert_eq!(token_of(&paths.codex_auth_json()), live);
+        assert!(!paths.active_file().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provisioning_shares_every_codex_entry_except_credentials() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+        let codex_home = paths.codex_home();
+        std::fs::create_dir_all(codex_home.join("sessions")).unwrap();
+        std::fs::write(codex_home.join("config.toml"), "model = \"gpt-5\"").unwrap();
+        std::fs::write(codex_home.join(AUTH_FILE), r#"{"access_token":"live"}"#).unwrap();
+
+        let home = provision_exec_home(&paths, "a").unwrap();
+
+        for shared in ["config.toml", "sessions"] {
+            let link = home.join(shared);
+            assert!(
+                link.symlink_metadata().unwrap().file_type().is_symlink(),
+                "{shared} is not shared"
+            );
+            assert_eq!(std::fs::read_link(&link).unwrap(), codex_home.join(shared));
+        }
+        assert!(
+            !home
+                .join(AUTH_FILE)
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "credentials must stay pinned per account"
+        );
+    }
+
+    /// A `codexctl use` mid-`atomic_replace` leaves a temporary file in the
+    /// live home for an instant. Linking it would dangle the moment the rename
+    /// lands, and nothing replaces an existing entry afterwards.
+    #[cfg(unix)]
+    #[test]
+    fn provisioning_skips_a_temporary_file_from_a_concurrent_switch() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+        std::fs::create_dir_all(paths.codex_home()).unwrap();
+        let temp_name = ".auth.json.codexctl-123-456-0.tmp";
+        std::fs::write(paths.codex_home().join(temp_name), "in flight").unwrap();
+
+        let home = provision_exec_home(&paths, "a").unwrap();
+
+        assert!(
+            home.join(temp_name).symlink_metadata().is_err(),
+            "a transient file was shared into the pinned home"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provisioning_keeps_an_entry_the_child_replaced() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+        std::fs::create_dir_all(paths.codex_home()).unwrap();
+        std::fs::write(paths.codex_home().join("config.toml"), "shared").unwrap();
+        let home = provision_exec_home(&paths, "a").unwrap();
+        std::fs::remove_file(home.join("config.toml")).unwrap();
+        std::fs::write(home.join("config.toml"), "pinned").unwrap();
+
+        provision_exec_home(&paths, "a").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(home.join("config.toml")).unwrap(),
+            "pinned"
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths.codex_home().join("config.toml")).unwrap(),
+            "shared"
+        );
+    }
+
+    #[test]
+    fn provisioning_works_without_a_live_codex_home() {
+        let token = format!("{JWT_HDR}.{SEAT_A}.sig");
+        let (_tmp, paths) = setup(&[("a", &token)]);
+
+        let home = provision_exec_home(&paths, "a").unwrap();
+
+        assert_eq!(token_of(&home.join(AUTH_FILE)), token);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_refreshed_pinned_token_is_folded_back_into_its_profile() {
+        let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+        let (_tmp, paths) = setup(&[("a", &stored)]);
+        let rotated = format!("{JWT_HDR}.{SEAT_A}.rotated");
+
+        let code = run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!(r#"printf '{{"access_token":"{rotated}"}}' > "$CODEX_HOME/auth.json""#),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            token_of(&paths.profiles_dir().join("a").join(AUTH_FILE)),
+            rotated
+        );
+    }
+
+    /// The refresh token is what buys the next access token, so a rotation of
+    /// it alone still has to reach the store.
+    #[cfg(unix)]
+    #[test]
+    fn a_rotated_refresh_token_is_captured_on_its_own() {
+        let access = format!("{JWT_HDR}.{SEAT_A}.stored");
+        let (_tmp, paths) = setup(&[("a", &access)]);
+        let profile_auth = paths.profiles_dir().join("a").join(AUTH_FILE);
+        std::fs::write(
+            &profile_auth,
+            format!(r#"{{"access_token":"{access}","refresh_token":"old"}}"#),
+        )
+        .unwrap();
+
+        run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!(
+                    r#"printf '{{"access_token":"{access}","refresh_token":"new"}}' > "$CODEX_HOME/auth.json""#
+                ),
+            ],
+        )
+        .unwrap();
+
+        let captured = api::read_auth_json(&profile_auth).unwrap();
+        assert_eq!(captured.access_token, access);
+        assert_eq!(captured.refresh_token.as_deref(), Some("new"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_foreign_login_in_the_pinned_home_is_not_folded_into_the_store() {
+        let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+        let (_tmp, paths) = setup(&[("a", &stored)]);
+        // sub seatC is not saved under any alias.
+        let foreign = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QyIsImV4cCI6MjAwMDAwMDAwMH0.sig");
+
+        run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!(r#"printf '{{"access_token":"{foreign}"}}' > "$CODEX_HOME/auth.json""#),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            token_of(&paths.profiles_dir().join("a").join(AUTH_FILE)),
+            stored
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_earlier_expiring_pinned_token_does_not_regress_the_profile() {
+        // `{"sub":"seatA","exp":1900000000}` — same seat, expires sooner.
+        let earlier = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImV4cCI6MTkwMDAwMDAwMH0.old");
+        let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+        let (_tmp, paths) = setup(&[("a", &stored)]);
+
+        run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!(r#"printf '{{"access_token":"{earlier}"}}' > "$CODEX_HOME/auth.json""#),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            token_of(&paths.profiles_dir().join("a").join(AUTH_FILE)),
+            stored
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_token_left_by_a_killed_run_is_captured_on_the_next_launch() {
+        let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+        let (_tmp, paths) = setup(&[("a", &stored)]);
+        let rotated = format!("{JWT_HDR}.{SEAT_A}.rotated");
+        let home = provision_exec_home(&paths, "a").unwrap();
+        // Stands in for a run that was killed before it could capture.
+        std::fs::write(
+            home.join(AUTH_FILE),
+            format!(r#"{{"access_token":"{rotated}"}}"#),
+        )
+        .unwrap();
+
+        provision_exec_home(&paths, "a").unwrap();
+
+        assert_eq!(
+            token_of(&paths.profiles_dir().join("a").join(AUTH_FILE)),
+            rotated
+        );
+        assert_eq!(token_of(&home.join(AUTH_FILE)), rotated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_exit_code_is_returned() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+
+        let code = run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "exit 7".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(code, 7);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_killed_by_a_signal_reports_the_shell_convention_code() {
+        let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+
+        let code = run_from(
+            &paths,
+            "a",
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "kill -TERM $$".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(code, 128 + libc::SIGTERM);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod alias;
 pub mod codex;
 pub mod completions;
+pub mod exec;
 pub mod list;
 pub mod login;
 pub mod remove;

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,12 +27,21 @@ impl Paths {
         self.codexctl_dir().join("login-homes")
     }
 
+    /// Root of the per-alias Codex homes that `codexctl exec` pins a child to.
+    pub fn exec_homes_dir(&self) -> PathBuf {
+        self.codexctl_dir().join("exec-homes")
+    }
+
     pub fn active_file(&self) -> PathBuf {
         self.codexctl_dir().join("active")
     }
 
+    pub fn codex_home(&self) -> PathBuf {
+        self.home.join(".codex")
+    }
+
     pub fn codex_auth_json(&self) -> PathBuf {
-        self.home.join(".codex").join("auth.json")
+        self.codex_home().join("auth.json")
     }
 
     pub fn ensure_dirs(&self) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,16 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Run a command with its Codex credentials pinned to one account,
+    /// without switching the active profile
+    Exec {
+        /// Profile alias the command runs as
+        #[arg(long)]
+        account: String,
+        /// Command to run, followed by its arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        args: Vec<String>,
+    },
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -176,6 +186,10 @@ fn main() {
             allow_resets,
         ))
         .into_result(),
+        Commands::Exec {
+            ref account,
+            ref args,
+        } => codex_command_outcome(commands::exec::run(account, args)).into_result(),
         Commands::Completions { shell } => commands::completions::run(shell),
     };
 
@@ -230,6 +244,32 @@ mod tests {
                 );
             }
             _ => panic!("expected codex command"),
+        }
+    }
+
+    /// A pinned child owns everything after `--`, including words that look
+    /// like codexctl's own flags.
+    #[test]
+    fn exec_subcommand_forwards_the_whole_child_command() {
+        let cli = Cli::parse_from([
+            "codexctl",
+            "exec",
+            "--account",
+            "amir@example.com",
+            "--",
+            "codex",
+            "--allow-billing",
+        ]);
+
+        match cli.command {
+            Commands::Exec { account, args } => {
+                assert_eq!(account, "amir@example.com");
+                assert_eq!(
+                    args,
+                    vec!["codex".to_string(), "--allow-billing".to_string()]
+                );
+            }
+            _ => panic!("expected exec command"),
         }
     }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -231,6 +231,150 @@ pub fn switch_to_auth_json_from(paths: &Paths, alias: &str, codex_auth: &Path) -
     Ok(profile.meta.email.unwrap_or_else(|| "unknown".to_string()))
 }
 
+/// Seed a pinned exec home's auth file from its saved profile.
+///
+/// This is deliberately not a switch: it never installs into the live Codex
+/// home and never writes the active profile marker, so a pinned launch leaves
+/// global state alone. A token left behind by an earlier pinned run is folded
+/// back into its owning profile first, which heals a run that was killed before
+/// it could capture its own refreshed token.
+pub fn seed_exec_auth_from(paths: &Paths, alias: &str, exec_auth: &Path) -> Result<()> {
+    let alias = store::validate_alias(alias)?;
+    let _lock = store::lock(paths)?;
+    let profile = get_profile_from(paths, alias)?;
+    capture_exec_auth_unlocked(paths, exec_auth, Some(alias));
+    store::atomic_copy(&profile.auth_json_path(), exec_auth)
+        .with_context(|| format!("failed to install auth.json at {}", exec_auth.display()))
+}
+
+/// Fold a pinned exec home's auth file back into the profile that owns it.
+///
+/// `pinned_alias` is the account the launch asked for. It settles the one case
+/// token inspection cannot: one seat saved under two aliases is ambiguous by
+/// subject, but the label the caller launched with is not.
+pub fn capture_exec_auth_from(paths: &Paths, exec_auth: &Path, pinned_alias: &str) -> Result<()> {
+    let pinned_alias = store::validate_alias(pinned_alias)?;
+    let _lock = store::lock(paths)?;
+    capture_exec_auth_unlocked(paths, exec_auth, Some(pinned_alias));
+    Ok(())
+}
+
+/// Best-effort capture of a pinned exec home's tokens. Failures only warn,
+/// because a capture problem must not fail a child run that already succeeded.
+///
+/// Subject matching keeps a foreign login inside an exec home out of the store.
+/// The expiry guard keeps a stale exec-home copy from replacing a newer profile
+/// token, which is what a re-login of the same alias during a long pinned run
+/// would otherwise cause.
+fn capture_exec_auth_unlocked(paths: &Paths, exec_auth: &Path, pinned_alias: Option<&str>) {
+    if !exec_auth.exists() {
+        return;
+    }
+    let Some(alias) = alias_for_auth_json_with_hint(paths, exec_auth, pinned_alias) else {
+        return;
+    };
+    let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
+        return;
+    };
+    if !captured_auth_supersedes_profile(exec_auth, &dest) {
+        return;
+    }
+    if let Err(error) = store::atomic_copy(exec_auth, &dest) {
+        eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
+    }
+}
+
+/// Which saved profile an auth file belongs to, given the alias the caller
+/// already knows.
+///
+/// Evidence outranks the hint, but only evidence that discriminates. The named
+/// alias wins first when it holds this exact token, because a store-wide scan
+/// cannot tell two aliases saved from one login apart and would answer by
+/// directory order. Failing that, an exact match elsewhere names its owner
+/// outright. The hint then breaks the tie token inspection cannot: one seat
+/// saved under two aliases matches both by subject. Recovery inside a pinned
+/// lane can rotate the file to a different account, so a file that matches
+/// nothing still falls back to a store-wide search.
+/// The profile holding this exact access token, if any.
+fn alias_for_exact_token_from(paths: &Paths, auth_json: &Path) -> Option<String> {
+    let target = api::read_auth_json(auth_json).ok()?;
+    list_profiles_from(paths)
+        .ok()?
+        .into_iter()
+        .find_map(|profile| {
+            let stored = api::read_auth_json(&profile.auth_json_path()).ok()?;
+            (stored.access_token == target.access_token).then_some(profile.meta.alias)
+        })
+}
+
+pub fn alias_for_auth_json_with_hint(
+    paths: &Paths,
+    auth_json: &Path,
+    known_alias: Option<&str>,
+) -> Option<String> {
+    let hinted = known_alias.and_then(|alias| get_profile_from(paths, alias).ok());
+    // The named alias holding this very token is the strongest confirmation the
+    // hint can get. It outranks the store-wide scan, which would otherwise let
+    // directory order pick between two aliases saved from the same login.
+    if let Some(profile) = &hinted
+        && auth_files_have_same_access_token(auth_json, &profile.auth_json_path())
+    {
+        return Some(profile.meta.alias.clone());
+    }
+    if let Some(alias) = alias_for_exact_token_from(paths, auth_json) {
+        return Some(alias);
+    }
+    if let Some(profile) = hinted
+        && auth_files_have_same_owner(auth_json, &profile.auth_json_path())
+    {
+        return Some(profile.meta.alias);
+    }
+    alias_for_auth_json_from(paths, auth_json).ok().flatten()
+}
+
+/// Whether captured credentials are worth writing over the saved profile.
+///
+/// Identical credentials are not worth a write. Otherwise the newer access
+/// token wins, judged by its issued-at claim and falling back to its expiry:
+/// an older snapshot carries an older refresh token too, so taking either would
+/// undo a newer login.
+///
+/// A refresh token that rotates on its own is still captured: the access token
+/// is unchanged in that case, so both sides report the same expiry and the
+/// comparison passes. The expiry only ever refuses a file whose access token
+/// also changed — that is, a whole older copy.
+fn captured_auth_supersedes_profile(captured_auth: &Path, profile_auth: &Path) -> bool {
+    let Ok(candidate) = api::read_auth_json(captured_auth) else {
+        return false;
+    };
+    let Ok(current) = api::read_auth_json(profile_auth) else {
+        return true;
+    };
+    if candidate.access_token == current.access_token
+        && candidate.refresh_token == current.refresh_token
+    {
+        return false;
+    }
+    // Issued-at orders the two tokens directly. Expiry only stands in for it,
+    // and stops being a proxy for recency the moment a shortened lifetime makes
+    // the newer token expire first.
+    if let (Some(candidate_iat), Some(current_iat)) = (
+        api::token_issued_at(&candidate.access_token),
+        api::token_issued_at(&current.access_token),
+    ) && candidate_iat != current_iat
+    {
+        return candidate_iat > current_iat;
+    }
+    // Same issuance instant, or no issued-at to compare: let expiry decide.
+    match (
+        api::token_expiry(&candidate.access_token),
+        api::token_expiry(&current.access_token),
+    ) {
+        (Some(candidate_exp), Some(current_exp)) => candidate_exp >= current_exp,
+        _ => true,
+    }
+}
+
 /// Pick the live auth file only when it belongs to the active saved profile.
 /// Otherwise use the stored snapshot and avoid attributing a foreign session.
 pub fn auth_json_path_for_profile_from(
@@ -247,6 +391,13 @@ pub fn auth_json_path_for_profile_from(
     } else {
         profile.auth_json_path()
     }
+}
+
+fn auth_files_have_same_access_token(left: &Path, right: &Path) -> bool {
+    let (Ok(left), Ok(right)) = (api::read_auth_json(left), api::read_auth_json(right)) else {
+        return false;
+    };
+    left.access_token == right.access_token
 }
 
 fn auth_files_have_same_owner(left: &Path, right: &Path) -> bool {
@@ -299,12 +450,28 @@ fn capture_auth_file_profile_tokens(paths: &Paths, codex_auth: &Path) {
     if !codex_auth.exists() {
         return;
     }
-    let Ok(Some(alias)) = alias_for_auth_json_from(paths, codex_auth) else {
+    // The active marker names the account that installed the live auth file, so
+    // it settles a seat saved under two aliases exactly as the pinned alias does
+    // for an exec home. It is only a hint: a file that does not match the marked
+    // profile is still resolved by inspecting the token.
+    let known_alias = if codex_auth == paths.codex_auth_json() {
+        get_active_from(paths).ok().flatten()
+    } else {
+        None
+    };
+    let Some(alias) = alias_for_auth_json_with_hint(paths, codex_auth, known_alias.as_deref())
+    else {
         return;
     };
     let Ok(dest) = store::profile_dir(paths, &alias).map(|dir| dir.join("auth.json")) else {
         return;
     };
+    // The live file is not always the newer copy. A pinned run that already
+    // folded a rotated token into this profile leaves the live file behind, and
+    // copying it now would undo that rotation.
+    if !captured_auth_supersedes_profile(codex_auth, &dest) {
+        return;
+    }
     if let Err(error) = store::atomic_copy(codex_auth, &dest) {
         eprintln!("warning: failed to capture tokens for profile '{alias}': {error}");
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -53,6 +53,12 @@ pub fn login_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
     checked_child(&paths.login_homes_dir(), alias)
 }
 
+/// Return a checked pinned Codex home below the exec-home root.
+pub fn exec_home(paths: &Paths, alias: &str) -> Result<PathBuf> {
+    let alias = validate_alias(alias)?;
+    checked_child(&paths.exec_homes_dir(), alias)
+}
+
 fn checked_child(root: &Path, name: &str) -> Result<PathBuf> {
     if root.exists() {
         for entry in

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -603,6 +603,21 @@ fn parse_account_settings_missing_limits() {
 const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
 
 #[test]
+fn token_issued_at_reads_iat_claim() {
+    // `{"sub":"seatA","iat":1900000000,"exp":2000000000}`
+    let tok =
+        format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImlhdCI6MTkwMDAwMDAwMCwiZXhwIjoyMDAwMDAwMDAwfQ.sig");
+
+    assert_eq!(api::token_issued_at(&tok), Some(1900000000));
+    // `{"exp":9999999999}` — no `iat` to read.
+    assert_eq!(
+        api::token_issued_at(&format!("{JWT_HDR}.eyJleHAiOjk5OTk5OTk5OTl9.sig")),
+        None
+    );
+    assert_eq!(api::token_issued_at("not-a-jwt"), None);
+}
+
+#[test]
 fn token_subject_reads_sub_claim() {
     // payload {"sub":"seatA"}
     let tok = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.sig");

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -14,6 +14,7 @@ fn help_shows_all_subcommands() {
     assert!(stdout.contains("remove"));
     assert!(stdout.contains("whoami"));
     assert!(stdout.contains("codex"));
+    assert!(stdout.contains("exec"));
     assert!(stdout.contains("resets"));
     assert!(stdout.contains("reset"));
     assert!(stdout.contains("completions"));

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -1,0 +1,475 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+use codexctl::config::Paths;
+use codexctl::profile;
+
+// Fake JWT header `{"alg":"none"}`; only the claims payload is read.
+const JWT_HDR: &str = "eyJhbGciOiJub25lIn0";
+// `{"sub":"seatA","exp":2000000000}`
+const SEAT_A: &str = "eyJzdWIiOiJzZWF0QSIsImV4cCI6MjAwMDAwMDAwMH0";
+// `{"sub":"seatB","exp":2000000000}`
+const SEAT_B: &str = "eyJzdWIiOiJzZWF0QiIsImV4cCI6MjAwMDAwMDAwMH0";
+// `{"sub":"seatC","exp":2000000000}`
+const SEAT_C: &str = "eyJzdWIiOiJzZWF0QyIsImV4cCI6MjAwMDAwMDAwMH0";
+
+fn setup(aliases: &[(&str, &str)]) -> (tempfile::TempDir, Paths) {
+    let tmp = tempfile::tempdir().unwrap();
+    let paths = Paths::from_home(tmp.path().to_path_buf());
+    paths.ensure_dirs().unwrap();
+    std::fs::create_dir_all(paths.codex_home()).unwrap();
+    for (alias, token) in aliases {
+        write_profile(&paths, alias, token);
+    }
+    (tmp, paths)
+}
+
+fn write_profile(paths: &Paths, alias: &str, access_token: &str) {
+    let dir = paths.profiles_dir().join(alias);
+    std::fs::create_dir_all(&dir).unwrap();
+    write_auth(&dir.join("auth.json"), access_token);
+    let meta = profile::Meta {
+        alias: alias.to_string(),
+        email: None,
+        plan: None,
+        saved_at: "2026-01-01T00:00:00Z".to_string(),
+    };
+    std::fs::write(
+        dir.join("meta.json"),
+        serde_json::to_string_pretty(&meta).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_auth(path: &Path, access_token: &str) {
+    std::fs::write(path, format!(r#"{{"access_token":"{access_token}"}}"#)).unwrap();
+}
+
+fn codexctl(paths: &Paths) -> Command {
+    let mut command = Command::cargo_bin("codexctl").unwrap();
+    command.env("HOME", &paths.home).env_remove("CODEX_HOME");
+    command
+}
+
+fn exec_home(paths: &Paths, alias: &str) -> std::path::PathBuf {
+    paths.exec_homes_dir().join(alias)
+}
+
+#[test]
+fn exec_help_documents_the_pinned_launch_shape() {
+    let output = Command::cargo_bin("codexctl")
+        .unwrap()
+        .args(["exec", "--help"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--account"), "{stdout}");
+    assert!(stdout.contains("<ARGS>"), "{stdout}");
+}
+
+/// The command to run is the whole point, so `exec` must not silently do
+/// nothing when it is missing.
+#[test]
+fn exec_requires_an_account_and_a_command() {
+    for args in [vec!["exec"], vec!["exec", "--account", "a"]] {
+        Command::cargo_bin("codexctl")
+            .unwrap()
+            .args(&args)
+            .assert()
+            .failure();
+    }
+}
+
+#[test]
+fn unknown_alias_fails_without_provisioning_anything() {
+    let (_tmp, paths) = setup(&[]);
+
+    let output = codexctl(&paths)
+        .args(["exec", "--account", "missing", "--", "true"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("missing"), "{stderr}");
+    assert!(!exec_home(&paths, "missing").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn pinned_launch_leaves_the_active_account_alone() {
+    let pinned = format!("{JWT_HDR}.{SEAT_A}.sig");
+    let live = format!("{JWT_HDR}.{SEAT_B}.live");
+    let (_tmp, paths) = setup(&[("a", &pinned), ("b", &live)]);
+    write_auth(&paths.codex_auth_json(), &live);
+    profile::set_active_from(&paths, "b").unwrap();
+
+    codexctl(&paths)
+        .args(["exec", "--account", "a", "--", "true"])
+        .assert()
+        .success();
+
+    let exec_auth = std::fs::read_to_string(exec_home(&paths, "a").join("auth.json")).unwrap();
+    assert!(exec_auth.contains(&pinned), "pinned auth not seeded");
+    assert!(
+        std::fs::read_to_string(paths.codex_auth_json())
+            .unwrap()
+            .contains(&live),
+        "live Codex auth was rewritten"
+    );
+    assert_eq!(
+        profile::get_active_from(&paths).unwrap().as_deref(),
+        Some("b"),
+        "active profile marker was rewritten"
+    );
+}
+
+/// A pinned launch owns CODEX_HOME, so it must not quietly discard one the
+/// caller already set.
+#[test]
+fn an_inherited_codex_home_is_refused() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+    let foreign = paths.home.join("work-codex");
+    std::fs::create_dir_all(&foreign).unwrap();
+
+    let output = codexctl(&paths)
+        .env("CODEX_HOME", &foreign)
+        .args(["exec", "--account", "a", "--", "true"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("CODEX_HOME"), "{stderr}");
+    assert!(
+        !exec_home(&paths, "a").exists(),
+        "refused launches must not provision anything"
+    );
+}
+
+/// The warning has to describe the token the child will use, not the one the
+/// store held before seeding folded a killed run's fresher token back in.
+#[cfg(unix)]
+#[test]
+fn a_healed_token_does_not_raise_a_stale_expiry_warning() {
+    // `{"sub":"seatA","exp":1000000000}` — expired in 2001.
+    let expired = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImV4cCI6MTAwMDAwMDAwMH0.old");
+    let (_tmp, paths) = setup(&[("a", &expired)]);
+    let fresh = format!("{JWT_HDR}.{SEAT_A}.rotated");
+    std::fs::create_dir_all(exec_home(&paths, "a")).unwrap();
+    write_auth(&exec_home(&paths, "a").join("auth.json"), &fresh);
+
+    let output = codexctl(&paths)
+        .args(["exec", "--account", "a", "--", "true"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !stderr.contains("expired"),
+        "false stale-token alarm: {stderr}"
+    );
+}
+
+/// One seat saved under two aliases is ambiguous by token subject alone. The
+/// alias the launch was pinned to is the fact that resolves it.
+#[cfg(unix)]
+#[test]
+fn a_rotation_lands_on_the_pinned_alias_when_two_aliases_share_a_seat() {
+    let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+    let (_tmp, paths) = setup(&[("primary", &stored), ("duplicate", &stored)]);
+    let rotated = format!("{JWT_HDR}.{SEAT_A}.rotated");
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "primary",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!(r#"printf '{{"access_token":"{rotated}"}}' > "$CODEX_HOME/auth.json""#),
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("primary").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "the pinned alias did not receive its own rotation"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn child_runs_with_codex_home_pointed_at_the_pinned_account() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+    let out = paths.home.join("seen-home");
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!(r#"printf %s "$CODEX_HOME" > "{}""#, out.display()),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read_to_string(&out).unwrap(),
+        exec_home(&paths, "a").display().to_string()
+    );
+}
+
+/// A nested `codexctl codex` must be told which account it is running as. It
+/// cannot always infer that from the token, and an account it fails to identify
+/// is one its recovery will switch back to right after that account failed.
+#[cfg(unix)]
+#[test]
+fn the_pinned_alias_is_named_for_nested_codexctl_processes() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+    let out = paths.home.join("seen-alias");
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!(
+                r#"printf %s "$CODEXCTL_PINNED_ALIAS" > "{}""#,
+                out.display()
+            ),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "a");
+}
+
+#[cfg(unix)]
+#[test]
+fn child_keeps_the_current_working_directory() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+    let workdir = paths.home.join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let output = codexctl(&paths)
+        .current_dir(&workdir)
+        .args(["exec", "--account", "a", "--", "/bin/sh", "-c", "pwd"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        std::fs::canonicalize(stdout.trim()).unwrap(),
+        std::fs::canonicalize(&workdir).unwrap()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn child_exit_code_becomes_the_process_exit_code() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+
+    let output = codexctl(&paths)
+        .args(["exec", "--account", "a", "--", "/bin/sh", "-c", "exit 7"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(7));
+}
+
+/// Forwarded arguments belong to the child, not to codexctl.
+#[cfg(unix)]
+#[test]
+fn child_arguments_that_look_like_flags_are_forwarded() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+
+    let output = codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            r#"printf %s "$1""#,
+            "sh",
+            "--allow-billing",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "--allow-billing");
+}
+
+#[cfg(unix)]
+#[test]
+fn shared_codex_entries_are_linked_and_sessions_land_in_the_real_home() {
+    let (_tmp, paths) = setup(&[("a", &format!("{JWT_HDR}.{SEAT_A}.sig"))]);
+    std::fs::create_dir_all(paths.codex_home().join("sessions")).unwrap();
+    std::fs::write(paths.codex_home().join("config.toml"), "model = \"gpt-5\"").unwrap();
+    write_auth(
+        &paths.codex_auth_json(),
+        &format!("{JWT_HDR}.{SEAT_B}.live"),
+    );
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            r#"printf rollout > "$CODEX_HOME/sessions/x""#,
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read_to_string(paths.codex_home().join("sessions").join("x")).unwrap(),
+        "rollout",
+        "session rollouts must reach the real Codex home"
+    );
+    assert!(
+        !exec_home(&paths, "a")
+            .join("auth.json")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "credentials must not be shared"
+    );
+    assert!(
+        exec_home(&paths, "a")
+            .join("config.toml")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_refreshed_token_is_folded_back_and_a_foreign_one_is_not() {
+    let stored = format!("{JWT_HDR}.{SEAT_A}.stored");
+    let (_tmp, paths) = setup(&[("a", &stored), ("b", &format!("{JWT_HDR}.{SEAT_B}.b"))]);
+    let rotated = format!("{JWT_HDR}.{SEAT_A}.rotated");
+    let foreign = format!("{JWT_HDR}.{SEAT_C}.foreign");
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!(r#"printf '{{"access_token":"{rotated}"}}' > "$CODEX_HOME/auth.json""#),
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("a").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "refreshed token was not captured"
+    );
+
+    codexctl(&paths)
+        .args([
+            "exec",
+            "--account",
+            "a",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!(r#"printf '{{"access_token":"{foreign}"}}' > "$CODEX_HOME/auth.json""#),
+        ])
+        .assert()
+        .success();
+
+    for alias in ["a", "b"] {
+        assert!(
+            !std::fs::read_to_string(paths.profiles_dir().join(alias).join("auth.json"))
+                .unwrap()
+                .contains(&foreign),
+            "a foreign login was folded into profile '{alias}'"
+        );
+    }
+}
+
+/// The SAW-9631 regression: two lanes launching at the same time must each keep
+/// their own account, which a global `use` cannot guarantee.
+#[cfg(unix)]
+#[test]
+fn simultaneous_pinned_launches_never_cross_credentials() {
+    let a_token = format!("{JWT_HDR}.{SEAT_A}.a");
+    let b_token = format!("{JWT_HDR}.{SEAT_B}.b");
+    let live = format!("{JWT_HDR}.{SEAT_C}.live");
+    let (_tmp, paths) = setup(&[("a", &a_token), ("b", &b_token)]);
+    write_auth(&paths.codex_auth_json(), &live);
+    profile::set_active_from(&paths, "a").unwrap();
+
+    let children: Vec<_> = ["a", "b"]
+        .iter()
+        .map(|alias| {
+            let out = paths.home.join(format!("out-{alias}"));
+            let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("codexctl"));
+            command
+                .env("HOME", &paths.home)
+                .args([
+                    "exec",
+                    "--account",
+                    alias,
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    &format!(
+                        r#"sleep 1; cat "$CODEX_HOME/auth.json" > "{}""#,
+                        out.display()
+                    ),
+                ])
+                .spawn()
+                .unwrap()
+        })
+        .collect();
+    for mut child in children {
+        assert!(child.wait().unwrap().success());
+    }
+
+    let seen_a = std::fs::read_to_string(paths.home.join("out-a")).unwrap();
+    let seen_b = std::fs::read_to_string(paths.home.join("out-b")).unwrap();
+    assert!(
+        seen_a.contains(&a_token) && !seen_a.contains(&b_token),
+        "{seen_a}"
+    );
+    assert!(
+        seen_b.contains(&b_token) && !seen_b.contains(&a_token),
+        "{seen_b}"
+    );
+    assert!(
+        std::fs::read_to_string(paths.codex_auth_json())
+            .unwrap()
+            .contains(&live),
+        "live Codex auth was rewritten"
+    );
+    assert_eq!(
+        profile::get_active_from(&paths).unwrap().as_deref(),
+        Some("a")
+    );
+}

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -432,6 +432,9 @@ fn simultaneous_pinned_launches_never_cross_credentials() {
             let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("codexctl"));
             command
                 .env("HOME", &paths.home)
+                // `exec` refuses an inherited Codex home, so the developer's
+                // own CODEX_HOME must not decide whether this test runs.
+                .env_remove("CODEX_HOME")
                 .args([
                     "exec",
                     "--account",

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -171,6 +171,271 @@ fn alias_for_auth_json_rejects_ambiguous_subject_fallback() {
     );
 }
 
+/// One seat can be saved under two aliases. Subject matching is ambiguous
+/// there, so the capture would drop the rotation; the alias the launch was
+/// pinned to is the fact that settles it.
+#[test]
+fn exec_capture_prefers_the_pinned_alias_over_an_ambiguous_subject() {
+    let (_tmp, paths) = setup_test_env();
+    let stored = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.stored");
+    let rotated = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.rotated");
+    write_profile(&paths, "primary", &stored);
+    write_profile(&paths, "duplicate", &stored);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{rotated}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "primary").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("primary").join("auth.json"))
+            .unwrap()
+            .contains(&rotated)
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("duplicate").join("auth.json"))
+            .unwrap()
+            .contains(&stored),
+        "an unrelated alias must not be rewritten"
+    );
+}
+
+/// Recovery inside a pinned lane rotates the home to another account, so a
+/// token that is not the pinned alias's still has to reach its real owner.
+#[test]
+fn exec_capture_falls_back_to_the_real_owner_after_a_recovery_switch() {
+    let (_tmp, paths) = setup_test_env();
+    let pinned_tok = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.pinned");
+    let recovered_old = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.old");
+    let recovered_live = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.live");
+    write_profile(&paths, "pinned", &pinned_tok);
+    write_profile(&paths, "recovered", &recovered_old);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{recovered_live}"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "pinned").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("recovered").join("auth.json"))
+            .unwrap()
+            .contains(&recovered_live)
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("pinned").join("auth.json"))
+            .unwrap()
+            .contains(&pinned_tok),
+        "the pinned alias must keep its own token"
+    );
+}
+
+/// A pinned run folds its rotated token into the profile while the live Codex
+/// file still holds the older one. The next switch must not copy that stale
+/// file back over the rotation.
+#[test]
+fn switch_capture_does_not_regress_a_profile_to_an_older_live_token() {
+    let (_tmp, paths) = setup_test_env();
+    // sub seatA, exp 2000000000 (fresh) and exp 1900000000 (older).
+    let rotated = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImV4cCI6MjAwMDAwMDAwMH0.rotated");
+    let stale = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImV4cCI6MTkwMDAwMDAwMH0.stale");
+    write_profile(&paths, "a", &rotated);
+    write_profile(&paths, "b", &format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.b"));
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{stale}"}}"#),
+    )
+    .unwrap();
+    profile::set_active_from(&paths, "a").unwrap();
+
+    profile::switch_to_from(&paths, "b").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("a").join("auth.json"))
+            .unwrap()
+            .contains(&rotated),
+        "the switch capture overwrote a newer token with an older live copy"
+    );
+}
+
+/// The active marker is only a hint. It decides which alias owns a live token
+/// when two aliases hold the same seat, but it never overrides the token: a
+/// marker left stale by an interrupted switch cannot claim a foreign seat,
+/// which `switch_skips_capture_for_foreign_codex_auth` proves from the other
+/// side.
+#[test]
+fn switch_capture_uses_the_active_marker_only_to_break_a_tie() {
+    let (_tmp, paths) = setup_test_env();
+    let shared_old = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.old");
+    let shared_live = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.live");
+    // One seat, saved twice — ambiguous by subject alone.
+    write_profile(&paths, "marked", &shared_old);
+    write_profile(&paths, "duplicate", &shared_old);
+    write_profile(
+        &paths,
+        "next",
+        &format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QiJ9.next"),
+    );
+    std::fs::write(
+        paths.codex_auth_json(),
+        format!(r#"{{"access_token":"{shared_live}"}}"#),
+    )
+    .unwrap();
+    profile::set_active_from(&paths, "marked").unwrap();
+
+    profile::switch_to_from(&paths, "next").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("marked").join("auth.json"))
+            .unwrap()
+            .contains(&shared_live),
+        "the marked alias should receive the rotation instead of it being dropped"
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("duplicate").join("auth.json"))
+            .unwrap()
+            .contains(&shared_old),
+        "an unmarked duplicate must not be rewritten"
+    );
+}
+
+/// A shortened token lifetime makes the newer token expire first, so expiry
+/// alone would refuse a genuine rotation and strand the profile on a refresh
+/// token the server has already replaced.
+#[test]
+fn exec_capture_orders_tokens_by_issued_at_not_expiry() {
+    let (_tmp, paths) = setup_test_env();
+    // iat 1900000000 / exp 2000000000 — issued earlier, longer lifetime.
+    let older =
+        format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImlhdCI6MTkwMDAwMDAwMCwiZXhwIjoyMDAwMDAwMDAwfQ.old");
+    // iat 1950000000 / exp 1960000000 — issued later, shorter lifetime.
+    let newer =
+        format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImlhdCI6MTk1MDAwMDAwMCwiZXhwIjoxOTYwMDAwMDAwfQ.new");
+    write_profile(&paths, "a", &older);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{newer}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "a").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("a").join("auth.json"))
+            .unwrap()
+            .contains(&newer),
+        "a later-issued token was refused because it expires sooner"
+    );
+}
+
+/// A token saved verbatim under one alias belongs to that alias, whatever the
+/// caller's hint says. The hint only settles what the token cannot.
+#[test]
+fn exec_capture_prefers_an_exact_token_owner_over_the_hint() {
+    let (_tmp, paths) = setup_test_env();
+    let hinted_tok = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.hinted");
+    let owner_tok = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.owner");
+    // One seat, two aliases holding different tokens for it.
+    write_profile(&paths, "hinted", &hinted_tok);
+    write_profile(&paths, "owner", &owner_tok);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{owner_tok}","refresh_token":"rotated"}}"#),
+    )
+    .unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "hinted").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("owner").join("auth.json"))
+            .unwrap()
+            .contains("rotated"),
+        "the exact-token owner should receive the capture"
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("hinted").join("auth.json"))
+            .unwrap()
+            .contains(&hinted_tok),
+        "the hinted alias must not absorb another alias's token"
+    );
+}
+
+/// Two tokens issued in the same second still have to be ordered, and the one
+/// that expires sooner is not the newer one.
+#[test]
+fn exec_capture_falls_back_to_expiry_when_issued_at_ties() {
+    let (_tmp, paths) = setup_test_env();
+    // Both iat 1900000000; exp 2000000000 stored, exp 1950000000 captured.
+    let stored = format!(
+        "{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImlhdCI6MTkwMDAwMDAwMCwiZXhwIjoyMDAwMDAwMDAwfQ.stored"
+    );
+    let sooner = format!(
+        "{JWT_HDR}.eyJzdWIiOiJzZWF0QSIsImlhdCI6MTkwMDAwMDAwMCwiZXhwIjoxOTUwMDAwMDAwfQ.sooner"
+    );
+    write_profile(&paths, "a", &stored);
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(&exec_auth, format!(r#"{{"access_token":"{sooner}"}}"#)).unwrap();
+
+    profile::capture_exec_auth_from(&paths, &exec_auth, "a").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("a").join("auth.json"))
+            .unwrap()
+            .contains(&stored),
+        "an earlier-expiring token from the same second must not win"
+    );
+}
+
+/// Two aliases saved from one login are byte-identical, so a store-wide scan
+/// answers by directory order. A refresh-only rotation still has the original
+/// access token, so only the launch label can say which alias earned it.
+#[test]
+fn exec_capture_keeps_a_refresh_rotation_on_the_pinned_identical_duplicate() {
+    let (_tmp, paths) = setup_test_env();
+    let shared = format!("{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.shared");
+    for alias in ["a-dup", "z-pin"] {
+        let dir = paths.profiles_dir().join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"access_token":"{shared}","refresh_token":"old"}}"#),
+        )
+        .unwrap();
+        let meta = profile::Meta {
+            alias: alias.to_string(),
+            email: None,
+            plan: None,
+            saved_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        std::fs::write(
+            dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+    let exec_auth = paths.home.join("exec-auth.json");
+    std::fs::write(
+        &exec_auth,
+        format!(r#"{{"access_token":"{shared}","refresh_token":"new"}}"#),
+    )
+    .unwrap();
+
+    // Pinned to the alias that sorts last, so directory order cannot supply it.
+    profile::capture_exec_auth_from(&paths, &exec_auth, "z-pin").unwrap();
+
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("z-pin").join("auth.json"))
+            .unwrap()
+            .contains("new"),
+        "the pinned alias lost its own refresh rotation"
+    );
+    assert!(
+        std::fs::read_to_string(paths.profiles_dir().join("a-dup").join("auth.json"))
+            .unwrap()
+            .contains("old"),
+        "an identical duplicate must not absorb the rotation"
+    );
+}
+
 #[test]
 fn active_starts_as_none() {
     let (_tmp, paths) = setup_test_env();


### PR DESCRIPTION
## Why

`codexctl use` switches the account for the whole machine. Two herdr lanes starting at once race: HQ-A selects account A, HQ-B runs `use B` before A's lane spawns, and A's lane launches on B. That is SAW-9631.

## What

`codexctl exec --account <alias> [--] <command> [args...]` pins credentials to one child process and never writes `~/.codex/auth.json` or the active marker.

```bash
codexctl exec --account amir+2@sawmills.ai -- codex -m gpt-5 "prompt"
codexctl exec --account amir+2@sawmills.ai -- codexctl codex -- "prompt"   # pinned + recovery
```

- **Pinned home** per alias at `~/.codexctl/exec-homes/<alias>`. Only `auth.json` is a real file; every other `~/.codex` entry is symlinked, so config stays shared and session rollouts land where `codex resume` looks.
- **Composes with the recovery wrapper.** The wrapper already reads its account from `CODEX_HOME`, so its switches stay inside the pinned home. `exec` names the account to children in `CODEXCTL_PINNED_ALIAS` so recovery never hands back the account that just failed.
- **Refuses an inherited `CODEX_HOME`** rather than silently replacing the caller's selection.
- **Token capture by evidence strength**: exact match on the named alias → store-wide exact match → verified alias hint → token subject. This fixes rotations being dropped when one seat is saved under two aliases, which subject matching alone cannot disambiguate.
- **Captures ordered by `iat`, falling back to `exp`**, so a newer token never loses to an older copy. The same guard now also protects the pre-existing switch capture (closes plan open question 2).

`use`, `switch`, `login`, `save`, `status`, and `whoami` are unchanged.

## Testing

240 tests pass; `cargo fmt --all -- --check` clean, `cargo clippy --all-targets` 0 warnings, release build ok.

New coverage includes the SAW-9631 regression itself — two simultaneous pinned launches on different aliases, asserting each child reads exactly its own token while global auth and the active marker stay byte-identical — plus exit-code and signal propagation, cwd preservation, symlink sharing, the inherited-`CODEX_HOME` refusal, and seven token-capture cases (refresh-only rotation, foreign login, killed-run heal, TTL-shrink ordering, issued-at ties, exact-owner precedence, and identical duplicate aliases).

## Review

Six rounds across two independent reviewers (codex `gpt-5.6-sol` autoreview and a Claude Fable design reviewer), both clean on the final tree. Ten findings: eight fixed, two rejected with grounds and upheld on re-review.

## Follow-ups (not in this PR)

- Dedupe recovery candidates by token subject when filtering `tried` — one wasted recovery bounce in a duplicate-alias config.
- `codex_home_for_child` treats an empty `CODEX_HOME` as a home named `""`; make it consistent with the refusal `exec` now enforces.
- herdr HQ adoption: the race is only closed for lanes that actually launch through `exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins credentials per process with `codexctl exec --account <alias> -- <command>`, fixing SAW-9631 by avoiding writes to `~/.codex/auth.json` and the active marker. Old: concurrent lanes could launch on the wrong account; New: each child runs in a per-alias exec home; Side effects: refuses an inherited `CODEX_HOME`, composes with recovery, and preserves the child’s exit status.

- Per-alias exec home at `~/.codexctl/exec-homes/<alias>`: only `auth.json` is real; other `~/.codex` entries are symlinked so config and sessions stay shared. Existing non-`auth.json` entries are never replaced; on platforms without symlinks, sharing errors.
- Recovery composition: sets `CODEX_HOME` and passes `CODEXCTL_PINNED_ALIAS` so recovery stays inside the pinned home and avoids switching back to the just-failed account. `status/whoami` are unchanged.
- Token capture: resolves ownership by evidence strength (exact match on the pinned alias → store‑wide exact match → verified alias hint → token subject). Captures are ordered by issued‑at then expiry so newer tokens never lose; the same guard now protects switch‑time and live-file capture. Refresh‑only rotations are captured.
- CLI/docs: adds `exec` subcommand; zsh/fish complete `exec --account` (bash intentionally omits it). README and plan document pinned launches; tests cover the SAW‑9631 race, exit codes, CWD, sharing, refusal on inherited `CODEX_HOME`, and capture semantics.

**Rollout**
- Launch lanes via `codexctl exec --account <alias> -- codexctl codex -- "<prompt>"` to close SAW‑9631 end‑to‑end.
- Ensure launch environments do not export `CODEX_HOME`; `exec` refuses inherited values. No other migration required.

<sup>Written for commit e0feb27bf774306b81c644fc71e200dd430cb5eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codexctl exec --account <alias> -- <command>` to run commands with credentials pinned to a saved account.
  * Preserves the active account while isolating credentials per execution.
  * Shares non-credential Codex files and propagates command exit codes.
  * Added shell completion support and improved help documentation.

* **Bug Fixes**
  * Improved token refresh, rotation, expiry handling, and recovery.
  * Prevented stale credentials from overwriting newer saved authentication data.

* **Documentation**
  * Updated the README and project guidance for account-pinned execution.

* **Tests**
  * Added comprehensive coverage for isolation, concurrency, token handling, argument forwarding, and exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->