### PR TITLE
chore(release): v0.1.21

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `codexctl` is a Rust 2024 CLI for managing multiple OpenAI Codex CLI accounts.
 - It saves profiles, switches accounts, reports rate limits, manages banked resets, launches Codex with account recovery, and runs account-pinned commands.
-- The package version is `0.1.20`.
+- The package version is `0.1.21`.
 - The license is Apache-2.0.
 
 ## Map

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"


### PR DESCRIPTION
Version bump only — `Cargo.toml`, `Cargo.lock`, `AGENTS.md`.

Cuts a release for #21, which fixes `"additional_rate_limits": null` failing deserialization. On an affected account that bug did more than show `error`: the failed usage fetch scored the seat `f64::MAX` with `bills_credits` defaulting to true, so it was excluded from automatic selection and its banked reset could not be redeemed. Verified against a live account — the released 0.1.20 showed `error`, the fix showed 100% on 7d with 1 redeemable reset.

Note for `feat/account-labels` (#19): that branch currently targets `v0.1.21`. Once this lands, it needs `v0.1.22` — I'll push that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `codexctl` v0.1.21 to accept backend responses with additional_rate_limits = null. v0.1.20 treated these as errors, scoring seats at f64::MAX with bills_credits = true, which excluded them from automatic selection and blocked banked reset redemption; v0.1.21 restores normal selection and redemption.

**Rollout**
- After this lands, update `feat/account-labels` to target v0.1.22.

<sup>Written for commit 8c24e215598bfe0f61b49dc54287caa57988cf61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from `0.1.20` to `0.1.21`.
  * Synchronized the documented version with the package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->