### PR TITLE
fix(login,save): reuse the profile that already holds this account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `codexctl` is a Rust 2024 CLI for managing multiple OpenAI Codex CLI accounts.
 - It saves profiles, labels and tells apart accounts, switches accounts, reports rate limits, manages banked resets, launches Codex with account recovery, and runs account-pinned commands.
-- The package version is `0.1.22`.
+- The package version is `0.1.23`.
 - The license is Apache-2.0.
 
 ## Map

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexctl"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexctl"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 rust-version = "1.89"
 description = "Manage multiple OpenAI Codex CLI accounts"

--- a/README.md
+++ b/README.md
@@ -288,9 +288,19 @@ codexctl login amir@sawmills.ai --label team       # saves 'amir@sawmills.ai+tea
 ```
 
 Logging the same seat in again refreshes whichever alias it already occupies,
-so this is stable across re-logins. Without `--label` there is nothing to
-qualify with, and a login onto an alias held by another account is refused
-rather than allowed to replace its credentials.
+so this is stable across re-logins — including when the alias you type is not
+that one. An account lives in exactly one profile, and that profile is where a
+login for it lands, whatever the alias asked for turned out to hold. The name
+typed is not recorded as the address of a profile it did not name.
+
+Without `--label` there is nothing to qualify with, so a login onto an alias
+held by _another_ account, for an account not saved anywhere yet, is refused
+rather than allowed to replace those credentials.
+
+`codexctl save` refuses instead of redirecting. A login has already
+authenticated by the time the alias is resolved, so refusing it would throw away
+a working credential; a save has nothing to lose by asking you to name the alias
+it would have written to.
 
 `--label` also works on `codexctl save`, and `codexctl label <alias> [text]`
 sets or clears one later.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -296,10 +296,23 @@ fn resolve_target_alias(
             // identify. It is not permission to make a second copy of an
             // account the store can already point to, so a saved seat wins
             // over the question rather than being asked around.
-            if let profile::ExistingSeat::One(existing) = &seat
-                && existing != alias
-            {
-                return Ok(Resolution::Ready(existing.clone()));
+            match &seat {
+                profile::ExistingSeat::One(existing) if existing != alias => {
+                    return Ok(Resolution::Ready(existing.clone()));
+                }
+                // Already saved more than once. Consent to replace an
+                // unidentifiable profile is not consent to add a third copy.
+                profile::ExistingSeat::Ambiguous(aliases) => {
+                    if aliases.iter().any(|existing| existing == alias) {
+                        return Ok(Resolution::Ready(alias.to_string()));
+                    }
+                    bail!(
+                        "this account is already saved under more than one alias ({}). \
+                         Remove the duplicates, or log in with one of them directly.",
+                        aliases.join(", ")
+                    )
+                }
+                _ => {}
             }
             return Ok(Resolution::NeedsConsent {
                 alias: alias.to_string(),
@@ -902,6 +915,53 @@ mod tests {
             std::fs::read_to_string(damaged.join("auth.json")).unwrap(),
             "{ not json",
             "the unidentifiable profile was replaced anyway"
+        );
+    }
+
+    /// Consent to replace a profile nothing can identify is not consent to add
+    /// a third copy of an account already saved twice.
+    #[test]
+    fn adoption_does_not_add_a_third_copy_of_an_ambiguous_account() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let stored = encode(claims);
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        for alias in ["one", "two"] {
+            profile::save_profile_to(&paths, alias, None, &paths.codex_auth_json().clone())
+                .unwrap();
+        }
+        // A third alias holding something nothing can identify.
+        let damaged = paths.profiles_dir().join("damaged");
+        std::fs::create_dir_all(&damaged).unwrap();
+        std::fs::write(damaged.join("auth.json"), "{ not json").unwrap();
+        std::fs::write(
+            damaged.join("meta.json"),
+            r#"{"alias":"damaged","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let refreshed = encode(claims).replace(".sig", ".sig2");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let error = run_from_with_consent(&paths, "damaged", None, true, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("more than one alias"),
+            "adoption added a third copy: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(damaged.join("auth.json")).unwrap(),
+            "{ not json",
+            "the damaged profile was replaced"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1103,6 +1103,48 @@ mod tests {
         );
     }
 
+    /// One access token can name two workspaces through an explicit
+    /// `account_id`. A holder declaring a different one is a different account,
+    /// so redirecting there would overwrite it with another workspace's
+    /// credentials — the opposite of what the reuse rule is for.
+    #[test]
+    fn an_identical_token_in_another_workspace_is_not_the_same_seat() {
+        let (_tmp, paths) = setup_test_env();
+        let shared = "opaque-not-a-jwt";
+        // The saved profile holds this token for workspace A.
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{shared}","account_id":"acct-a"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "workspace-a",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The login returns the same token, declaring workspace B.
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{shared}","account_id":"acct-b"}}"#
+        ));
+
+        let saved = run_from(&paths, "workspace-b", None, &mut runner).unwrap();
+
+        assert_eq!(
+            saved, "workspace-b",
+            "a second workspace was folded into the first"
+        );
+        let kept =
+            std::fs::read_to_string(paths.profiles_dir().join("workspace-a").join("auth.json"))
+                .unwrap();
+        assert!(
+            kept.contains("acct-a"),
+            "the first workspace's profile was overwritten: {kept}"
+        );
+    }
+
     /// The label path writes to an alias the operator did not type — it is
     /// derived from the alias and the label together. That is acceptable only
     /// while the question names the profile that is actually replaced, because

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -249,21 +249,18 @@ fn resolve_target_alias(
     incoming_account: Option<&str>,
     incoming_user: &api::Logins,
 ) -> Result<Resolution> {
+    // Where this account already lives, if anywhere. Consulted before every
+    // decision below rather than only when the requested alias is empty: the
+    // account identifies the profile, and the alias is only the name reached
+    // for. Saving a second copy forks it, which every later lookup reports as
+    // ambiguous — and the fresh login revokes the older grant server-side,
+    // leaving the duplicate dead as well as confusing.
+    let seat = profile::existing_seat(paths, incoming_account, incoming_user)
+        .context("could not check whether this account is already saved")?;
+
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
     let Some(conflict) = conflict else {
-        // The requested alias is usable, but this seat may already be saved
-        // under another one — and saving it here too would fork one account
-        // across two profiles, which is what makes ownership ambiguous later.
-        //
-        // Checked whatever the operator typed, label or not. The account
-        // identifies the profile; the alias is only the name reached for. A
-        // mistyped alias is free by definition, so gating this on anything the
-        // operator got right is gating it on the case that never needed it —
-        // and the fresh login revokes the older grant server-side, leaving the
-        // duplicate dead as well as confusing.
-        match profile::existing_seat(paths, incoming_account, incoming_user)
-            .context("could not check whether this account is already saved")?
-        {
+        match seat {
             profile::ExistingSeat::One(existing) if existing != alias => {
                 return Ok(Resolution::Ready(existing));
             }
@@ -295,6 +292,15 @@ fn resolve_target_alias(
         // could make replacing it right. One that simply cannot be compared is a
         // question, and the operator is the only one who can answer it.
         let profile::AccountConflict::Different(different) = &conflict else {
+            // Adoption consent is permission to replace a profile nothing can
+            // identify. It is not permission to make a second copy of an
+            // account the store can already point to, so a saved seat wins
+            // over the question rather than being asked around.
+            if let profile::ExistingSeat::One(existing) = &seat
+                && existing != alias
+            {
+                return Ok(Resolution::Ready(existing.clone()));
+            }
             return Ok(Resolution::NeedsConsent {
                 alias: alias.to_string(),
                 stored,
@@ -313,9 +319,7 @@ fn resolve_target_alias(
     // another one. Refreshing that profile keeps a re-login stable and avoids a
     // second profile for one account, which is what makes ownership ambiguous
     // later. A store that cannot be scanned is not an answer of "no".
-    match profile::existing_seat(paths, incoming_account, incoming_user)
-        .context("could not check whether this account is already saved")?
-    {
+    match seat {
         profile::ExistingSeat::One(existing) => return Ok(Resolution::Ready(existing)),
         profile::ExistingSeat::Ambiguous(aliases) => {
             // Naming one of the duplicates is refreshing it, not adding to them.
@@ -850,6 +854,54 @@ mod tests {
             aliases,
             vec!["amir@sawmills.ai"],
             "one account was forked across two profiles"
+        );
+    }
+
+    /// The reuse check must not depend on the requested alias being empty.
+    ///
+    /// An alias whose occupant cannot be identified is a question, and answering
+    /// it replaces that occupant — but if the arriving account is already saved
+    /// elsewhere, replacing anything forks it. Adoption consent is permission to
+    /// overwrite an unidentifiable profile, not permission to make a second copy
+    /// of an account the store can already point to.
+    #[test]
+    fn run_from_reuses_a_saved_seat_over_an_unprovable_occupant() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let stored = encode(claims);
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "real", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // A profile nothing can identify: unreadable credentials, no claims.
+        let damaged = paths.profiles_dir().join("damaged");
+        std::fs::create_dir_all(&damaged).unwrap();
+        std::fs::write(damaged.join("auth.json"), "{ not json").unwrap();
+        std::fs::write(
+            damaged.join("meta.json"),
+            r#"{"alias":"damaged","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let refreshed = encode(claims).replace(".sig", ".sig2");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        // Even with adoption pre-approved, the account is already saved.
+        let saved = run_from_with_consent(&paths, "damaged", None, true, &mut runner).unwrap();
+
+        assert_eq!(saved, "real", "the login forked an already-saved account");
+        assert_eq!(
+            std::fs::read_to_string(damaged.join("auth.json")).unwrap(),
+            "{ not json",
+            "the unidentifiable profile was replaced anyway"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -321,12 +321,14 @@ fn resolve_target_alias(
             profile::ExistingSeat::One(existing) if existing != alias => {
                 return Ok(Resolution::Ready(existing.clone()));
             }
-            // Already saved more than once. Nothing here is permission to add a
-            // third copy.
+            // Already saved more than once. Nothing here is permission to add
+            // a third copy — and naming one of them is not permission either,
+            // because reaching this branch means the requested alias holds
+            // something this account cannot be matched to. Membership in the
+            // set proves only that the credential is stored there, which for an
+            // exact-token match can mean a profile for another workspace
+            // entirely.
             profile::ExistingSeat::Ambiguous(aliases) => {
-                if aliases.iter().any(|existing| existing == alias) {
-                    return Ok(Resolution::Ready(alias.to_string()));
-                }
                 bail!(
                     "this account is already saved under more than one alias ({}). \
                      Remove the duplicates, or log in with one of them directly.",
@@ -360,10 +362,10 @@ fn resolve_target_alias(
     match seat {
         profile::ExistingSeat::One(existing) => return Ok(Resolution::Ready(existing)),
         profile::ExistingSeat::Ambiguous(aliases) => {
-            // Naming one of the duplicates is refreshing it, not adding to them.
-            if aliases.iter().any(|existing| existing == alias) {
-                return Ok(Resolution::Ready(alias.to_string()));
-            }
+            // Naming one of them is not refreshing it here: the requested alias
+            // holds something this account cannot be matched to, so membership
+            // says only that the credential is stored there — which for an
+            // exact-token match can mean a profile for another workspace.
             bail!(
                 "this account is already saved under more than one alias ({}). \
                  Remove the duplicates, or log in with one of them directly.",
@@ -1142,6 +1144,58 @@ mod tests {
         assert!(
             kept.contains("acct-a"),
             "the first workspace's profile was overwritten: {kept}"
+        );
+    }
+
+    /// Being listed among the holders of a credential is not proof of owning
+    /// the arriving account. One token stored for two workspaces makes every
+    /// holder ambiguous, so naming one of them must not be read as refreshing
+    /// it — that would overwrite a profile for another workspace outright,
+    /// past the conflict that proves it is another workspace.
+    #[test]
+    fn membership_in_an_ambiguous_holder_set_is_not_ownership() {
+        let (_tmp, paths) = setup_test_env();
+        let shared = "opaque-not-a-jwt";
+        for (alias, workspace) in [("acct-a-profile", "acct-a"), ("acct-b-profile", "acct-b")] {
+            let dir = paths.profiles_dir().join(alias);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("auth.json"),
+                format!(r#"{{"access_token":"{shared}","account_id":"{workspace}"}}"#),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("meta.json"),
+                format!(
+                    r#"{{"alias":"{alias}","email":null,"plan":null,"account_id":"{workspace}","saved_at":"2026-01-01T00:00:00Z"}}"#
+                ),
+            )
+            .unwrap();
+        }
+
+        // The same token arriving for a third workspace.
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{shared}","account_id":"acct-c"}}"#
+        ));
+
+        let error =
+            run_from_with_consent(&paths, "acct-a-profile", None, true, &mut runner).unwrap_err();
+
+        assert!(
+            error.to_string().contains("more than one alias")
+                || error.to_string().contains("different account"),
+            "unhelpful refusal: {error}"
+        );
+        let kept = std::fs::read_to_string(
+            paths
+                .profiles_dir()
+                .join("acct-a-profile")
+                .join("auth.json"),
+        )
+        .unwrap();
+        assert!(
+            kept.contains("acct-a"),
+            "a profile for another workspace was overwritten: {kept}"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -288,32 +288,36 @@ fn resolve_target_alias(
     let stored = conflict.stored().map(str::to_string);
 
     let Some(label) = label else {
+        // Wherever this account is already saved, that profile is where the
+        // login belongs — whatever the requested alias turned out to hold.
+        // Consent to replace an unidentifiable profile is not permission to make
+        // a second copy of an account the store can already point to, and a
+        // proven conflict on the requested alias is no reason to fail either:
+        // the browser login has already refreshed this grant, so stopping here
+        // discards the new token and leaves the saved profile holding the one
+        // this login just revoked.
+        match &seat {
+            profile::ExistingSeat::One(existing) if existing != alias => {
+                return Ok(Resolution::Ready(existing.clone()));
+            }
+            // Already saved more than once. Nothing here is permission to add a
+            // third copy.
+            profile::ExistingSeat::Ambiguous(aliases) => {
+                if aliases.iter().any(|existing| existing == alias) {
+                    return Ok(Resolution::Ready(alias.to_string()));
+                }
+                bail!(
+                    "this account is already saved under more than one alias ({}). \
+                     Remove the duplicates, or log in with one of them directly.",
+                    aliases.join(", ")
+                )
+            }
+            _ => {}
+        }
         // A claim that positively disagrees is never this account, so no answer
         // could make replacing it right. One that simply cannot be compared is a
         // question, and the operator is the only one who can answer it.
         let profile::AccountConflict::Different(different) = &conflict else {
-            // Adoption consent is permission to replace a profile nothing can
-            // identify. It is not permission to make a second copy of an
-            // account the store can already point to, so a saved seat wins
-            // over the question rather than being asked around.
-            match &seat {
-                profile::ExistingSeat::One(existing) if existing != alias => {
-                    return Ok(Resolution::Ready(existing.clone()));
-                }
-                // Already saved more than once. Consent to replace an
-                // unidentifiable profile is not consent to add a third copy.
-                profile::ExistingSeat::Ambiguous(aliases) => {
-                    if aliases.iter().any(|existing| existing == alias) {
-                        return Ok(Resolution::Ready(alias.to_string()));
-                    }
-                    bail!(
-                        "this account is already saved under more than one alias ({}). \
-                         Remove the duplicates, or log in with one of them directly.",
-                        aliases.join(", ")
-                    )
-                }
-                _ => {}
-            }
             return Ok(Resolution::NeedsConsent {
                 alias: alias.to_string(),
                 stored,
@@ -962,6 +966,59 @@ mod tests {
             std::fs::read_to_string(damaged.join("auth.json")).unwrap(),
             "{ not json",
             "the damaged profile was replaced"
+        );
+    }
+
+    /// The requested alias holds a proven different account, and this account
+    /// is saved elsewhere. Failing here would be worse than useless: the
+    /// browser login has already run and revoked the grant the saved profile
+    /// holds, and the fresh token then goes in the bin with the isolated home.
+    #[test]
+    fn run_from_saves_to_the_known_seat_when_the_named_alias_holds_another() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let mine = encode(claims);
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{mine}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // A different account occupies the alias about to be typed.
+        let other = encode(
+            r#"{"sub":"seatB","https://api.openai.com/auth":{"chatgpt_account_id":"acct-personal","chatgpt_user_id":"user-b"}}"#,
+        );
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{other}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "personal", None, &paths.codex_auth_json().clone())
+            .unwrap();
+
+        let refreshed = encode(claims).replace(".sig", ".sig2");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let saved = run_from(&paths, "personal", None, &mut runner).unwrap();
+
+        assert_eq!(saved, "team", "the refreshed credential was discarded");
+        assert!(
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("auth.json"))
+                .unwrap()
+                .contains(&refreshed),
+            "the known seat did not receive its refreshed token"
+        );
+        assert!(
+            std::fs::read_to_string(paths.profiles_dir().join("personal").join("auth.json"))
+                .unwrap()
+                .contains(&other),
+            "the unrelated profile was overwritten"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -269,15 +269,21 @@ fn resolve_target_alias(
     // for. Saving a second copy forks it, which every later lookup reports as
     // ambiguous — and the fresh login revokes the older grant server-side,
     // leaving the duplicate dead as well as confusing.
-    let mut seat = profile::existing_seat(paths, incoming_account, incoming_user)
-        .context("could not check whether this account is already saved")?;
-    // A device login can return an opaque or pre-claims credential, which offers
-    // the lookup above nothing to match on. Being byte-identical to one already
-    // stored still proves whose it is.
-    if matches!(seat, profile::ExistingSeat::None) {
-        seat = profile::exact_token_seat(paths, incoming_auth)
-            .context("could not check which profile holds this credential")?;
-    }
+    // An exact access token decides ownership on its own; claims are what a
+    // *rotated* credential has to fall back on. Asking the weaker question first
+    // and only consulting the stronger one when it came up empty inverts that:
+    // two profiles carrying the same claims read as ambiguous even when just one
+    // of them holds the credential that arrived, and the login is refused or
+    // written to the wrong one.
+    let seat = match profile::exact_token_seat(paths, incoming_auth)
+        .context("could not check which profile holds this credential")?
+    {
+        profile::ExistingSeat::None => {
+            profile::existing_seat(paths, incoming_account, incoming_user)
+                .context("could not check whether this account is already saved")?
+        }
+        exact => exact,
+    };
 
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
     let Some(conflict) = conflict else {
@@ -1196,6 +1202,47 @@ mod tests {
         assert!(
             kept.contains("acct-a"),
             "a profile for another workspace was overwritten: {kept}"
+        );
+    }
+
+    /// An exact access token decides ownership on its own. Two profiles can
+    /// carry the same claims while only one holds the credential that arrived —
+    /// asking the claims first reads that as ambiguous and either refuses a
+    /// resolvable login or refreshes the wrong copy.
+    #[test]
+    fn exact_token_ownership_outranks_ambiguous_claims() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let held = encode(claims);
+        let other = encode(claims).replace(".sig", ".sig-other");
+
+        // Both profiles claim the same account; only `holder` has the token.
+        for (alias, token) in [("holder", &held), ("twin", &other)] {
+            std::fs::write(
+                paths.codex_auth_json(),
+                format!(r#"{{"access_token":"{token}"}}"#),
+            )
+            .unwrap();
+            profile::save_profile_to(&paths, alias, None, &paths.codex_auth_json().clone())
+                .unwrap();
+        }
+
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{held}"}}"#));
+
+        let saved = run_from(&paths, "fresh-alias", None, &mut runner).unwrap();
+
+        assert_eq!(
+            saved, "holder",
+            "claims ambiguity hid the profile that actually holds this credential"
+        );
+        assert!(
+            !paths.profiles_dir().join("fresh-alias").exists(),
+            "a resolvable login created a new profile"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -324,17 +324,22 @@ fn resolve_target_alias(
         // discards the new token and leaves the saved profile holding the one
         // this login just revoked.
         match &seat {
-            profile::ExistingSeat::One(existing) if existing != alias => {
+            // Conclusive, including when it names the alias that was asked for:
+            // reaching here only means the *claims* could not settle it, and an
+            // exact token does not need them to. Falling through would demand
+            // consent to overwrite a profile with its own credential, and refuse
+            // outright where nobody can answer.
+            profile::ExistingSeat::One(existing) => {
                 return Ok(Resolution::Ready(existing.clone()));
             }
-            // Already saved more than once. Nothing here is permission to add
-            // a third copy — and naming one of them is not permission either,
-            // because reaching this branch means the requested alias holds
-            // something this account cannot be matched to. Membership in the
-            // set proves only that the credential is stored there, which for an
-            // exact-token match can mean a profile for another workspace
-            // entirely.
-            profile::ExistingSeat::Ambiguous(aliases) => {
+            // Held under several aliases, so nothing here permits a third copy.
+            // Naming one of them is different: replacing that profile adds
+            // nothing. It falls through to the ordinary handling below, where a
+            // proven conflict still fails and an unprovable one is asked about —
+            // rather than being refused with `remove` as its only way forward.
+            profile::ExistingSeat::Ambiguous(aliases)
+                if !aliases.iter().any(|existing| existing == alias) =>
+            {
                 bail!(
                     "this account is already saved under more than one alias ({}). \
                      Remove the duplicates, or log in with one of them directly.",
@@ -1243,6 +1248,82 @@ mod tests {
         assert!(
             !paths.profiles_dir().join("fresh-alias").exists(),
             "a resolvable login created a new profile"
+        );
+    }
+
+    /// A profile refreshing its own credential must not be asked to approve
+    /// replacing itself. The claims cannot settle it when only one side names a
+    /// workspace, but the token is identical — and an unattended run would fail
+    /// and throw away a login that already completed.
+    #[test]
+    fn an_exact_token_settles_the_alias_that_was_asked_for() {
+        let (_tmp, paths) = setup_test_env();
+        let shared = "opaque-not-a-jwt";
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{shared}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "real", None, &paths.codex_auth_json().clone()).unwrap();
+
+        // The same token, now naming a workspace the stored copy never did.
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{shared}","account_id":"acct-a"}}"#
+        ));
+
+        // No approval available, and none should be needed.
+        let saved = run_from(&paths, "real", None, &mut runner).unwrap();
+
+        assert_eq!(saved, "real");
+        assert!(
+            std::fs::read_to_string(paths.profiles_dir().join("real").join("auth.json"))
+                .unwrap()
+                .contains("acct-a"),
+            "the profile did not take its own refreshed credential"
+        );
+    }
+
+    /// Naming one of several holders is not adding a copy — replacing it leaves
+    /// the same number of profiles. Refusing outright would leave `remove` as
+    /// the only way forward, which is the shape this design exists to avoid.
+    #[test]
+    fn a_named_ambiguous_holder_can_still_be_adopted() {
+        let (_tmp, paths) = setup_test_env();
+        let shared = "opaque-not-a-jwt";
+        let write = |alias: &str, account: Option<&str>| {
+            let dir = paths.profiles_dir().join(alias);
+            std::fs::create_dir_all(&dir).unwrap();
+            let field = account
+                .map(|a| format!(r#","account_id":"{a}""#))
+                .unwrap_or_default();
+            std::fs::write(
+                dir.join("auth.json"),
+                format!(r#"{{"access_token":"{shared}"{field}}}"#),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("meta.json"),
+                format!(
+                    r#"{{"alias":"{alias}","email":null,"plan":null{field},"saved_at":"2026-01-01T00:00:00Z"}}"#
+                ),
+            )
+            .unwrap();
+        };
+        write("claimless", None);
+        write("other", Some("acct-b"));
+
+        let mut runner = FakeLoginRunner::new(&format!(
+            r#"{{"access_token":"{shared}","account_id":"acct-c"}}"#
+        ));
+
+        let saved = run_from_with_consent(&paths, "claimless", None, true, &mut runner).unwrap();
+
+        assert_eq!(saved, "claimless");
+        assert!(
+            std::fs::read_to_string(paths.profiles_dir().join("other").join("auth.json"))
+                .unwrap()
+                .contains("acct-b"),
+            "the other holder was touched"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -126,7 +126,14 @@ fn run_from_with_consent(
         // concurrent login change the answer before the write lands.
         let lock = store::lock(paths)?;
         let resolve = |_: &store::StoreLock| {
-            resolve_target_alias(paths, alias, label, incoming.as_deref(), &incoming_user)
+            resolve_target_alias(
+                paths,
+                alias,
+                label,
+                incoming.as_deref(),
+                &incoming_user,
+                &auth_path,
+            )
         };
         let (lock, target) = match resolve(&lock)? {
             Resolution::Ready(target) => (lock, target),
@@ -254,6 +261,7 @@ fn resolve_target_alias(
     label: Option<&str>,
     incoming_account: Option<&str>,
     incoming_user: &api::Logins,
+    incoming_auth: &Path,
 ) -> Result<Resolution> {
     // Where this account already lives, if anywhere. Consulted before every
     // decision below rather than only when the requested alias is empty: the
@@ -261,8 +269,15 @@ fn resolve_target_alias(
     // for. Saving a second copy forks it, which every later lookup reports as
     // ambiguous — and the fresh login revokes the older grant server-side,
     // leaving the duplicate dead as well as confusing.
-    let seat = profile::existing_seat(paths, incoming_account, incoming_user)
+    let mut seat = profile::existing_seat(paths, incoming_account, incoming_user)
         .context("could not check whether this account is already saved")?;
+    // A device login can return an opaque or pre-claims credential, which offers
+    // the lookup above nothing to match on. Being byte-identical to one already
+    // stored still proves whose it is.
+    if matches!(seat, profile::ExistingSeat::None) {
+        seat = profile::exact_token_seat(paths, incoming_auth)
+            .context("could not check which profile holds this credential")?;
+    }
 
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
     let Some(conflict) = conflict else {
@@ -1060,6 +1075,31 @@ mod tests {
         assert!(
             !meta.contains("personal@example.com"),
             "the requested alias was recorded as another account's address: {meta}"
+        );
+    }
+
+    /// A device login can return an opaque or pre-claims credential, which the
+    /// claim-based seat lookup cannot match. Byte-identical to one already
+    /// stored still proves whose it is, and without consulting that the login
+    /// writes a second profile for the same credential.
+    #[test]
+    fn run_from_reuses_a_saved_seat_for_an_identical_opaque_credential() {
+        let (_tmp, paths) = setup_test_env();
+        let opaque = r#"{"access_token":"opaque-not-a-jwt"}"#;
+        std::fs::write(paths.codex_auth_json(), opaque).unwrap();
+        profile::save_profile_to(&paths, "real", None, &paths.codex_auth_json().clone()).unwrap();
+
+        let mut runner = FakeLoginRunner::new(opaque);
+
+        let saved = run_from(&paths, "typo", None, &mut runner).unwrap();
+
+        assert_eq!(
+            saved, "real",
+            "an identical credential forked a new profile"
+        );
+        assert!(
+            !paths.profiles_dir().join("typo").exists(),
+            "a second profile was created for one credential"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -251,33 +251,37 @@ fn resolve_target_alias(
 ) -> Result<Resolution> {
     let conflict = profile::conflicting_workspace(paths, alias, incoming_account, incoming_user);
     let Some(conflict) = conflict else {
-        // The requested alias is usable. When a label was given, this seat may
-        // still be saved under a label-derived alias from an earlier run — and
-        // saving it here too would fork one account across two profiles, which
-        // is what makes ownership ambiguous later.
-        if label.is_some() {
-            match profile::existing_seat(paths, incoming_account, incoming_user)
-                .context("could not check whether this account is already saved")?
-            {
-                profile::ExistingSeat::One(existing) if existing != alias => {
-                    return Ok(Resolution::Ready(existing));
-                }
-                // Already ambiguous. A free alias is room for a third copy,
-                // not permission to make one — unless the operator named one of
-                // the duplicates, which is refreshing an existing profile and
-                // the very remedy this error recommends.
-                profile::ExistingSeat::Ambiguous(aliases) => {
-                    if aliases.iter().any(|existing| existing == alias) {
-                        return Ok(Resolution::Ready(alias.to_string()));
-                    }
-                    bail!(
-                        "this account is already saved under more than one alias ({}). \
-                         Remove the duplicates, or log in with one of them directly.",
-                        aliases.join(", ")
-                    )
-                }
-                _ => {}
+        // The requested alias is usable, but this seat may already be saved
+        // under another one — and saving it here too would fork one account
+        // across two profiles, which is what makes ownership ambiguous later.
+        //
+        // Checked whatever the operator typed, label or not. The account
+        // identifies the profile; the alias is only the name reached for. A
+        // mistyped alias is free by definition, so gating this on anything the
+        // operator got right is gating it on the case that never needed it —
+        // and the fresh login revokes the older grant server-side, leaving the
+        // duplicate dead as well as confusing.
+        match profile::existing_seat(paths, incoming_account, incoming_user)
+            .context("could not check whether this account is already saved")?
+        {
+            profile::ExistingSeat::One(existing) if existing != alias => {
+                return Ok(Resolution::Ready(existing));
             }
+            // Already ambiguous. A free alias is room for a third copy,
+            // not permission to make one — unless the operator named one of
+            // the duplicates, which is refreshing an existing profile and
+            // the very remedy this error recommends.
+            profile::ExistingSeat::Ambiguous(aliases) => {
+                if aliases.iter().any(|existing| existing == alias) {
+                    return Ok(Resolution::Ready(alias.to_string()));
+                }
+                bail!(
+                    "this account is already saved under more than one alias ({}). \
+                     Remove the duplicates, or log in with one of them directly.",
+                    aliases.join(", ")
+                )
+            }
+            _ => {}
         }
         return Ok(Resolution::Ready(alias.to_string()));
     };
@@ -792,6 +796,60 @@ mod tests {
                 .unwrap()
                 .contains(legacy),
             "the live credential was replaced with an unreadable one"
+        );
+    }
+
+    /// A login to a free alias for an account that is already saved.
+    ///
+    /// A mistyped alias is the everyday way to reach this, and the alias being
+    /// free is exactly why nothing stops it. Saving here anyway forks one
+    /// account across two profiles, which every later lookup reports as
+    /// ambiguous — and the fresh login revokes the older profile's grant
+    /// server-side, so the duplicate left behind is dead as well as confusing.
+    /// The account is what identifies the profile, not the string typed for it.
+    #[test]
+    fn run_from_reuses_a_saved_seat_when_the_alias_is_a_typo() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let stored = encode(claims);
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{stored}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(
+            &paths,
+            "amir@sawmills.ai",
+            None,
+            &paths.codex_auth_json().clone(),
+        )
+        .unwrap();
+
+        // The same account signing in again, under a mistyped alias.
+        let refreshed = encode(claims).replace(".sig", ".sig2");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let saved = run_from(&paths, "amir@sawmils.ai", None, &mut runner).unwrap();
+
+        assert_eq!(
+            saved, "amir@sawmills.ai",
+            "a login for an already-saved account landed on a second alias"
+        );
+        let mut aliases: Vec<String> = std::fs::read_dir(paths.profiles_dir())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+        aliases.sort();
+        assert_eq!(
+            aliases,
+            vec!["amir@sawmills.ai"],
+            "one account was forked across two profiles"
         );
     }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -198,7 +198,13 @@ fn run_from_with_consent(
         let email = profile::get_profile_from(paths, &target)
             .ok()
             .and_then(|existing| existing.meta.email)
-            .or_else(|| email_from_alias(alias));
+            .or_else(|| {
+                // The requested alias is an address for the profile it names and
+                // no other. Resolution can redirect to the profile that already
+                // holds this account, and deriving from the alias there would
+                // stamp the name typed for one account onto another's profile.
+                (target == alias).then(|| email_from_alias(alias)).flatten()
+            });
         profile::save_profile_and_activate_locked(
             &lock,
             paths,
@@ -1019,6 +1025,41 @@ mod tests {
                 .unwrap()
                 .contains(&other),
             "the unrelated profile was overwritten"
+        );
+    }
+
+    /// The requested alias is an address for the profile it names and no other.
+    /// A redirect lands on a different profile, so deriving an address from that
+    /// alias would record one account's name against another's credentials.
+    #[test]
+    fn a_redirected_login_does_not_take_its_email_from_the_requested_alias() {
+        let (_tmp, paths) = setup_test_env();
+        use base64::Engine;
+        let encode = |claims: &str| {
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+        };
+        // No email claim anywhere, so only the alias could supply one.
+        let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+        let mine = encode(claims);
+        std::fs::write(
+            paths.codex_auth_json(),
+            format!(r#"{{"access_token":"{mine}"}}"#),
+        )
+        .unwrap();
+        profile::save_profile_to(&paths, "team", None, &paths.codex_auth_json().clone()).unwrap();
+
+        let refreshed = encode(claims).replace(".sig", ".sig2");
+        let mut runner = FakeLoginRunner::new(&format!(r#"{{"access_token":"{refreshed}"}}"#));
+
+        let saved = run_from(&paths, "personal@example.com", None, &mut runner).unwrap();
+
+        assert_eq!(saved, "team");
+        let meta =
+            std::fs::read_to_string(paths.profiles_dir().join("team").join("meta.json")).unwrap();
+        assert!(
+            !meta.contains("personal@example.com"),
+            "the requested alias was recorded as another account's address: {meta}"
         );
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -100,15 +100,11 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     // saved under a second alias — while being byte-identical to what the first
     // profile holds, which the store already treats as conclusive everywhere
     // else.
-    if let Some(owner) = profile::alias_for_auth_json_from(&paths, &auth_path)
-        .context("could not check which profile holds this credential")?
-        && owner != resolved_alias
-    {
-        anyhow::bail!(
-            "this credential is already saved as '{owner}'. Save to that alias instead: \
-             codexctl save {owner}"
-        );
-    }
+    refuse_a_duplicate_of(
+        &profile::exact_token_seat(&paths, &auth_path)
+            .context("could not check which profile holds this credential")?,
+        &resolved_alias,
+    )?;
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
@@ -272,6 +268,14 @@ fn save_verified_snapshot(
         }
         _ => {}
     }
+    // Repeated under the lock for the same reason as the seat check above, and
+    // against the snapshot rather than the live file, since that is what will be
+    // written.
+    refuse_a_duplicate_of(
+        &profile::exact_token_seat(paths, snapshot)
+            .context("could not check which profile holds this credential")?,
+        resolved_alias,
+    )?;
     if store::profile_dir(paths, resolved_alias)?.exists() {
         // Re-run under the lock against the store as it actually stands. An
         // adoption the operator already approved carries over; one that only
@@ -320,6 +324,26 @@ enum Adoption {
     /// has no way to decide. Only the operator can say whether replacing it is
     /// right, so this is a question rather than a refusal.
     AskOperator { stored: Option<String> },
+}
+
+/// Stop a credential already stored elsewhere from being saved again here.
+fn refuse_a_duplicate_of(seat: &profile::ExistingSeat, resolved_alias: &str) -> Result<()> {
+    match seat {
+        profile::ExistingSeat::One(owner) if owner != resolved_alias => anyhow::bail!(
+            "this credential is already saved as '{owner}'. Save to that alias instead: \
+             codexctl save {owner}"
+        ),
+        profile::ExistingSeat::Ambiguous(aliases)
+            if !aliases.iter().any(|owner| owner == resolved_alias) =>
+        {
+            anyhow::bail!(
+                "this credential is already saved under more than one alias ({}). \
+                 Remove the duplicates, or save to one of them directly.",
+                aliases.join(", ")
+            )
+        }
+        _ => Ok(()),
+    }
 }
 
 /// The address to keep when the arriving token names none.

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -106,7 +106,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     // what `list` and `whoami` show. Never kept across an adoption: there the
     // occupant is a different or unidentifiable account, and its address would
     // label the arriving credential as somebody else.
-    let mut established_email: Option<String> = None;
+    let mut keep_email: Option<String> = None;
     if existing.exists() {
         let adoption = classify_overwrite(
             &paths,
@@ -119,11 +119,15 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         // is being shown and agreeing to replace. Reading it afterwards would
         // silently adopt whatever landed there while they were deciding.
         let shown = adopt::stored_credentials(&existing);
+        let adoption_kind = match &adoption {
+            Adoption::Unneeded => Adoption::Unneeded,
+            Adoption::AskOperator { stored } => Adoption::AskOperator {
+                stored: stored.clone(),
+            },
+        };
         let approved = match adoption {
             Adoption::Unneeded => {
-                established_email = profile::get_profile_from(&paths, &resolved_alias)
-                    .ok()
-                    .and_then(|profile| profile.meta.email);
+                keep_email = established_email(&paths, &resolved_alias, &adoption_kind);
                 eprint!(
                     "profile '{}' already exists. Overwrite? [y/N] ",
                     resolved_alias
@@ -168,7 +172,7 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     // block every other codexctl process for as long as the operator takes to
     // answer. That makes the checks so far advisory, so they are re-run here
     // against the store as it actually stands at write time.
-    let email = email.or(established_email);
+    let email = email.or(keep_email);
 
     let lock = store::lock(&paths)?;
     // Everything above was decided from the auth file as it read at the start,
@@ -304,6 +308,20 @@ enum Adoption {
     /// has no way to decide. Only the operator can say whether replacing it is
     /// right, so this is a question rather than a refusal.
     AskOperator { stored: Option<String> },
+}
+
+/// The address to keep when the arriving token names none.
+///
+/// Only a profile settled as this same account has an address worth keeping.
+/// Across an adoption the occupant is a different or unidentifiable account, and
+/// its address would label the arriving credential as somebody else.
+fn established_email(paths: &config::Paths, alias: &str, adoption: &Adoption) -> Option<String> {
+    match adoption {
+        Adoption::Unneeded => profile::get_profile_from(paths, alias)
+            .ok()
+            .and_then(|profile| profile.meta.email),
+        Adoption::AskOperator { .. } => None,
+    }
 }
 
 /// Decide how the target profile stands against the account being saved.
@@ -497,6 +515,28 @@ mod tests {
         assert!(
             stored(&paths).contains(&token("legacy")),
             "the duplicate was written anyway"
+        );
+    }
+
+    /// The address a profile established survives a token that names none —
+    /// but only where the profile is settled as this same account.
+    #[test]
+    fn an_established_email_is_kept_only_without_an_adoption() {
+        let (_tmp, paths, _snapshot) = setup(&token("stored"));
+        std::fs::write(
+            paths.profiles_dir().join("work").join("meta.json"),
+            r#"{"alias":"work","email":"amir@sawmills.ai","plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            established_email(&paths, "work", &Adoption::Unneeded).as_deref(),
+            Some("amir@sawmills.ai")
+        );
+        assert_eq!(
+            established_email(&paths, "work", &Adoption::AskOperator { stored: None }),
+            None,
+            "an adopted account inherited the old occupant's address"
         );
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -73,7 +73,19 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     )
     .context("could not check whether this account is already saved")?
     {
-        profile::ExistingSeat::One(saved) if saved != resolved_alias => saved,
+        profile::ExistingSeat::One(saved) if saved != resolved_alias => {
+            // The redirect writes to a profile the operator did not name, so it
+            // must not undo a newer login that profile already holds.
+            if profile::write_would_regress(&paths, &saved, &auth_path) {
+                anyhow::bail!(
+                    "this account is saved as '{saved}', which holds a newer credential than \
+                     {}. Saving would undo it; switch to '{saved}' and save from there, or \
+                     remove it first.",
+                    auth_path.display()
+                );
+            }
+            saved
+        }
         profile::ExistingSeat::Ambiguous(aliases)
             if !aliases.iter().any(|saved| saved == &resolved_alias) =>
         {
@@ -85,6 +97,16 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         }
         _ => resolved_alias,
     };
+
+    // A redirected save lands on a profile with its own established address.
+    // The token's claim still wins when it has one; this only stops the write
+    // rebuilding metadata with no email at all and erasing what `list` and
+    // `whoami` show.
+    let email = email.or_else(|| {
+        profile::get_profile_from(&paths, &resolved_alias)
+            .ok()
+            .and_then(|existing| existing.meta.email)
+    });
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
@@ -476,6 +498,46 @@ mod tests {
         assert!(
             stored(&paths).contains(&token("legacy")),
             "the duplicate was written anyway"
+        );
+    }
+
+    /// A redirect writes to a profile the operator did not name, so it must not
+    /// undo a newer login that profile already holds — the live file can be an
+    /// older copy of a seat a pinned run has since refreshed.
+    #[test]
+    fn write_would_regress_spots_an_older_live_copy() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_home(tmp.path().to_path_buf());
+        paths.ensure_dirs().unwrap();
+        let at = |iat: i64, jti: &str| {
+            use base64::Engine;
+            let claims = format!(
+                r#"{{"sub":"seatA","iat":{iat},"exp":{},"jti":"{jti}"}}"#,
+                iat + 3600
+            );
+            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+            format!("{JWT_HDR}.{payload}.sig")
+        };
+        let dir = paths.profiles_dir().join("real");
+        std::fs::create_dir_all(&dir).unwrap();
+        // The profile holds the newer token.
+        std::fs::write(dir.join("auth.json"), auth_bytes(&at(2000, "newer"))).unwrap();
+
+        let older = tmp.path().join("older.json");
+        let mut f = std::fs::File::create(&older).unwrap();
+        f.write_all(auth_bytes(&at(1000, "older")).as_bytes())
+            .unwrap();
+        assert!(
+            profile::write_would_regress(&paths, "real", &older),
+            "an older live copy was not recognised"
+        );
+
+        let newer = tmp.path().join("newer.json");
+        std::fs::write(&newer, auth_bytes(&at(3000, "newest"))).unwrap();
+        assert!(
+            !profile::write_would_regress(&paths, "real", &newer),
+            "a newer credential was refused"
         );
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -208,6 +208,33 @@ fn save_verified_snapshot(
              Re-run the command to save the account that is active now."
         );
     }
+    // The seat was resolved before the lock, because the prompt must not be held
+    // under it. A concurrent save can create the profile this one should have
+    // reused in that window, which would rebuild the duplicate this check
+    // exists to prevent. Refuse rather than redirect: the operator already
+    // answered about a specific profile, and this is not it.
+    match profile::existing_seat(
+        paths,
+        live_now.account_id.as_deref(),
+        &api::token_logins(&live_now.access_token),
+    )
+    .context("could not check whether this account is already saved")?
+    {
+        profile::ExistingSeat::One(saved) if saved != resolved_alias => anyhow::bail!(
+            "this account was saved as '{saved}' while this command was preparing. \
+             Re-run it to refresh that profile."
+        ),
+        profile::ExistingSeat::Ambiguous(aliases)
+            if !aliases.iter().any(|saved| saved == resolved_alias) =>
+        {
+            anyhow::bail!(
+                "this account is already saved under more than one alias ({}). \
+                 Remove the duplicates, or save to one of them directly.",
+                aliases.join(", ")
+            )
+        }
+        _ => {}
+    }
     if store::profile_dir(paths, resolved_alias)?.exists() {
         // Re-run under the lock against the store as it actually stands. An
         // adoption the operator already approved carries over; one that only
@@ -415,6 +442,40 @@ mod tests {
         assert!(
             stored(&paths).contains(&incoming),
             "the approved save did not land"
+        );
+    }
+
+    /// The seat is resolved before the lock, so a concurrent save can create
+    /// the profile this one should have reused while the prompt is open.
+    /// Writing anyway rebuilds the duplicate the reuse check exists to prevent.
+    #[test]
+    fn refuses_when_another_alias_took_this_account_first() {
+        let (_tmp, paths, snapshot) = setup(&token("legacy"));
+        let arriving = workspace_token("acct-team");
+        std::fs::write(&snapshot, auth_bytes(&arriving)).unwrap();
+
+        // A concurrent save landed this very account under another alias.
+        let other = paths.profiles_dir().join("winner");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(other.join("auth.json"), auth_bytes(&arriving)).unwrap();
+        std::fs::write(
+            other.join("meta.json"),
+            r#"{"alias":"winner","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let approved = Some(Some(auth_bytes(&token("legacy")).into_bytes()));
+        let lock = store::lock(&paths).unwrap();
+        let verified = api::read_auth_json(&snapshot).unwrap();
+        let error = save_verified_snapshot(
+            &lock, &paths, "work", None, None, &snapshot, &verified, true, approved, true,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("winner"), "{error}");
+        assert!(
+            stored(&paths).contains(&token("legacy")),
+            "the duplicate was written anyway"
         );
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -73,19 +73,16 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     )
     .context("could not check whether this account is already saved")?
     {
-        profile::ExistingSeat::One(saved) if saved != resolved_alias => {
-            // The redirect writes to a profile the operator did not name, so it
-            // must not undo a newer login that profile already holds.
-            if profile::write_would_regress(&paths, &saved, &auth_path) {
-                anyhow::bail!(
-                    "this account is saved as '{saved}', which holds a newer credential than \
-                     {}. Saving would undo it; switch to '{saved}' and save from there, or \
-                     remove it first.",
-                    auth_path.display()
-                );
-            }
-            saved
-        }
+        // Refused rather than redirected. Writing credentials into a profile
+        // the operator did not name means deciding on their behalf what to do
+        // about that profile's own state — whether its saved credential is
+        // newer than the live one, which address its metadata should keep,
+        // whether the approval they gave covers it. Naming the alias answers
+        // all of that at once, and the error says which alias to name.
+        profile::ExistingSeat::One(saved) if saved != resolved_alias => anyhow::bail!(
+            "this account is already saved as '{saved}'. Save to that alias instead: \
+             codexctl save {saved}"
+        ),
         profile::ExistingSeat::Ambiguous(aliases)
             if !aliases.iter().any(|saved| saved == &resolved_alias) =>
         {
@@ -97,16 +94,6 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         }
         _ => resolved_alias,
     };
-
-    // A redirected save lands on a profile with its own established address.
-    // The token's claim still wins when it has one; this only stops the write
-    // rebuilding metadata with no email at all and erasing what `list` and
-    // `whoami` show.
-    let email = email.or_else(|| {
-        profile::get_profile_from(&paths, &resolved_alias)
-            .ok()
-            .and_then(|existing| existing.meta.email)
-    });
 
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
@@ -498,46 +485,6 @@ mod tests {
         assert!(
             stored(&paths).contains(&token("legacy")),
             "the duplicate was written anyway"
-        );
-    }
-
-    /// A redirect writes to a profile the operator did not name, so it must not
-    /// undo a newer login that profile already holds — the live file can be an
-    /// older copy of a seat a pinned run has since refreshed.
-    #[test]
-    fn write_would_regress_spots_an_older_live_copy() {
-        use std::io::Write;
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = Paths::from_home(tmp.path().to_path_buf());
-        paths.ensure_dirs().unwrap();
-        let at = |iat: i64, jti: &str| {
-            use base64::Engine;
-            let claims = format!(
-                r#"{{"sub":"seatA","iat":{iat},"exp":{},"jti":"{jti}"}}"#,
-                iat + 3600
-            );
-            let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
-            format!("{JWT_HDR}.{payload}.sig")
-        };
-        let dir = paths.profiles_dir().join("real");
-        std::fs::create_dir_all(&dir).unwrap();
-        // The profile holds the newer token.
-        std::fs::write(dir.join("auth.json"), auth_bytes(&at(2000, "newer"))).unwrap();
-
-        let older = tmp.path().join("older.json");
-        let mut f = std::fs::File::create(&older).unwrap();
-        f.write_all(auth_bytes(&at(1000, "older")).as_bytes())
-            .unwrap();
-        assert!(
-            profile::write_would_regress(&paths, "real", &older),
-            "an older live copy was not recognised"
-        );
-
-        let newer = tmp.path().join("newer.json");
-        std::fs::write(&newer, auth_bytes(&at(3000, "newest"))).unwrap();
-        assert!(
-            !profile::write_would_regress(&paths, "real", &newer),
-            "a newer credential was refused"
         );
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -62,6 +62,30 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         },
     };
 
+    // One account, one profile. If this account is already saved, refresh that
+    // profile rather than adding a second copy under whatever name was reached
+    // for — a mistyped alias is free by definition, and the fork it leaves is
+    // what every later lookup reports as ambiguous.
+    let resolved_alias = match profile::existing_seat(
+        &paths,
+        auth.account_id.as_deref(),
+        &api::token_logins(&auth.access_token),
+    )
+    .context("could not check whether this account is already saved")?
+    {
+        profile::ExistingSeat::One(saved) if saved != resolved_alias => saved,
+        profile::ExistingSeat::Ambiguous(aliases)
+            if !aliases.iter().any(|saved| saved == &resolved_alias) =>
+        {
+            anyhow::bail!(
+                "this account is already saved under more than one alias ({}). \
+                 Remove the duplicates, or save to one of them directly.",
+                aliases.join(", ")
+            )
+        }
+        _ => resolved_alias,
+    };
+
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
     // applied to some other credential that lands there while they answer.

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -100,6 +100,13 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     // applied to some other credential that lands there while they answer.
     let mut confirmed_state: Option<Option<Vec<u8>>> = None;
     let mut adoption_approved = false;
+    // An address the profile established, kept only when the profile is settled
+    // as this same account. A token carrying no email claim, with the `/me`
+    // lookup unavailable, would otherwise rebuild metadata with none and erase
+    // what `list` and `whoami` show. Never kept across an adoption: there the
+    // occupant is a different or unidentifiable account, and its address would
+    // label the arriving credential as somebody else.
+    let mut established_email: Option<String> = None;
     if existing.exists() {
         let adoption = classify_overwrite(
             &paths,
@@ -114,6 +121,9 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         let shown = adopt::stored_credentials(&existing);
         let approved = match adoption {
             Adoption::Unneeded => {
+                established_email = profile::get_profile_from(&paths, &resolved_alias)
+                    .ok()
+                    .and_then(|profile| profile.meta.email);
                 eprint!(
                     "profile '{}' already exists. Overwrite? [y/N] ",
                     resolved_alias
@@ -158,6 +168,8 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
     // block every other codexctl process for as long as the operator takes to
     // answer. That makes the checks so far advisory, so they are re-run here
     // against the store as it actually stands at write time.
+    let email = email.or(established_email);
+
     let lock = store::lock(&paths)?;
     // Everything above was decided from the auth file as it read at the start,
     // and `codexctl use` can rewrite that file while the prompt waits. The alias

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -80,8 +80,8 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         // whether the approval they gave covers it. Naming the alias answers
         // all of that at once, and the error says which alias to name.
         profile::ExistingSeat::One(saved) if saved != resolved_alias => anyhow::bail!(
-            "this account is already saved as '{saved}'. Save to that alias instead: \
-             codexctl save {saved}"
+            "this account is already saved as '{saved}'. Save to that alias instead: {}",
+            save_command_for(&saved)
         ),
         profile::ExistingSeat::Ambiguous(aliases)
             if !aliases.iter().any(|saved| saved == &resolved_alias) =>
@@ -326,12 +326,35 @@ enum Adoption {
     AskOperator { stored: Option<String> },
 }
 
+/// A `codexctl save` command the operator can actually paste.
+///
+/// `validate_alias` accepts spaces and shell metacharacters, and these messages
+/// name an alias the operator never typed — it was found in the store. Inserting
+/// it raw turns `team account` into two arguments, an alias containing shell
+/// syntax into something else entirely, and one starting with `-` into a flag.
+fn save_command_for(alias: &str) -> String {
+    let plain = !alias.is_empty()
+        && alias
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-' | '@' | '+'));
+    let quoted = if plain {
+        alias.to_string()
+    } else {
+        format!("'{}'", alias.replace('\'', r"'\''"))
+    };
+    if alias.starts_with('-') {
+        format!("codexctl save -- {quoted}")
+    } else {
+        format!("codexctl save {quoted}")
+    }
+}
+
 /// Stop a credential already stored elsewhere from being saved again here.
 fn refuse_a_duplicate_of(seat: &profile::ExistingSeat, resolved_alias: &str) -> Result<()> {
     match seat {
         profile::ExistingSeat::One(owner) if owner != resolved_alias => anyhow::bail!(
-            "this credential is already saved as '{owner}'. Save to that alias instead: \
-             codexctl save {owner}"
+            "this credential is already saved as '{owner}'. Save to that alias instead: {}",
+            save_command_for(owner)
         ),
         profile::ExistingSeat::Ambiguous(aliases)
             if !aliases.iter().any(|owner| owner == resolved_alias) =>
@@ -574,6 +597,23 @@ mod tests {
             None,
             "an adopted account inherited the old occupant's address"
         );
+    }
+
+    /// The alias in these messages came from the store, not from the operator,
+    /// and `validate_alias` accepts spaces, shell syntax and a leading dash.
+    #[test]
+    fn a_suggested_save_command_can_be_pasted() {
+        assert_eq!(
+            save_command_for("amir@sawmills.ai"),
+            "codexctl save amir@sawmills.ai"
+        );
+        assert_eq!(
+            save_command_for("team account"),
+            "codexctl save 'team account'"
+        );
+        assert_eq!(save_command_for("a;rm -rf b"), "codexctl save 'a;rm -rf b'");
+        assert_eq!(save_command_for("it's"), r"codexctl save 'it'\''s'");
+        assert_eq!(save_command_for("-weird"), "codexctl save -- -weird");
     }
 
     /// The operator approved replacing one credential. Another process replaced

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -95,6 +95,21 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         _ => resolved_alias,
     };
 
+    // Claims are not the only proof of ownership. An opaque or pre-claims token
+    // gives `existing_seat` nothing to match on, so the same credential could be
+    // saved under a second alias — while being byte-identical to what the first
+    // profile holds, which the store already treats as conclusive everywhere
+    // else.
+    if let Some(owner) = profile::alias_for_auth_json_from(&paths, &auth_path)
+        .context("could not check which profile holds this credential")?
+        && owner != resolved_alias
+    {
+        anyhow::bail!(
+            "this credential is already saved as '{owner}'. Save to that alias instead: \
+             codexctl save {owner}"
+        );
+    }
+
     let existing = store::profile_dir(&paths, &resolved_alias)?;
     // What the operator is agreeing to replace, so the approval cannot be
     // applied to some other credential that lands there while they answer.

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -119,15 +119,12 @@ pub fn run(alias: Option<&str>, label: Option<&str>, allow_adopt: bool) -> Resul
         // is being shown and agreeing to replace. Reading it afterwards would
         // silently adopt whatever landed there while they were deciding.
         let shown = adopt::stored_credentials(&existing);
-        let adoption_kind = match &adoption {
-            Adoption::Unneeded => Adoption::Unneeded,
-            Adoption::AskOperator { stored } => Adoption::AskOperator {
-                stored: stored.clone(),
-            },
-        };
+        // Decided here, once, for whichever way the overwrite goes — leaving it
+        // to one arm of the match below would make the rule the call site's
+        // rather than the rule's, and a later arm could quietly not apply it.
+        keep_email = established_email(&paths, &resolved_alias, &adoption);
         let approved = match adoption {
             Adoption::Unneeded => {
-                keep_email = established_email(&paths, &resolved_alias, &adoption_kind);
                 eprint!(
                     "profile '{}' already exists. Overwrite? [y/N] ",
                     resolved_alias

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1127,44 +1127,6 @@ pub fn alias_for_auth_json_with_hint(
 
 /// Whether captured credentials are worth writing over the saved profile.
 ///
-/// Whether writing `candidate` over `alias` would replace a newer credential.
-///
-/// `save` is an explicit act, so it may overwrite what a profile holds. But a
-/// redirected save writes to a profile the operator did not name, and the live
-/// file can be an older copy of a seat some pinned run has since refreshed —
-/// so the ordering capture already applies has to apply here too, or the
-/// redirect quietly destroys a newer grant.
-pub fn write_would_regress(paths: &Paths, alias: &str, candidate: &Path) -> bool {
-    let Ok(dir) = store::profile_dir(paths, alias) else {
-        return false;
-    };
-    let (Ok(incoming), Ok(stored)) = (
-        api::read_auth_json(candidate),
-        api::read_auth_json(&dir.join("auth.json")),
-    ) else {
-        return false;
-    };
-    if incoming.access_token == stored.access_token
-        && incoming.refresh_token == stored.refresh_token
-    {
-        return false;
-    }
-    if let (Some(incoming_iat), Some(stored_iat)) = (
-        api::token_issued_at(&incoming.access_token),
-        api::token_issued_at(&stored.access_token),
-    ) && incoming_iat != stored_iat
-    {
-        return incoming_iat < stored_iat;
-    }
-    match (
-        api::token_expiry(&incoming.access_token),
-        api::token_expiry(&stored.access_token),
-    ) {
-        (Some(incoming_exp), Some(stored_exp)) => incoming_exp < stored_exp,
-        _ => false,
-    }
-}
-
 /// Identical credentials are not worth a write. Otherwise the newer access
 /// token wins, judged by its issued-at claim and falling back to its expiry:
 /// an older snapshot carries an older refresh token too, so taking either would

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -460,6 +460,33 @@ fn identity_of_profile(
     )
 }
 
+/// Which profile holds this exact access token.
+///
+/// Claims are not the only proof of ownership, and an opaque or pre-claims
+/// credential offers no others — so without this a byte-identical token can be
+/// stored under a second alias. Reports ambiguity rather than collapsing it: two
+/// profiles already holding the token is a reason to refuse a third, not a
+/// reason to proceed as though none did.
+pub fn exact_token_seat(paths: &Paths, auth_json: &Path) -> Result<ExistingSeat> {
+    let Ok(target) = api::read_auth_json(auth_json) else {
+        return Ok(ExistingSeat::None);
+    };
+    let holders: Vec<String> = stored_aliases(paths)?
+        .into_iter()
+        .filter(|alias| {
+            store::profile_dir(paths, alias)
+                .ok()
+                .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
+                .is_some_and(|stored| stored.access_token == target.access_token)
+        })
+        .collect();
+    Ok(match holders.len() {
+        0 => ExistingSeat::None,
+        1 => ExistingSeat::One(holders.into_iter().next().expect("one holder")),
+        _ => ExistingSeat::Ambiguous(holders),
+    })
+}
+
 pub fn existing_seat(
     paths: &Paths,
     workspace: Option<&str>,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -474,10 +474,20 @@ pub fn exact_token_seat(paths: &Paths, auth_json: &Path) -> Result<ExistingSeat>
     let holders: Vec<String> = stored_aliases(paths)?
         .into_iter()
         .filter(|alias| {
-            store::profile_dir(paths, alias)
+            let holds = store::profile_dir(paths, alias)
                 .ok()
                 .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
-                .is_some_and(|stored| stored.access_token == target.access_token)
+                .is_some_and(|stored| stored.access_token == target.access_token);
+            // Holding the token is not the whole answer. One access token can
+            // name two workspaces through an explicit `account_id`, so a holder
+            // declaring a different one is a different account — and redirecting
+            // there would overwrite it with credentials for another workspace.
+            // The same rule `strongest_exact_match` applies to attribution.
+            holds
+                && !workspace_contradicts(
+                    target.account_id.as_deref(),
+                    workspace_of_profile(paths, alias).as_deref(),
+                )
         })
         .collect();
     Ok(match holders.len() {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1127,6 +1127,44 @@ pub fn alias_for_auth_json_with_hint(
 
 /// Whether captured credentials are worth writing over the saved profile.
 ///
+/// Whether writing `candidate` over `alias` would replace a newer credential.
+///
+/// `save` is an explicit act, so it may overwrite what a profile holds. But a
+/// redirected save writes to a profile the operator did not name, and the live
+/// file can be an older copy of a seat some pinned run has since refreshed —
+/// so the ordering capture already applies has to apply here too, or the
+/// redirect quietly destroys a newer grant.
+pub fn write_would_regress(paths: &Paths, alias: &str, candidate: &Path) -> bool {
+    let Ok(dir) = store::profile_dir(paths, alias) else {
+        return false;
+    };
+    let (Ok(incoming), Ok(stored)) = (
+        api::read_auth_json(candidate),
+        api::read_auth_json(&dir.join("auth.json")),
+    ) else {
+        return false;
+    };
+    if incoming.access_token == stored.access_token
+        && incoming.refresh_token == stored.refresh_token
+    {
+        return false;
+    }
+    if let (Some(incoming_iat), Some(stored_iat)) = (
+        api::token_issued_at(&incoming.access_token),
+        api::token_issued_at(&stored.access_token),
+    ) && incoming_iat != stored_iat
+    {
+        return incoming_iat < stored_iat;
+    }
+    match (
+        api::token_expiry(&incoming.access_token),
+        api::token_expiry(&stored.access_token),
+    ) {
+        (Some(incoming_exp), Some(stored_exp)) => incoming_exp < stored_exp,
+        _ => false,
+    }
+}
+
 /// Identical credentials are not worth a write. Otherwise the newer access
 /// token wins, judged by its issued-at claim and falling back to its expiry:
 /// an older snapshot carries an older refresh token too, so taking either would

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -471,30 +471,74 @@ pub fn exact_token_seat(paths: &Paths, auth_json: &Path) -> Result<ExistingSeat>
     let Ok(target) = api::read_auth_json(auth_json) else {
         return Ok(ExistingSeat::None);
     };
-    let holders: Vec<String> = stored_aliases(paths)?
+    let holders: Vec<AliasWorkspace> = stored_aliases(paths)?
         .into_iter()
         .filter(|alias| {
-            let holds = store::profile_dir(paths, alias)
+            store::profile_dir(paths, alias)
                 .ok()
                 .and_then(|dir| api::read_auth_json(&dir.join("auth.json")).ok())
-                .is_some_and(|stored| stored.access_token == target.access_token);
-            // Holding the token is not the whole answer. One access token can
-            // name two workspaces through an explicit `account_id`, so a holder
-            // declaring a different one is a different account — and redirecting
-            // there would overwrite it with credentials for another workspace.
-            // The same rule `strongest_exact_match` applies to attribution.
-            holds
-                && !workspace_contradicts(
-                    target.account_id.as_deref(),
-                    workspace_of_profile(paths, alias).as_deref(),
-                )
+                .is_some_and(|stored| stored.access_token == target.access_token)
+        })
+        .map(|alias| {
+            let workspace = workspace_of_profile(paths, &alias);
+            (alias, workspace)
         })
         .collect();
-    Ok(match holders.len() {
-        0 => ExistingSeat::None,
-        1 => ExistingSeat::One(holders.into_iter().next().expect("one holder")),
-        _ => ExistingSeat::Ambiguous(holders),
-    })
+    Ok(exact_token_holder(target.account_id.as_deref(), &holders))
+}
+
+/// Weigh the whole holder set, the way `strongest_exact_match` does.
+///
+/// Judging holders one at a time gets this wrong in both directions. It can
+/// invent a sole owner — a claimless holder survives a filter that removes the
+/// holder proving the token spans workspaces, so an undecidable case looks
+/// settled — and it can discard the real one, when the arriving file declares no
+/// workspace and the only holder declares one.
+fn exact_token_holder(target_workspace: Option<&str>, holders: &[AliasWorkspace]) -> ExistingSeat {
+    if let [only] = holders {
+        // A lone holder of an identical token owns it. Only a workspace both
+        // sides declare *differently* rules it out.
+        let mismatch = matches!(
+            (target_workspace, only.1.as_deref()),
+            (Some(target), Some(stored)) if target != stored
+        );
+        return if mismatch {
+            ExistingSeat::None
+        } else {
+            ExistingSeat::One(only.0.clone())
+        };
+    }
+    let named = |set: Vec<&AliasWorkspace>| match set.len() {
+        0 => None,
+        1 => Some(ExistingSeat::One(set[0].0.clone())),
+        _ => Some(ExistingSeat::Ambiguous(
+            set.into_iter().map(|holder| holder.0.clone()).collect(),
+        )),
+    };
+    let declared: Vec<&AliasWorkspace> = holders
+        .iter()
+        .filter(|(_, workspace)| {
+            target_workspace.is_some() && workspace.as_deref() == target_workspace
+        })
+        .collect();
+    if let Some(seat) = named(declared) {
+        return seat;
+    }
+    // Nothing declares the target's workspace, and something declares another:
+    // the token demonstrably spans workspaces, so no holder is proven to own
+    // this one. Reported as ambiguous rather than absent — several profiles
+    // already hold this credential, which is a reason to refuse another copy.
+    if holders
+        .iter()
+        .any(|(_, workspace)| workspace_contradicts(target_workspace, workspace.as_deref()))
+    {
+        return ExistingSeat::Ambiguous(holders.iter().map(|holder| holder.0.clone()).collect());
+    }
+    let permitted: Vec<&AliasWorkspace> = holders
+        .iter()
+        .filter(|(_, workspace)| workspace_permits(target_workspace, workspace.as_deref()))
+        .collect();
+    named(permitted).unwrap_or(ExistingSeat::None)
 }
 
 pub fn existing_seat(

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -524,10 +524,25 @@ fn exact_token_holder(target_workspace: Option<&str>, holders: &[AliasWorkspace]
     if let Some(seat) = named(declared) {
         return seat;
     }
-    // Nothing declares the target's workspace, and something declares another:
-    // the token demonstrably spans workspaces, so no holder is proven to own
-    // this one. Reported as ambiguous rather than absent — several profiles
-    // already hold this credential, which is a reason to refuse another copy.
+    // Every holder naming some *other* workspace means none of them is this
+    // account. The token spans workspaces and this is simply another seat of
+    // it — which the lone-holder case above already allows, so refusing it here
+    // would block a workspace from being recorded at all once two others share
+    // the token.
+    if target_workspace.is_some()
+        && holders.iter().all(|(_, workspace)| {
+            workspace
+                .as_deref()
+                .is_some_and(|held| Some(held) != target_workspace)
+        })
+    {
+        return ExistingSeat::None;
+    }
+    // Something declares another workspace while something else could still be
+    // this account — a claimless holder beside a contradicting one. No holder is
+    // proven to own this credential, and reporting that as ambiguous rather than
+    // absent matters: several profiles already hold it, which is a reason to
+    // refuse another copy.
     if holders
         .iter()
         .any(|(_, workspace)| workspace_contradicts(target_workspace, workspace.as_deref()))

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -680,3 +680,46 @@ fn save_writes_the_right_email_when_the_token_names_none() {
         "an adopted account inherited the old occupant's address: {meta}"
     );
 }
+
+/// Claims are not the only proof of ownership. An opaque or pre-claims token
+/// gives the seat lookup nothing to match on, so without honouring the exact
+/// token the same credential lands under a second alias — the duplicate this
+/// whole change exists to prevent.
+#[test]
+fn save_refuses_a_second_alias_for_an_identical_opaque_credential() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    std::fs::create_dir_all(home.join(".codex")).unwrap();
+    std::fs::write(
+        home.join(".codex").join("auth.json"),
+        r#"{"access_token":"opaque-not-a-jwt"}"#,
+    )
+    .unwrap();
+
+    let save = |alias: &str| {
+        Command::cargo_bin("codexctl")
+            .unwrap()
+            .env("HOME", home)
+            .env("HTTPS_PROXY", "http://127.0.0.1:1")
+            .env("HTTP_PROXY", "http://127.0.0.1:1")
+            .env("ALL_PROXY", "http://127.0.0.1:1")
+            .args(["save", alias])
+            .write_stdin("y\n")
+            .output()
+            .unwrap()
+    };
+
+    assert!(save("alias-a").status.success());
+    let second = save("alias-b");
+    assert!(!second.status.success(), "{second:?}");
+    let stderr = String::from_utf8(second.stderr).unwrap();
+    assert!(stderr.contains("already saved as 'alias-a'"), "{stderr}");
+
+    let mut aliases: Vec<String> = std::fs::read_dir(home.join(".codexctl").join("profiles"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect();
+    aliases.sort();
+    assert_eq!(aliases, vec!["alias-a"], "one credential was saved twice");
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -546,8 +546,13 @@ fn save_requires_an_explicit_alias_to_pre_approve_adoption() {
 /// One account, one profile. A mistyped alias is free by definition, so nothing
 /// about the name stops a second copy being written — and the fork it leaves is
 /// what every later lookup reports as ambiguous.
+///
+/// `save` refuses rather than writing to the profile that holds the account:
+/// that profile has its own state — a possibly newer credential, its own
+/// recorded address — and deciding all of that on the operator's behalf is what
+/// naming the alias settles.
 #[test]
-fn save_reuses_the_profile_that_already_holds_this_account() {
+fn save_refuses_a_second_alias_for_an_account_it_already_holds() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
     std::fs::create_dir_all(home.join(".codex")).unwrap();
@@ -570,13 +575,20 @@ fn save_reuses_the_profile_that_already_holds_this_account() {
         .success();
 
     // The same account again, under a mistyped alias.
-    Command::cargo_bin("codexctl")
+    let output = Command::cargo_bin("codexctl")
         .unwrap()
         .env("HOME", home)
         .args(["save", "amir@sawmils.ai"])
         .write_stdin("y\n")
-        .assert()
-        .success();
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("already saved as 'amir@sawmills.ai'"),
+        "{stderr}"
+    );
 
     let mut aliases: Vec<String> = std::fs::read_dir(home.join(".codexctl").join("profiles"))
         .unwrap()
@@ -588,107 +600,5 @@ fn save_reuses_the_profile_that_already_holds_this_account() {
         aliases,
         vec!["amir@sawmills.ai"],
         "one account was saved twice under different aliases"
-    );
-}
-
-/// Review read a redirect as able to carry `--allow-adopt` onto a profile the
-/// operator never named. The two are mutually exclusive and this pins why: a
-/// redirect needs `existing_seat` to positively match both the workspace and
-/// the login, and that is exactly the state in which nothing needs adopting.
-/// If the preconditions ever stop excluding each other, this fails.
-#[test]
-fn a_redirect_never_carries_pre_approved_adoption() {
-    use base64::Engine;
-    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
-    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
-    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
-
-    // `real` is damaged but fully identified, so a redirect is possible.
-    let case = |meta: &str| {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path().to_path_buf();
-        std::fs::create_dir_all(home.join(".codex")).unwrap();
-        std::fs::write(
-            home.join(".codex").join("auth.json"),
-            format!(r#"{{"access_token":"{token}"}}"#),
-        )
-        .unwrap();
-        let real = home.join(".codexctl").join("profiles").join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        std::fs::write(real.join("auth.json"), "{ not json").unwrap();
-        std::fs::write(real.join("meta.json"), meta).unwrap();
-
-        let output = Command::cargo_bin("codexctl")
-            .unwrap()
-            .env("HOME", &home)
-            .args(["save", "typo", "--allow-adopt"])
-            .write_stdin("")
-            .output()
-            .unwrap();
-        let damaged = std::fs::read_to_string(real.join("auth.json")).unwrap();
-        (String::from_utf8_lossy(&output.stdout).to_string(), damaged)
-    };
-
-    // Identified on both halves: the save redirects to `real`, and because the
-    // account is settled it takes the ordinary overwrite prompt — the adoption
-    // flag never applies, so an unanswered prompt aborts.
-    let (out, damaged) = case(
-        r#"{"alias":"real","email":null,"plan":null,"account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
-    );
-    assert!(out.contains("aborted"), "{out}");
-    assert_eq!(damaged, "{ not json", "a redirect adopted without approval");
-
-    // Workspace only: adoption would be required, and precisely because the
-    // login cannot be matched there is no redirect to carry it.
-    let (_out, damaged) = case(
-        r#"{"alias":"real","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
-    );
-    assert_eq!(damaged, "{ not json", "an unidentified profile was adopted");
-}
-
-/// A redirected save lands on a profile with its own established address. The
-/// write rebuilds metadata, so without carrying that address forward it is
-/// erased from everything `list` and `whoami` show.
-#[test]
-fn a_redirected_save_keeps_the_profile_email() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
-    std::fs::create_dir_all(home.join(".codex")).unwrap();
-    // A token with no email claim, so nothing can re-derive the address.
-    use base64::Engine;
-    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
-    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
-    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
-    std::fs::write(
-        home.join(".codex").join("auth.json"),
-        format!(r#"{{"access_token":"{token}"}}"#),
-    )
-    .unwrap();
-
-    let real = home.join(".codexctl").join("profiles").join("real");
-    std::fs::create_dir_all(&real).unwrap();
-    std::fs::write(
-        real.join("auth.json"),
-        format!(r#"{{"access_token":"{token}"}}"#),
-    )
-    .unwrap();
-    std::fs::write(
-        real.join("meta.json"),
-        r#"{"alias":"real","email":"amir@sawmills.ai","plan":"team","account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
-    )
-    .unwrap();
-
-    Command::cargo_bin("codexctl")
-        .unwrap()
-        .env("HOME", home)
-        .args(["save", "typo"])
-        .write_stdin("y\n")
-        .assert()
-        .success();
-
-    let meta = std::fs::read_to_string(real.join("meta.json")).unwrap();
-    assert!(
-        meta.contains("amir@sawmills.ai"),
-        "the redirected save erased the profile's email: {meta}"
     );
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -557,7 +557,10 @@ fn save_refuses_a_second_alias_for_an_account_it_already_holds() {
     let home = tmp.path();
     std::fs::create_dir_all(home.join(".codex")).unwrap();
     use base64::Engine;
-    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+    // The email claim is present so `save` never falls back to the `/me`
+    // endpoint: a test that reaches the network is slow offline and depends on
+    // a service it is not trying to exercise.
+    let claims = r#"{"sub":"seatA","https://api.openai.com/profile":{"email":"amir@sawmills.ai"},"https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
     let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
     let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
     std::fs::write(
@@ -600,69 +603,5 @@ fn save_refuses_a_second_alias_for_an_account_it_already_holds() {
         aliases,
         vec!["amir@sawmills.ai"],
         "one account was saved twice under different aliases"
-    );
-}
-
-/// A token can carry no email claim, and the `/me` lookup is not always
-/// available. The write rebuilds metadata, so without keeping what the profile
-/// established, the address `list` and `whoami` show is erased.
-///
-/// Kept only when the profile is settled as this same account. Across an
-/// adoption the occupant is a different or unidentifiable account, and its
-/// address would label the arriving credential as somebody else.
-#[test]
-fn save_keeps_an_established_email_but_never_across_an_adoption() {
-    use base64::Engine;
-    let token = |account: &str, user: &str| {
-        let claims = format!(
-            r#"{{"sub":"seatA","https://api.openai.com/auth":{{"chatgpt_account_id":"{account}","chatgpt_user_id":"{user}"}}}}"#
-        );
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
-        format!("eyJhbGciOiJub25lIn0.{payload}.sig")
-    };
-
-    let run = |stored_auth: String, meta: &str, args: &[&str]| {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path().to_path_buf();
-        std::fs::create_dir_all(home.join(".codex")).unwrap();
-        std::fs::write(
-            home.join(".codex").join("auth.json"),
-            format!(r#"{{"access_token":"{}"}}"#, token("acct-team", "user-a")),
-        )
-        .unwrap();
-        let dir = home.join(".codexctl").join("profiles").join("real");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("auth.json"), stored_auth).unwrap();
-        std::fs::write(dir.join("meta.json"), meta).unwrap();
-        Command::cargo_bin("codexctl")
-            .unwrap()
-            .env("HOME", &home)
-            .args(args)
-            .write_stdin("y\n")
-            .output()
-            .unwrap();
-        std::fs::read_to_string(dir.join("meta.json")).unwrap()
-    };
-
-    // Same account, settled: the established address survives.
-    let meta = run(
-        format!(r#"{{"access_token":"{}"}}"#, token("acct-team", "user-a")),
-        r#"{"alias":"real","email":"amir@sawmills.ai","plan":"team","account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
-        &["save", "real"],
-    );
-    assert!(
-        meta.contains("amir@sawmills.ai"),
-        "email was erased: {meta}"
-    );
-
-    // Unidentifiable occupant, adopted: its address must not follow.
-    let meta = run(
-        "{ not json".to_string(),
-        r#"{"alias":"real","email":"someone-else@example.com","plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
-        &["save", "real", "--allow-adopt"],
-    );
-    assert!(
-        !meta.contains("someone-else@example.com"),
-        "an adopted account inherited the old occupant's address: {meta}"
     );
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -602,3 +602,67 @@ fn save_refuses_a_second_alias_for_an_account_it_already_holds() {
         "one account was saved twice under different aliases"
     );
 }
+
+/// A token can carry no email claim, and the `/me` lookup is not always
+/// available. The write rebuilds metadata, so without keeping what the profile
+/// established, the address `list` and `whoami` show is erased.
+///
+/// Kept only when the profile is settled as this same account. Across an
+/// adoption the occupant is a different or unidentifiable account, and its
+/// address would label the arriving credential as somebody else.
+#[test]
+fn save_keeps_an_established_email_but_never_across_an_adoption() {
+    use base64::Engine;
+    let token = |account: &str, user: &str| {
+        let claims = format!(
+            r#"{{"sub":"seatA","https://api.openai.com/auth":{{"chatgpt_account_id":"{account}","chatgpt_user_id":"{user}"}}}}"#
+        );
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+        format!("eyJhbGciOiJub25lIn0.{payload}.sig")
+    };
+
+    let run = |stored_auth: String, meta: &str, args: &[&str]| {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::write(
+            home.join(".codex").join("auth.json"),
+            format!(r#"{{"access_token":"{}"}}"#, token("acct-team", "user-a")),
+        )
+        .unwrap();
+        let dir = home.join(".codexctl").join("profiles").join("real");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), stored_auth).unwrap();
+        std::fs::write(dir.join("meta.json"), meta).unwrap();
+        Command::cargo_bin("codexctl")
+            .unwrap()
+            .env("HOME", &home)
+            .args(args)
+            .write_stdin("y\n")
+            .output()
+            .unwrap();
+        std::fs::read_to_string(dir.join("meta.json")).unwrap()
+    };
+
+    // Same account, settled: the established address survives.
+    let meta = run(
+        format!(r#"{{"access_token":"{}"}}"#, token("acct-team", "user-a")),
+        r#"{"alias":"real","email":"amir@sawmills.ai","plan":"team","account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
+        &["save", "real"],
+    );
+    assert!(
+        meta.contains("amir@sawmills.ai"),
+        "email was erased: {meta}"
+    );
+
+    // Unidentifiable occupant, adopted: its address must not follow.
+    let meta = run(
+        "{ not json".to_string(),
+        r#"{"alias":"real","email":"someone-else@example.com","plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        &["save", "real", "--allow-adopt"],
+    );
+    assert!(
+        !meta.contains("someone-else@example.com"),
+        "an adopted account inherited the old occupant's address: {meta}"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -590,3 +590,58 @@ fn save_reuses_the_profile_that_already_holds_this_account() {
         "one account was saved twice under different aliases"
     );
 }
+
+/// Review read a redirect as able to carry `--allow-adopt` onto a profile the
+/// operator never named. The two are mutually exclusive and this pins why: a
+/// redirect needs `existing_seat` to positively match both the workspace and
+/// the login, and that is exactly the state in which nothing needs adopting.
+/// If the preconditions ever stop excluding each other, this fails.
+#[test]
+fn a_redirect_never_carries_pre_approved_adoption() {
+    use base64::Engine;
+    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+
+    // `real` is damaged but fully identified, so a redirect is possible.
+    let case = |meta: &str| {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::write(
+            home.join(".codex").join("auth.json"),
+            format!(r#"{{"access_token":"{token}"}}"#),
+        )
+        .unwrap();
+        let real = home.join(".codexctl").join("profiles").join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::write(real.join("auth.json"), "{ not json").unwrap();
+        std::fs::write(real.join("meta.json"), meta).unwrap();
+
+        let output = Command::cargo_bin("codexctl")
+            .unwrap()
+            .env("HOME", &home)
+            .args(["save", "typo", "--allow-adopt"])
+            .write_stdin("")
+            .output()
+            .unwrap();
+        let damaged = std::fs::read_to_string(real.join("auth.json")).unwrap();
+        (String::from_utf8_lossy(&output.stdout).to_string(), damaged)
+    };
+
+    // Identified on both halves: the save redirects to `real`, and because the
+    // account is settled it takes the ordinary overwrite prompt — the adoption
+    // flag never applies, so an unanswered prompt aborts.
+    let (out, damaged) = case(
+        r#"{"alias":"real","email":null,"plan":null,"account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    assert!(out.contains("aborted"), "{out}");
+    assert_eq!(damaged, "{ not json", "a redirect adopted without approval");
+
+    // Workspace only: adoption would be required, and precisely because the
+    // login cannot be matched there is no redirect to carry it.
+    let (_out, damaged) = case(
+        r#"{"alias":"real","email":null,"plan":null,"account_id":"acct-team","saved_at":"2026-01-01T00:00:00Z"}"#,
+    );
+    assert_eq!(damaged, "{ not json", "an unidentified profile was adopted");
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -723,3 +723,51 @@ fn save_refuses_a_second_alias_for_an_identical_opaque_credential() {
     aliases.sort();
     assert_eq!(aliases, vec!["alias-a"], "one credential was saved twice");
 }
+
+/// Two profiles already holding one credential is a reason to refuse a third,
+/// not a reason to behave as though none held it. A lookup that reports "no
+/// single owner" for both cases loses exactly that distinction.
+#[test]
+fn save_refuses_a_third_alias_for_an_already_duplicated_credential() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    std::fs::create_dir_all(home.join(".codex")).unwrap();
+    let auth = r#"{"access_token":"opaque-not-a-jwt"}"#;
+    std::fs::write(home.join(".codex").join("auth.json"), auth).unwrap();
+    // Two aliases already hold it, as an older codexctl could leave them.
+    for alias in ["alias-a", "alias-b"] {
+        let dir = home.join(".codexctl").join("profiles").join(alias);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), auth).unwrap();
+        std::fs::write(
+            dir.join("meta.json"),
+            format!(
+                r#"{{"alias":"{alias}","email":null,"plan":null,"saved_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    let output = Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .env("HTTPS_PROXY", "http://127.0.0.1:1")
+        .env("HTTP_PROXY", "http://127.0.0.1:1")
+        .env("ALL_PROXY", "http://127.0.0.1:1")
+        .args(["save", "alias-c"])
+        .write_stdin("y\n")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("more than one alias"), "{stderr}");
+    assert!(
+        !home
+            .join(".codexctl")
+            .join("profiles")
+            .join("alias-c")
+            .exists(),
+        "a third copy was created"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -645,3 +645,50 @@ fn a_redirect_never_carries_pre_approved_adoption() {
     );
     assert_eq!(damaged, "{ not json", "an unidentified profile was adopted");
 }
+
+/// A redirected save lands on a profile with its own established address. The
+/// write rebuilds metadata, so without carrying that address forward it is
+/// erased from everything `list` and `whoami` show.
+#[test]
+fn a_redirected_save_keeps_the_profile_email() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    std::fs::create_dir_all(home.join(".codex")).unwrap();
+    // A token with no email claim, so nothing can re-derive the address.
+    use base64::Engine;
+    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+    std::fs::write(
+        home.join(".codex").join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+
+    let real = home.join(".codexctl").join("profiles").join("real");
+    std::fs::create_dir_all(&real).unwrap();
+    std::fs::write(
+        real.join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        real.join("meta.json"),
+        r#"{"alias":"real","email":"amir@sawmills.ai","plan":"team","account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(["save", "typo"])
+        .write_stdin("y\n")
+        .assert()
+        .success();
+
+    let meta = std::fs::read_to_string(real.join("meta.json")).unwrap();
+    assert!(
+        meta.contains("amir@sawmills.ai"),
+        "the redirected save erased the profile's email: {meta}"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -605,3 +605,68 @@ fn save_refuses_a_second_alias_for_an_account_it_already_holds() {
         "one account was saved twice under different aliases"
     );
 }
+
+/// End-to-end cover for what `save` writes into `meta.json` when the arriving
+/// token names no address: the profile's established one survives a same-account
+/// save, and never follows an adoption onto a different account.
+///
+/// The `/me` fallback is what makes this case reachable, so the proxy is pointed
+/// at a closed port: the lookup fails at once instead of reaching the real
+/// service, which would make the suite slow and dependent on it.
+#[test]
+fn save_writes_the_right_email_when_the_token_names_none() {
+    use base64::Engine;
+    // Deliberately no profile/email claim — that is the case under test.
+    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+
+    let run = |stored_auth: String, meta: &str, args: &[&str]| {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::write(
+            home.join(".codex").join("auth.json"),
+            format!(r#"{{"access_token":"{token}"}}"#),
+        )
+        .unwrap();
+        let dir = home.join(".codexctl").join("profiles").join("real");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("auth.json"), stored_auth).unwrap();
+        std::fs::write(dir.join("meta.json"), meta).unwrap();
+        Command::cargo_bin("codexctl")
+            .unwrap()
+            .env("HOME", &home)
+            .env("HTTPS_PROXY", "http://127.0.0.1:1")
+            .env("HTTP_PROXY", "http://127.0.0.1:1")
+            .env("ALL_PROXY", "http://127.0.0.1:1")
+            .args(args)
+            .write_stdin("y\n")
+            .output()
+            .unwrap();
+        std::fs::read_to_string(dir.join("meta.json")).unwrap()
+    };
+
+    // Settled as the same account: the established address survives the write.
+    let meta = run(
+        format!(r#"{{"access_token":"{token}"}}"#),
+        r#"{"alias":"real","email":"amir@sawmills.ai","plan":"team","account_id":"acct-team","user_id":"user-a","saved_at":"2026-01-01T00:00:00Z"}"#,
+        &["save", "real"],
+    );
+    assert!(
+        meta.contains("amir@sawmills.ai"),
+        "the established email was erased: {meta}"
+    );
+
+    // Adopted: the previous occupant cannot be shown to be this account, so its
+    // address must not label the arriving credential.
+    let meta = run(
+        "{ not json".to_string(),
+        r#"{"alias":"real","email":"someone-else@example.com","plan":null,"saved_at":"2026-01-01T00:00:00Z"}"#,
+        &["save", "real", "--allow-adopt"],
+    );
+    assert!(
+        !meta.contains("someone-else@example.com"),
+        "an adopted account inherited the old occupant's address: {meta}"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -634,7 +634,7 @@ fn save_writes_the_right_email_when_the_token_names_none() {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("auth.json"), stored_auth).unwrap();
         std::fs::write(dir.join("meta.json"), meta).unwrap();
-        Command::cargo_bin("codexctl")
+        let output = Command::cargo_bin("codexctl")
             .unwrap()
             .env("HOME", &home)
             .env("HTTPS_PROXY", "http://127.0.0.1:1")
@@ -644,6 +644,16 @@ fn save_writes_the_right_email_when_the_token_names_none() {
             .write_stdin("y\n")
             .output()
             .unwrap();
+        // Without this the assertions read a file the command never touched: the
+        // starting metadata already satisfies one of them, so a save that failed
+        // early would pass for the wrong reason.
+        assert!(output.status.success(), "{args:?} failed: {output:?}");
+        assert!(
+            std::fs::read_to_string(dir.join("auth.json"))
+                .unwrap()
+                .contains(&token),
+            "{args:?} did not write the credential"
+        );
         std::fs::read_to_string(dir.join("meta.json")).unwrap()
     };
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -542,3 +542,51 @@ fn save_requires_an_explicit_alias_to_pre_approve_adoption() {
         "{stderr}"
     );
 }
+
+/// One account, one profile. A mistyped alias is free by definition, so nothing
+/// about the name stops a second copy being written — and the fork it leaves is
+/// what every later lookup reports as ambiguous.
+#[test]
+fn save_reuses_the_profile_that_already_holds_this_account() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    std::fs::create_dir_all(home.join(".codex")).unwrap();
+    use base64::Engine;
+    let claims = r#"{"sub":"seatA","https://api.openai.com/auth":{"chatgpt_account_id":"acct-team","chatgpt_user_id":"user-a"}}"#;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims);
+    let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
+    std::fs::write(
+        home.join(".codex").join("auth.json"),
+        format!(r#"{{"access_token":"{token}"}}"#),
+    )
+    .unwrap();
+
+    Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(["save", "amir@sawmills.ai"])
+        .write_stdin("")
+        .assert()
+        .success();
+
+    // The same account again, under a mistyped alias.
+    Command::cargo_bin("codexctl")
+        .unwrap()
+        .env("HOME", home)
+        .args(["save", "amir@sawmils.ai"])
+        .write_stdin("y\n")
+        .assert()
+        .success();
+
+    let mut aliases: Vec<String> = std::fs::read_dir(home.join(".codexctl").join("profiles"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect();
+    aliases.sort();
+    assert_eq!(
+        aliases,
+        vec!["amir@sawmills.ai"],
+        "one account was saved twice under different aliases"
+    );
+}

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -2468,4 +2468,14 @@ fn exact_token_ownership_weighs_the_whole_holder_set() {
     );
     // Two copies with nothing to tell them apart stay ambiguous.
     assert_eq!(case(None, &[("a", None), ("b", None)]), "ambiguous:a,b");
+    // Every holder naming some other workspace means none of them is this
+    // account, so a seat for the arriving one can still be recorded — the same
+    // answer the lone-holder case gives.
+    assert_eq!(
+        case(
+            Some("acct-c"),
+            &[("a", Some("acct-a")), ("b", Some("acct-b"))]
+        ),
+        "none"
+    );
 }

--- a/tests/profile_test.rs
+++ b/tests/profile_test.rs
@@ -2395,3 +2395,77 @@ fn a_contested_live_workspace_is_not_inferred_onto_a_claimless_profile() {
         "an uncontested live workspace stopped identifying its own profile"
     );
 }
+
+/// Who owns an exact token, across the shapes two review rounds each got wrong
+/// in a different direction. Judging holders one at a time invents a sole owner
+/// in one case and discards the real one in another; only the whole set decides.
+#[test]
+fn exact_token_ownership_weighs_the_whole_holder_set() {
+    let shared = "opaque-not-a-jwt";
+    let case = |target: Option<&str>, holders: &[(&str, Option<&str>)]| {
+        let (_tmp, paths) = setup_test_env();
+        for (alias, workspace) in holders {
+            let dir = paths.profiles_dir().join(alias);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("auth.json"),
+                format!(r#"{{"access_token":"{shared}"}}"#),
+            )
+            .unwrap();
+            let account = match workspace {
+                Some(workspace) => format!(r#","account_id":"{workspace}""#),
+                None => String::new(),
+            };
+            std::fs::write(
+                dir.join("meta.json"),
+                format!(
+                    r#"{{"alias":"{alias}","email":null,"plan":null{account},"saved_at":"2026-01-01T00:00:00Z"}}"#
+                ),
+            )
+            .unwrap();
+        }
+        let incoming = paths.home.join("incoming.json");
+        let body = match target {
+            Some(workspace) => {
+                format!(r#"{{"access_token":"{shared}","account_id":"{workspace}"}}"#)
+            }
+            None => format!(r#"{{"access_token":"{shared}"}}"#),
+        };
+        std::fs::write(&incoming, body).unwrap();
+        match profile::exact_token_seat(&paths, &incoming).unwrap() {
+            profile::ExistingSeat::None => "none".to_string(),
+            profile::ExistingSeat::One(alias) => format!("one:{alias}"),
+            profile::ExistingSeat::Ambiguous(mut aliases) => {
+                aliases.sort();
+                format!("ambiguous:{}", aliases.join(","))
+            }
+        }
+    };
+
+    // Nobody holds it.
+    assert_eq!(case(Some("acct-a"), &[]), "none");
+    // A lone holder owns it, even when only one side names a workspace —
+    // otherwise a login for an identical credential forks a new profile.
+    assert_eq!(case(None, &[("a", Some("acct-a"))]), "one:a");
+    assert_eq!(case(Some("acct-a"), &[("a", None)]), "one:a");
+    assert_eq!(case(None, &[("a", None)]), "one:a");
+    // ...but not when both name a workspace and they differ.
+    assert_eq!(case(Some("acct-b"), &[("a", Some("acct-a"))]), "none");
+    // The holder declaring the arriving workspace owns it.
+    assert_eq!(
+        case(
+            Some("acct-a"),
+            &[("a", Some("acct-a")), ("b", Some("acct-b"))]
+        ),
+        "one:a"
+    );
+    // A claimless holder beside one proving the token spans workspaces is not a
+    // sole owner: ownership is undecidable, and several profiles already hold
+    // this credential.
+    assert_eq!(
+        case(Some("acct-c"), &[("a", None), ("b", Some("acct-b"))]),
+        "ambiguous:a,b"
+    );
+    // Two copies with nothing to tell them apart stay ambiguous.
+    assert_eq!(case(None, &[("a", None), ("b", None)]), "ambiguous:a,b");
+}


### PR DESCRIPTION
A login or save for an account already saved under another alias created a
second profile for it. The check that prevents exactly this ran only when a
label was given, and `save` had no such check at all — so the everyday way to
reach it was a mistyped alias, which is free by definition and therefore never
looked at.

The fork is not cosmetic. Every later lookup reports the account as ambiguous,
and the fresh login revokes the older profile's grant server-side, so the
duplicate left behind is dead as well as confusing.

Observed in a real store after v0.1.22:

```
amir@sawmills.ai   login user-sL90O5IP…  workspace b12c5f05…  Aug 16   invalidated
amir@sawmils.ai    login user-sL90O5IP…  workspace b12c5f05…  Aug 23   ACTIVE
```

One `(workspace, login)` pair, two profiles.

## What changed

- `login` and `save` check for an existing seat whatever alias was typed, label
  or not, and refresh the profile that already holds the account.
- `save` re-resolves that seat under the store lock. It is resolved before the
  lock because the overwrite prompt must not be held under one, and a concurrent
  save can claim the account in that window.

## Notes

Gating the guard on a label gated it on the case that never needed it. Every
test written for seat reuse passed a label, so the unlabeled path had no
coverage at all — that is the blind spot, not bad luck.

One review finding was rejected with evidence rather than fixed: a redirect
cannot carry `--allow-adopt` onto a profile nobody named, because a redirect
requires both the workspace and the login to match positively, which is exactly
the state in which nothing needs adopting. Verified in both directions against
the built binary and pinned by a test.

Gates: 371 tests, clippy 0, fmt clean, trunk clean. Version bumped to 0.1.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses the existing profile for an already-saved account and prevents duplicates from mistyped aliases, opaque/pre-claims tokens, and cross-workspace overlaps. Previously `login`/`save` could fork profiles or overwrite unrelated ones; now `login` redirects to the saved seat, `save` refuses a second alias, and exact-token ownership is decisive with workspace-aware handling.

- `login`: resolve the saved seat by exact token before claims; redirect to the saved alias even if the requested alias holds another account; if the named alias is the sole exact-token holder, refresh it without prompting; when several aliases hold the same token, allow adoption only if the named alias is one of those holders; do not derive an email from the requested alias after a redirect.
- `save`: refuse writing the same account or identical credential under a second alias and print the correct alias; re-resolve the seat and exact-token ownership under the store lock and refuse (not redirect) if a concurrent save created the seat; keep an established email only when refreshing the same account, never across an adoption; error messages now include a safely quoted `codexctl save` command (with `--` when needed) that can be pasted even for aliases with spaces, shell metacharacters, or a leading dash.
- Profile/tests/docs: add workspace-aware `profile::exact_token_seat` that returns None/One/Ambiguous and weighs the whole holder set; honour exact-token ownership over claims; allow a new seat when an identical token exists only under other workspaces; report ambiguity (and refuse a third copy) when holders leave ownership undecided; clarify `login` redirect vs `save` refusal in the README; add offline end-to-end coverage; bump `codexctl` to `0.1.23`.

<sup>Written for commit 08b8e0efc590d741e96410800347b0058889d685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/codexctl/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account matching during login and saving to prevent duplicate profiles, including for opaque credentials.
  * Added safeguards against ambiguous matches, conflicting aliases, and concurrent duplicate saves.
  * Preserved account metadata during same-account refreshes while preventing stale metadata during adoption.
  * Adoption and redirect flows now enforce alias and approval rules consistently.

* **Documentation**
  * Clarified profile resolution, alias conflicts, and save behavior.

* **Release**
  * Updated the package version to 0.1.23.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->