### PR TITLE
fix: handle null additional_rate_limits

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -31,6 +31,14 @@ struct CodexTokens {
     chatgpt_account_id: Option<String>,
 }
 
+fn deserialize_null_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
 #[derive(Deserialize)]
 pub struct RateLimitResponse {
     pub plan_type: Option<String>,
@@ -38,7 +46,7 @@ pub struct RateLimitResponse {
     pub credits: Option<Credits>,
     pub spend_control: Option<SpendControl>,
     /// Extra feature or model buckets returned alongside the main Codex limit.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Banked rate-limit reset credits, when the plan has any.
     pub rate_limit_reset_credits: Option<ResetCreditsSummary>,

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -638,3 +638,15 @@ fn is_token_expired_distinguishes_exp_claim() {
         "{JWT_HDR}.eyJzdWIiOiJzZWF0QSJ9.sig"
     )));
 }
+
+#[test]
+fn parse_null_additional_rate_limits_as_empty() {
+    let json = r#"{
+        "plan_type": "plus",
+        "rate_limit": null,
+        "additional_rate_limits": null
+    }"#;
+
+    let response: RateLimitResponse = serde_json::from_str(json).unwrap();
+    assert!(response.additional_rate_limits.is_empty());
+}


### PR DESCRIPTION
## Summary

- Treat `additional_rate_limits: null` as an empty list.
- Add a regression test covering an explicit `null` value.

## Problem

The current ChatGPT `WHAM /usage` response can return:

```json
"additional_rate_limits": null
````

`RateLimitResponse` currently declares the field as:

```rust
#[serde(default)]
pub additional_rate_limits: Vec<AdditionalRateLimit>,
```

`#[serde(default)]` handles a missing field, but not an explicitly `null` value.

As a result, an otherwise successful `HTTP 200` response fails during deserialization with:

```text
invalid type: null, expected a sequence
```

This causes commands such as `codexctl status` and `codexctl resets` to report `error`, even though authentication and the backend requests themselves are successful.

## Reproduction

Observed with `codexctl 0.1.20` against the current ChatGPT backend:

1. `GET /backend-api/wham/usage` returns `HTTP 200`.
2. The response contains `"additional_rate_limits": null`.
3. `resp.json::<RateLimitResponse>()` fails with:
   `invalid type: null, expected a sequence`.
4. The CLI consequently renders the account as `error`.

The same response succeeds after treating `null` as an empty vector.

## Fix

Deserialize `additional_rate_limits` through a small helper that maps:

* missing field -> `[]`
* `null` -> `[]`
* JSON array -> the original array

This preserves the existing `Vec<AdditionalRateLimit>` API and avoids propagating an `Option` throughout the codebase.

## Testing

Added a regression test for:

```json
{
  "plan_type": "plus",
  "rate_limit": null,
  "additional_rate_limits": null
}
```

and verified the full test suite with:

```text
cargo test
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats additional_rate_limits: null in WHAM /usage as an empty list to prevent deserialization failures that surfaced as CLI errors on successful HTTP 200 responses. Previously, explicit null caused “invalid type: null, expected a sequence”; now null or missing values deserialize to [].

- Adds a small deserializer applied to RateLimitResponse.additional_rate_limits to map null/missing to [] while preserving the Vec API.
- Adds a regression test for a response with additional_rate_limits: null.
- No behavior change for non-null arrays; commands like codexctl status/resets now render correctly.

<sup>Written for commit da4a1481ad81d5c98eefa3e1b8266d40f54b87f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

